### PR TITLE
Update example Apache configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ as Specify 7 makes use of resource files. Specify 6 code is also
 executed by the server for Workbench validation and uploads.
 
 ```shell
-wget http://update.specifysoftware.org/6800/Specify_unix_64.sh
+wget https://update.specifysoftware.org/6800/Specify_unix_64.sh
 sh Specify_unix_64.sh -q -dir ./Specify6.8.0
 sudo ln -s $(pwd)/Specify6.8.0 /opt/Specify
 ```
@@ -100,7 +100,7 @@ sudo ln -s $(pwd)/Specify6.8.0 /opt/Specify
 Clone this repository.
 
 ```shell
-git clone git://github.com/specify/specify7.git
+git clone https://github.com/specify/specify7.git
 ```
 
 You will now have a specify7 directory containing the source
@@ -109,7 +109,7 @@ tree.
 
 ### Setting up Python Virtual Environment
 Using a Python
-[virtual environment](http://docs.python-guide.org/en/latest/dev/virtualenvs/)
+[virtual environment](https://docs.python-guide.org/dev/virtualenvs/)
 will avoid version conflicts with other Python libraries on your
 system. Also, it avoids having to use a superuser account to install
 the Python dependencies.
@@ -280,7 +280,7 @@ proceed as follows:
 1. Clone or download a new copy of this repository in a directory next
    to your existing installation.
 
-    `git clone git://github.com/specify/specify7.git specify7-new-version`
+    `git clone https://github.com/specify/specify7.git specify7-new-version`
 
 2. Copy the settings from the existing to the new installation.
 
@@ -296,7 +296,7 @@ proceed as follows:
 
 6. [Build](#building) the new version of Specify 7.
 
-7. Testing it out with the [development server](#the-development-server).
+7. Test it out with the [development server](#the-development-server).
 
 8. Deploy the new version by updating your Apache config to replace
    the old installation paths with the new ones and restarting Apache.

--- a/specifyweb_apache.conf
+++ b/specifyweb_apache.conf
@@ -1,5 +1,14 @@
 <VirtualHost *:80>
-        <Directory />
+        # Grant access to the Specify directories.
+        <Directory /home/specify/specify_depository>
+            Require all granted
+        </Directory>
+
+        <Directory /opt/Specify/config>
+            Require all granted
+        </Directory>
+
+        <Directory /opt/specify7>
             Require all granted
         </Directory>
 
@@ -13,9 +22,9 @@
         Alias /static           /opt/specify7/specifyweb/frontend/static
 
         # Set the user and group you want the Specify 7 python process to run as.
-        # The python-path points to the location of the python libraries in the
+        # The python-home points to the location of the python libraries in the
         # virtualenv you established. If not using a virtualenv, leave off the
-        # python-path parameter.
+        # python-home parameter.
         WSGIDaemonProcess $servername user=specify group=specify python-home=/opt/specify7/ve
         WSGIProcessGroup $servername
 
@@ -24,9 +33,9 @@
 
 
         # ErrorLog /var/log/apache2/error.log
-	# # Possible values include: debug, info, notice, warn, error, crit,
-	# # alert, emerg.
-	# LogLevel warn
+        # # Possible values include: debug, info, notice, warn, error, crit,
+        # # alert, emerg.
+        # LogLevel warn
 
-	# CustomLog /var/log/apache2/access.log combined
+        # CustomLog /var/log/apache2/access.log combined
 </VirtualHost>


### PR DESCRIPTION
Allow Apache access only to the required directories rather than the whole server.  Also update the documented WSGI parameter name.

And use HTTPS rather than Git protocol for clone (more likely to be allowed through a firewall), and update some changed links.

(Issues noticed while helping someone with a Specify installation. I don't run Specify myself, so please treat these changes as suggestions.)