### PR TITLE
Don't check for institutional policies in roles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fix error when adding Address of Record SubView to Borrow form
   ([#2006](https://github.com/specify/specify7/pull/2006)) -
   _Reported by CSIRO_
+- Fix Specify incorrectly checking for `Permissions -> List Admins ->
+  read` permission ([#2019](https://github.com/specify/specify7/issues/2019))
 
 ## [7.7.3](https://github.com/specify/specify7/compare/v7.7.2...v7.7.3) (26 September 2022)
 

--- a/specifyweb/frontend/js_src/lib/components/securityuser.tsx
+++ b/specifyweb/frontend/js_src/lib/components/securityuser.tsx
@@ -382,7 +382,8 @@ export function SecurityUser({
                   onSaving={(): undefined | false => {
                     if (
                       userResource.isNew() &&
-                      typeof password === 'undefined'
+                      typeof password === 'undefined' &&
+                      canSetPassword
                     ) {
                       setState({
                         type: 'SetPasswordDialog',

--- a/specifyweb/frontend/js_src/lib/permissions.ts
+++ b/specifyweb/frontend/js_src/lib/permissions.ts
@@ -126,7 +126,7 @@ export const institutionPermissions = new Set([
   '/admin/user/sp6/collection_access',
   '/export/feed',
   '/permissions/library/roles',
-  'permissions/list_admins',
+  '/permissions/list_admins',
 ]);
 
 /**

--- a/specifyweb/frontend/js_src/lib/permissions.ts
+++ b/specifyweb/frontend/js_src/lib/permissions.ts
@@ -126,6 +126,7 @@ export const institutionPermissions = new Set([
   '/admin/user/sp6/collection_access',
   '/export/feed',
   '/permissions/library/roles',
+  'permissions/list_admins',
 ]);
 
 /**
@@ -242,15 +243,29 @@ export const queryUserPermissions = async (
        * no effect
        */
       data.details
-        .map(({ resource, matching_user_policies, ...rest }) => ({
-          ...rest,
-          resource,
-          matching_user_policies: institutionPermissions.has(resource)
-            ? matching_user_policies.filter(
-                ({ collectionid }) => collectionid === null
-              )
-            : matching_user_policies,
-        }))
+        .map(
+          ({
+            resource,
+            matching_user_policies,
+            matching_role_policies,
+            ...rest
+          }) => ({
+            ...rest,
+            resource,
+            matching_user_policies: institutionPermissions.has(resource)
+              ? matching_user_policies.filter(
+                  ({ collectionid }) => collectionid === null
+                )
+              : matching_user_policies,
+            /*
+             * Since institutional policies can not be given in a role,
+             * ignore matching_role_policies
+             */
+            matching_role_policies: institutionPermissions.has(resource)
+              ? []
+              : matching_role_policies,
+          })
+        )
         .map(({ resource, allowed, matching_user_policies, ...rest }) => ({
           ...rest,
           resource,


### PR DESCRIPTION
If user has a "All -> All" policy on the collection level, don't use
that as a justification for an institutional policy, since you can
not give it at a collection level.

Fixes #2019

To Test:
- Create a user that has a "Collection Admin" role and no policies (other than collection access)
- Sign in as that user
- Open the "Create User" form
- Wait for everything to load
- No permission error should happen