### PR TITLE
Make Query Builder ignore "hide field" schema overrides

### DIFF
--- a/specifyweb/frontend/js_src/lib/wbplanviewnavigator.ts
+++ b/specifyweb/frontend/js_src/lib/wbplanviewnavigator.ts
@@ -402,9 +402,7 @@ export function getMappingLineData({
               (generateFieldData === 'all' &&
                 isFieldVisible(
                   showHiddenFields,
-                  scope === 'queryBuilder'
-                    ? model.idField.isHidden
-                    : model.idField.overrides.isHidden,
+                  model.idField.isHidden,
                   model.idField.name
                 ))
                 ? [
@@ -441,7 +439,9 @@ export function getMappingLineData({
                           )))) &&
                     isFieldVisible(
                       showHiddenFields,
-                      field.overrides.isHidden,
+                      scope === 'queryBuilder'
+                        ? field.isHidden
+                        : field.overrides.isHidden,
                       field.name
                     ) &&
                     (!field.isRelationship ||
@@ -510,7 +510,10 @@ export function getMappingLineData({
                       scope !== 'queryBuilder' &&
                       field.overrides.isRequired &&
                       !mustMatchPreferences[model.name],
-                    isHidden: field.overrides.isHidden,
+                    isHidden:
+                      scope === 'queryBuilder'
+                        ? field.isHidden
+                        : field.overrides.isHidden,
                     isDefault: field.name === internalState.defaultValue,
                     isRelationship: field.isRelationship,
                     tableName: field.isRelationship

--- a/specifyweb/frontend/js_src/lib/wbplanviewnavigator.ts
+++ b/specifyweb/frontend/js_src/lib/wbplanviewnavigator.ts
@@ -402,7 +402,9 @@ export function getMappingLineData({
               (generateFieldData === 'all' &&
                 isFieldVisible(
                   showHiddenFields,
-                  model.idField.overrides.isHidden,
+                  scope === 'queryBuilder'
+                    ? model.idField.isHidden
+                    : model.idField.overrides.isHidden,
                   model.idField.name
                 ))
                 ? [


### PR DESCRIPTION
While this kind of schema override is useful in the WorkBench, it
creates issues in Query Builder

Fixes #1894
See also #1845