### PR TITLE
Changed link to Docker implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ version, if problems arise).
 
 
 # Deployment with Docker
-If you would like to deploy Specify 7 in a [Docker](https://www.docker.com/) container checkout the instructions in this repository by [MfN Berlin](https://github.com/MfN-Berlin/):  https://github.com/MfN-Berlin/specify7-docker
+If you would like to deploy Specify 7 in a [Docker](https://www.docker.com/) container checkout the instructions in this repository by the Royal Botanic Gardens Victoria:  https://github.com/rbgvictoria/specify7-docker
 
 
 


### PR DESCRIPTION
Changed the link to the Docker implementation from the Museum für Naturkunde Berlin implementation, which doesn't work anymore, to the new implementation at Royal Botanic Gardens Victoria.