### PR TITLE
don't designate collection relationship tables as "system" tables.

### DIFF
--- a/specifyweb/specify/load_datamodel.py
+++ b/specifyweb/specify/load_datamodel.py
@@ -361,8 +361,6 @@ system_tables = {
     'Attachmenttag',
     'Attributedef',
     'Autonumberingscheme',
-    'Collectionreltype',
-    'Collectionrelationship',
     'Datatype',
     'Morphbankview',
     'Picklist',


### PR DESCRIPTION
So that they can be uploaded to through the work bench.