### PR TITLE
Don't let title enlarge Dialog window

### DIFF
--- a/specifyweb/frontend/js_src/lib/querycbx.js
+++ b/specifyweb/frontend/js_src/lib/querycbx.js
@@ -525,7 +525,14 @@ var QueryCbx = Backbone.View.extend({
         this.fillIn();
     },
     changeDialogTitle: function(resource, title) {
-        this.dialogIsOpen() && this.dialog.dialog('option', 'title', title);
+        if(!this.dialogIsOpen())
+          return;
+        this.dialog.dialog('option', 'title', title);
+        const dialog = this.dialog[0].closest('.ui-dialog');
+        const maxTitleWidth = Math.floor(this.dialog.width() * 0.9);
+        const titleElement =
+          dialog.getElementsByClassName('ui-dialog-title')[0];
+        titleElement.style.maxWidth = `${maxTitleWidth}px`;
     },
     blur: function() {
         var val = this.$('input').val().trim();


### PR DESCRIPTION
Fixes #703

Since resource view dialog has width: auto, long titles can increase the
width of the dialog. A somewhat ugly workaround is to record the dialog
width before changing the title, and setting title's max-width to
previous dialog width.