### PR TITLE
Send additional data when opening GeoLocate in WB

### DIFF
--- a/specifyweb/frontend/js_src/lib/wblocalitydataextractor.ts
+++ b/specifyweb/frontend/js_src/lib/wblocalitydataextractor.ts
@@ -189,10 +189,12 @@ export const getLocalitiesDataFromSpreadsheet = (
         index: customRowNumbers[index] ?? index,
       }))
       .filter(({ locality }) => typeof locality !== 'boolean')
-      .map(({ locality, index }) => ({
-        ...locality,
-        rowNumber: { headerName: 'Row Number', value: index },
-      }))
+      .map(({ locality, index }) =>
+        reshapeLocalityData({
+          ...locality,
+          rowNumber: { headerName: 'Row Number', value: index },
+        })
+      )
   );
 
 // Aggregate tree ranks into a single full name
@@ -268,13 +270,9 @@ export function getLocalityCoordinate(
     value: formatCoordinate(getFieldCurried(fieldName).value),
   });
 
-  const localityData = getLocalityData(
+  return getLocalityData(
     localityColumns,
     getFieldCurried,
     formatCoordinateCurried
   );
-
-  return typeof localityData === 'object'
-    ? reshapeLocalityData(localityData)
-    : localityData;
 }


### PR DESCRIPTION
Fixes #931

@specify/ux-testing To test this, create a new data set with the following columns:
Latitude1, Longidute1, Latitude2, Longidute2, Lat Long Type, Lat Long Accuracy, Country Name, State Name, County Name.
Fill some data into all of these fields
Open GeoLocate
Make sure GeoLocate received data from all WB columns