### PR TITLE
Add backward compatibility with pick lists in Sp6 QB

### DIFF
--- a/specifyweb/frontend/js_src/lib/components/querybuilderfieldfilter.tsx
+++ b/specifyweb/frontend/js_src/lib/components/querybuilderfieldfilter.tsx
@@ -167,7 +167,14 @@ function QueryInputField({
         {...commonProps}
         required={Boolean(validationAttributes.required)}
         multiple={listInput}
-        value={listInput ? value.split(',').map(f.trim) : value}
+        value={
+          listInput
+            ? value
+                .split(',')
+                .map(f.trim)
+                .map((value) => resolveItem(pickListItems, value))
+            : resolveItem(pickListItems, value)
+        }
         size={listInput ? selectMultipleSize : 1}
       >
         <option value="" />
@@ -198,6 +205,14 @@ function QueryInputField({
     </span>
   );
 }
+
+const resolveItem = (
+  items: RA<PickListItemSimple>,
+  currentValue: string
+): string =>
+  items.find(({ value }) => value === currentValue)?.value ??
+  items.find(({ title }) => title === currentValue)?.value ??
+  value;
 
 function SingleField({
   filter,

--- a/specifyweb/frontend/js_src/lib/components/querybuilderfieldfilter.tsx
+++ b/specifyweb/frontend/js_src/lib/components/querybuilderfieldfilter.tsx
@@ -212,7 +212,7 @@ const resolveItem = (
 ): string =>
   items.find(({ value }) => value === currentValue)?.value ??
   items.find(({ title }) => title === currentValue)?.value ??
-  value;
+  currentValue;
 
 function SingleField({
   filter,


### PR DESCRIPTION
Sp7 QB stores PickListItem.value when selecting a pick list item as a
column filter

Sp6 QB uses PickListItem.title column, which is probably a bug or
an oversight as that column is intended for UI purposes only.

This commit makes Sp7 UI be able to resolve PickListItem even if it
was saved using the title field. The value would still be saved using
the value field, as that is the correct behavior.

Fixes #1934