### PR TITLE
Unhide "GUID" for Taxon tables in the WB mapper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [Unreleased](https://github.com/specify/specify7/compare/v7.7.1...HEAD)
+
+### Added
+
+- You can now upload `GUIDs` for tree tables though the WorkBench ([#2097](https://github.com/specify/specify7/issues/2097))
+
+### Fixed
+
+- Fixed `taxonId` field on the forms not getting populated ([#2083](https://github.com/specify/specify7/issues/2083))
+- Fixed `ExsiccataItem` table being hidden in the WorkBench ([#2077](https://github.com/specify/specify7/issues/2077))
+
+
 ##  [7.7.1](https://github.com/specify/specify7/compare/v7.7.0...v7.7.1) (29 August 2022)
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Fixed
 
 - Fixed `taxonId` field on the forms not getting populated ([#2083](https://github.com/specify/specify7/issues/2083))
-- Fixed `ExsiccataItem` table being hidden in the WorkBench ([#2077](https://github.com/specify/specify7/issues/2077))
+- Fixed `ExsiccataItem` table being hidden in the WorkBench ([#2077](https://github.com/specify/specify7/issues/2077)) - *Reported by CSIRO*
 
 
 ##  [7.7.1](https://github.com/specify/specify7/compare/v7.7.0...v7.7.1) (29 August 2022)

--- a/specifyweb/frontend/js_src/lib/schemaoverrides.ts
+++ b/specifyweb/frontend/js_src/lib/schemaoverrides.ts
@@ -103,28 +103,24 @@ const globalFieldOverrides: {
     timestampCreated: 'readOnly',
   },
   Taxon: {
-    guid: 'readOnly',
     parent: 'required',
     isAccepted: 'readOnly',
     acceptedTaxon: 'readOnly',
     fullName: 'readOnly',
   },
   Geography: {
-    guid: 'readOnly',
     parent: 'required',
     isAccepted: 'readOnly',
     acceptedGeography: 'readOnly',
     fullName: 'readOnly',
   },
   LithoStrat: {
-    guid: 'readOnly',
     parent: 'required',
     isAccepted: 'readOnly',
     acceptedLithoStrat: 'readOnly',
     fullName: 'readOnly',
   },
   GeologicTimePeriod: {
-    guid: 'readOnly',
     parent: 'required',
     isAccepted: 'readOnly',
     acceptedGeologicTimePeriod: 'readOnly',

--- a/specifyweb/frontend/js_src/lib/tests/testwbplanviewnavigator.ts
+++ b/specifyweb/frontend/js_src/lib/tests/testwbplanviewnavigator.ts
@@ -335,6 +335,14 @@ export function testWbPlanViewNavigator(): void {
                   isDefault: false,
                   isRelationship: false,
                 },
+                guid : {
+                  optionLabel: "GUID",
+                  isEnabled: true,
+                  isRequired: false,
+                  isHidden: false,
+                  isDefault: false,
+                  isRelationship: false,
+                },
                 name: {
                   optionLabel: 'Name',
                   isEnabled: true,


### PR DESCRIPTION
Fixes #2097