### PR TITLE
Support customizing CO formatter in ColRels Plugin

### DIFF
--- a/specifyweb/frontend/js_src/lib/components/collectionrelonetooneplugin.tsx
+++ b/specifyweb/frontend/js_src/lib/components/collectionrelonetooneplugin.tsx
@@ -9,17 +9,21 @@ import { useAsyncState } from './hooks';
 export function CollectionOneToOnePlugin({
   resource,
   relationship,
+  formatting,
 }: {
   readonly resource: SpecifyResource<CollectionObject>;
   readonly relationship: string;
+  readonly formatting: string | undefined;
 }): JSX.Element | null {
   const [data] = useAsyncState(
     React.useCallback(
       async () =>
-        fetchOtherCollectionData(resource, relationship).catch((error) => {
-          console.error(error);
-          return undefined;
-        }),
+        fetchOtherCollectionData(resource, relationship, formatting).catch(
+          (error) => {
+            console.error(error);
+            return undefined;
+          }
+        ),
       [resource, relationship]
     ),
     true

--- a/specifyweb/frontend/js_src/lib/components/specifyformplugin.tsx
+++ b/specifyweb/frontend/js_src/lib/components/specifyformplugin.tsx
@@ -134,7 +134,10 @@ const pluginRenderers: {
             <WrongTable resource={resource} allowedTable="CollectionObject" />
           );
   },
-  ColRelTypePlugin({ resource, pluginDefinition: { relationship } }) {
+  ColRelTypePlugin({
+    resource,
+    pluginDefinition: { formatting, relationship },
+  }) {
     if (typeof relationship === 'undefined') {
       console.error(
         "Can't display CollectionRelOneToManyPlugin because initialize.relname is not set"
@@ -149,6 +152,7 @@ const pluginRenderers: {
             <CollectionOneToOnePlugin
               resource={collectionObject}
               relationship={relationship}
+              formatting={formatting}
             />
           )) ?? (
             <WrongTable resource={resource} allowedTable="CollectionObject" />

--- a/specifyweb/frontend/js_src/lib/components/specifyformplugin.tsx
+++ b/specifyweb/frontend/js_src/lib/components/specifyformplugin.tsx
@@ -113,7 +113,7 @@ const pluginRenderers: {
   },
   CollectionRelOneToManyPlugin({
     resource,
-    pluginDefinition: { relationship },
+    pluginDefinition: { relationship, formatting },
   }) {
     if (typeof relationship === 'undefined') {
       console.error(
@@ -128,6 +128,7 @@ const pluginRenderers: {
             <CollectionOneToManyPlugin
               resource={collectionObject}
               relationship={relationship}
+              formatting={formatting}
             />
           )) ?? (
             <WrongTable resource={resource} allowedTable="CollectionObject" />

--- a/specifyweb/frontend/js_src/lib/parseformfields.ts
+++ b/specifyweb/frontend/js_src/lib/parseformfields.ts
@@ -128,6 +128,7 @@ const processFieldType: {
   Plugin: (cell, getProperty) => ({
     type: 'Plugin',
     pluginDefinition: parseUiPlugin(
+      cell,
       getProperty,
       withStringDefault(cell).defaultValue
     ),

--- a/specifyweb/frontend/js_src/lib/parseuiplugins.ts
+++ b/specifyweb/frontend/js_src/lib/parseuiplugins.ts
@@ -4,10 +4,12 @@
 
 import type { State } from 'typesafe-reducer';
 
+import type { CoordinateType } from './components/latlongui';
+import { coordinateType } from './components/latlongui';
 import type { PartialDatePrecision } from './components/partialdateui';
 import { f } from './functools';
+import { getParsedAttribute } from './helpers';
 import { parseRelativeDate } from './relativedate';
-import { CoordinateType, coordinateType } from './components/latlongui';
 
 export type UiPlugins = {
   readonly LatLonUI: State<
@@ -30,6 +32,7 @@ export type UiPlugins = {
     'CollectionRelOneToManyPlugin',
     {
       readonly relationship: string | undefined;
+      readonly formatting: string | undefined;
     }
   >;
   readonly ColRelTypePlugin: State<
@@ -65,6 +68,7 @@ export type UiPlugins = {
 
 const processUiPlugin: {
   readonly [KEY in keyof UiPlugins]: (props: {
+    readonly cell: Element;
     readonly getProperty: (name: string) => string | undefined;
     readonly defaultValue: string | undefined;
   }) => UiPlugins[KEY];
@@ -96,9 +100,10 @@ const processUiPlugin: {
           : 'full'
     ),
   }),
-  CollectionRelOneToManyPlugin: ({ getProperty }) => ({
+  CollectionRelOneToManyPlugin: ({ cell, getProperty }) => ({
     type: 'CollectionRelOneToManyPlugin',
     relationship: getProperty('relName'),
+    formatting: getParsedAttribute(cell, 'formatting'),
   }),
   // Collection one-to-one Relationship plugin
   ColRelTypePlugin: ({ getProperty }) => ({
@@ -127,11 +132,12 @@ const processUiPlugin: {
 export type PluginDefinition = UiPlugins[keyof UiPlugins];
 
 export function parseUiPlugin(
+  cell: Element,
   getProperty: (name: string) => string | undefined,
   defaultValue: string | undefined
 ): PluginDefinition {
   const uiCommand =
     processUiPlugin[(getProperty('name') ?? '') as keyof UiPlugins] ??
     processUiPlugin.Unsupported;
-  return uiCommand({ getProperty, defaultValue });
+  return uiCommand({ cell, getProperty, defaultValue });
 }

--- a/specifyweb/frontend/js_src/lib/parseuiplugins.ts
+++ b/specifyweb/frontend/js_src/lib/parseuiplugins.ts
@@ -39,6 +39,7 @@ export type UiPlugins = {
     'ColRelTypePlugin',
     {
       readonly relationship: string | undefined;
+      readonly formatting: string | undefined;
     }
   >;
   readonly LocalityGeoRef: State<'LocalityGeoRef'>;
@@ -106,9 +107,10 @@ const processUiPlugin: {
     formatting: getParsedAttribute(cell, 'formatting'),
   }),
   // Collection one-to-one Relationship plugin
-  ColRelTypePlugin: ({ getProperty }) => ({
+  ColRelTypePlugin: ({ cell, getProperty }) => ({
     type: 'ColRelTypePlugin',
     relationship: getProperty('relName'),
+    formatting: getParsedAttribute(cell, 'formatting'),
   }),
   LocalityGeoRef: () => ({ type: 'LocalityGeoRef' }),
   WebLinkButton: ({ getProperty }) => ({


### PR DESCRIPTION
Fixes #1981

Added a `formatting` attribute - https://github.com/specify/specify7/wiki/Form-System#collectionrelonetomanyplugin

The [ColRelTypePlugin](https://github.com/specify/specify7/wiki/Form-System#colreltypeplugin) plugin supports that attribute too

It supports the name of the formatter only at present. It will be expanded in the future to support providing multiple values