### PR TITLE
update python from 3.6 to 3.8.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ LABEL maintainer="Specify Collections Consortium <github.com/specify>"
 RUN apt-get update \
  && apt-get -y install --no-install-recommends \
         gettext \
-        python3.6 \
+        python3.8 \
         libldap-2.4-2 \
         libmariadbclient18 \
  && apt-get clean \
@@ -50,14 +50,15 @@ RUN apt-get update \
         libldap2-dev \
         libmariadbclient-dev \
         libsasl2-dev \
-        python3-venv \
-        python3.6-dev
+        python3.8-venv \
+        python3.8-distutils \
+        python3.8-dev
 
 USER specify
 COPY --chown=specify:specify requirements.txt /home/specify/
 
 WORKDIR /opt/specify7
-RUN python3.6 -m venv ve \
+RUN python3.8 -m venv ve \
  && ve/bin/pip install --no-cache-dir -r /home/specify/requirements.txt
 RUN ve/bin/pip install --no-cache-dir gunicorn
 
@@ -149,7 +150,7 @@ USER root
 
 RUN apt-get update \
  && apt-get -y install --no-install-recommends \
-        python3.6-distutils \
+        python3.8-distutils \
         ca-certificates \
         make
 

--- a/default.nix
+++ b/default.nix
@@ -3,9 +3,9 @@ stdenv.mkDerivation rec {
   name = "env";
   env = buildEnv { name = name; paths = buildInputs; };
   buildInputs = [
-    python36
-    python36Packages.virtualenv
-    python36Packages.pip
+    python38
+    python38Packages.virtualenv
+    python38Packages.pip
     libmysqlclient
     libzip
     openssl

--- a/specifyweb/attachment_gw/views.py
+++ b/specifyweb/attachment_gw/views.py
@@ -141,7 +141,7 @@ def delete_attachment_file(attch_loc):
 def generate_token(timestamp, filename):
     """Generate the auth token for the given filename and timestamp. """
     msg = str(timestamp).encode() + filename.encode()
-    mac = hmac.new(settings.WEB_ATTACHMENT_KEY.encode(), msg)
+    mac = hmac.new(settings.WEB_ATTACHMENT_KEY.encode(), msg, 'md5')
     return ':'.join((mac.hexdigest(), str(timestamp)))
 
 def get_timestamp():


### PR DESCRIPTION
Updates Python used by the back end from 3.6 to 3.8 which is good until October 2024.

I think this should be a pretty safe update. It would be good to test drive it using test.specifysystems.org before merging.