### PR TITLE
Fix autocomplete clear not workign for single char

### DIFF
--- a/specifyweb/frontend/js_src/lib/components/autocomplete.tsx
+++ b/specifyweb/frontend/js_src/lib/components/autocomplete.tsx
@@ -389,7 +389,7 @@ export function Autocomplete<T>({
         className: listHasItems ? 'autocomplete' : '',
         onKeyDown: (event) => (showList ? handleKeyDown(event) : handleOpen()),
         onValueChange(value) {
-          if (value === '' && pendingValue.length > 1) handleCleared?.();
+          if (value === '') handleCleared?.();
           handleRefreshItems(source, value);
           setPendingValue(value);
           if (typeof pendingValueRef === 'object')

--- a/specifyweb/frontend/js_src/lib/components/preferencesrenderers.tsx
+++ b/specifyweb/frontend/js_src/lib/components/preferencesrenderers.tsx
@@ -158,7 +158,6 @@ export const FontFamilyPreferenceItem: PreferenceItemComponent<string> =
         delay={0}
         onNewValue={handleChange}
         onChange={({ data }): void => handleChange(data)}
-        // OnCleared={}
         filterItems={true}
         aria-label={undefined}
         value={value === defaultFont ? preferencesText('defaultFont') : value}


### PR DESCRIPTION
Fixes #1924

Happened only when the selected pick list item is one character long.

This was used to differentiate the "x" (clear) button click from using the backspace key


Fixed. Please test this with non-read-only pick lists, query combo boxes, and the search box in tree viewer.

Test using the clear button and backspace key when there is one character