### PR TITLE
Fix Sp7.7 not parsing QCB's TypeSearch correctly

### DIFF
--- a/specifyweb/frontend/js_src/lib/components/querycombobox.tsx
+++ b/specifyweb/frontend/js_src/lib/components/querycombobox.tsx
@@ -218,7 +218,7 @@ export function QueryComboBox({
             );
       if (typeof typeSearch === 'undefined') return false;
 
-      const searchFieldsNames =
+      const rawSearchFieldsNames =
         typeSearch === null
           ? []
           : getParsedAttribute(typeSearch, 'searchField')
@@ -230,7 +230,7 @@ export function QueryComboBox({
                   ? columnToFieldMapper(typeSearch.textContent)
                   : f.id
               ) ?? [];
-      const searchFields = searchFieldsNames.map((searchField) =>
+      const searchFields = rawSearchFieldsNames.map((searchField) =>
         defined(relatedModel.getField(searchField))
       );
 
@@ -244,7 +244,6 @@ export function QueryComboBox({
       return {
         title: queryText('queryBoxDescription', formatList(fieldTitles)),
         searchFields,
-        searchFieldsNames,
         relatedModel,
         dataObjectFormatter:
           typeSearch?.getAttribute('dataObjFormatter') ?? undefined,
@@ -408,8 +407,8 @@ export function QueryComboBox({
           async (value) =>
             isLoaded && typeof typeSearch === 'object'
               ? Promise.all(
-                  typeSearch.searchFieldsNames
-                    .map((fieldName) =>
+                  typeSearch.searchFields
+                    .map(({ name: fieldName }) =>
                       makeComboBoxQuery({
                         fieldName,
                         value,

--- a/specifyweb/frontend/js_src/lib/querycomboboxutils.ts
+++ b/specifyweb/frontend/js_src/lib/querycomboboxutils.ts
@@ -217,7 +217,6 @@ export type CollectionRelationships = {
 export type TypeSearch = {
   readonly title: string;
   readonly searchFields: RA<LiteralField | Relationship>;
-  readonly searchFieldsNames: RA<string>;
   readonly relatedModel: SpecifyModel;
   readonly dataObjectFormatter: string | undefined;
 };


### PR DESCRIPTION
To test:
See the video: https://github.com/specify/specify7/issues/2014
Make sure that particular PaleoContext query combo box in their database returns results on search
Make sure there are no errors in the console when typing into the combo box