### PR TITLE
fix regression introduced by pr #1088.

### DIFF
--- a/specifyweb/frontend/js_src/lib/interactionsdialog.js
+++ b/specifyweb/frontend/js_src/lib/interactionsdialog.js
@@ -59,10 +59,9 @@ module.exports = Backbone.View.extend({
             'click a.interaction-action': 'interactionActionClick'
         },
         render: function() {
-            var render = this._render.bind(this);
-            if(typeof getFormsPromise === 'undefined')
-              render();
-            else {
+            if(getFormsPromise.isFulfilled()) {
+                this._render();
+            } else {
               const loadingDialog = $(
                   '<div><div class="progress-bar"></div></div>'
               ).dialog({
@@ -72,10 +71,8 @@ module.exports = Backbone.View.extend({
               });
               $('.progress-bar', loadingDialog).progressbar({ value: false });
               getFormsPromise.done(fetchedForms=>{
-                this.forms = fetchedForms;
-                getFormsPromise = undefined;
                 loadingDialog.dialog('destroy');
-                render();
+                this._render();
               });
             }
             return this;
@@ -125,10 +122,12 @@ module.exports = Backbone.View.extend({
         },
         selected: function(evt) {
             var index = this.$('a').filter(".intercept-navigation").index(evt.currentTarget);
-            this.$el.dialog('close');
-            var form = this.forms[index];
-            var model = schema.getModel(form['class'].split('.').pop());
-            this.trigger('selected', model);
+            getFormsPromise.done(forms => {
+                this.$el.dialog('close');
+                var form = forms[index];
+                var model = schema.getModel(form['class'].split('.').pop());
+                this.trigger('selected', model);
+            });
         },
         isRsAction: function(actionName) {
             return actionName == 'NEW_GIFT' || actionName == 'NEW_LOAN';


### PR DESCRIPTION
You can't use `this.forms` because every time the dialog is invoked it is a new instance... But, you already have all the values in the `getFormsPromise` which is captured in a closure. So just use that!

Please test by making sure entries in both Data Entry and Interactions dialogs can be invoked multiple times in succession.