### PR TITLE
Make web asset server work in docker

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,8 +40,8 @@ services:
       - MASTER_NAME=master
       - MASTER_PASSWORD=master
       - SECRET_KEY=change this to some unique random string
-      # - ASSET_SERVER_URL=http://asset-server:8080/web_asset_store.xml
-      # - ASSET_SERVER_KEY=your asset server access key
+      - ASSET_SERVER_URL=http://asset-server:8080/web_asset_store.xml
+      - ASSET_SERVER_KEY=your asset server access key
       - REPORT_RUNNER_HOST=report-runner
       - REPORT_RUNNER_PORT=8080
       - CELERY_BROKER_URL=redis://redis/0
@@ -77,8 +77,8 @@ services:
       - MASTER_NAME=master
       - MASTER_PASSWORD=master
       - SECRET_KEY=change this to some unique random string
-      # - ASSET_SERVER_URL=http://asset-server:8080/web_asset_store.xml
-      # - ASSET_SERVER_KEY=your asset server access key
+      - ASSET_SERVER_URL=http://asset-server:8080/web_asset_store.xml
+      - ASSET_SERVER_KEY=your asset server access key
       - REPORT_RUNNER_HOST=report-runner
       - REPORT_RUNNER_PORT=8080
       - CELERY_BROKER_URL=redis://redis/0
@@ -89,16 +89,16 @@ services:
   redis:
     image: redis
 
-  # asset-server:
-  #   image: specifyconsortium/specify-asset-service
-  #   init: true
-  #   volumes:
-  #     - "attachments:/home/specify/attachments"
-  #   environment:
-  #     - SERVER_NAME=localhost
-  #     - SERVER_PORT=80
-  #     - ATTACHMENT_KEY=your asset server access key
-  #     - DEBUG_MODE=false
+  asset-server:
+    image: specifyconsortium/specify-asset-service
+    init: true
+    volumes:
+      - "attachments:/home/specify/attachments"
+    environment:
+      - SERVER_NAME=localhost
+      - SERVER_PORT=80
+      - ATTACHMENT_KEY=your asset server access key
+      - DEBUG_MODE=false
 
   specify6:
     image: specifyconsortium/specify6-service:6.8.01.test_09_01

--- a/specifyweb/frontend/js_src/lib/attachments.js
+++ b/specifyweb/frontend/js_src/lib/attachments.js
@@ -57,6 +57,7 @@ var initialContext = require('./initialcontext.js');
             if (!_(thumbnailable).contains(mimetype)) {
                 var src = iconForMimeType(mimetype);
                 return $.when( $('<img>', {src: src, style: style}) );
+
             }
 
             var attachmentLocation = attachment.get('attachmentlocation');


### PR DESCRIPTION
Back-end replaces the origin of the URLs returned from the web server
by the origin taken from ASSET_SERVER_URL

This makes web asset server work both on the front-end and the back-end

For environments outside of docker, if ASSET_SERVER_URL and web asset
server point to the same origin, this change would have no effect