### PR TITLE
Make specify look for "invisible=true" in form definition

### DIFF
--- a/specifyweb/frontend/js_src/lib/parseformcells.ts
+++ b/specifyweb/frontend/js_src/lib/parseformcells.ts
@@ -276,9 +276,9 @@ export function parseFormCell(
      * this checkbox and button would disappear from forms in Specify 7 when
      * users update to 7.7.0.
      * To mitigate the above issues, Specify 7 form definitions are using
-     * "invisible=true" instead of "visible=false" for makign fields invisible
+     * "invisible=true" instead of "visible=false" for making fields invisible
      */
-    visible: getBooleanAttribute(cellNode, 'invisible') ?? true,
+    visible: getBooleanAttribute(cellNode, 'invisible') !== true,
     ...parsedCell({ cell: cellNode, model, getProperty }),
     // This mag get filled out in postProcessRows or parseFormTableDefinition
     ariaLabel: undefined,

--- a/specifyweb/frontend/js_src/lib/parseformcells.ts
+++ b/specifyweb/frontend/js_src/lib/parseformcells.ts
@@ -275,11 +275,10 @@ export function parseFormCell(
      * visible=false. Adding support for that attribute in Specify 7 would mean
      * this checkbox and button would disappear from forms in Specify 7 when
      * users update to 7.7.0.
-     * Thus, support for visible=false was cut out of the 7.7.0 release, but
-     * can be reenabled in the future by uncommenting the following line:
+     * To mitigate the above issues, Specify 7 form definitions are using
+     * "invisible=true" instead of "visible=false" for makign fields invisible
      */
-    // visible: getProperty('visible')?.toLowerCase() !== 'false',
-    visible: true,
+    visible: getProperty('invisible')?.toLowerCase() !== 'true',
     ...parsedCell({ cell: cellNode, model, getProperty }),
     // This mag get filled out in postProcessRows or parseFormTableDefinition
     ariaLabel: undefined,

--- a/specifyweb/frontend/js_src/lib/parseformcells.ts
+++ b/specifyweb/frontend/js_src/lib/parseformcells.ts
@@ -278,7 +278,7 @@ export function parseFormCell(
      * To mitigate the above issues, Specify 7 form definitions are using
      * "invisible=true" instead of "visible=false" for makign fields invisible
      */
-    visible: getProperty('invisible')?.toLowerCase() !== 'true',
+    visible: getBooleanAttribute(cellNode, 'invisible') ?? true,
     ...parsedCell({ cell: cellNode, model, getProperty }),
     // This mag get filled out in postProcessRows or parseFormTableDefinition
     ariaLabel: undefined,


### PR DESCRIPTION
Allows to make a field invisible

Fixes #1070