### PR TITLE
Export improvements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,6 +45,7 @@ typecheck:
 	$(MYPY) --follow-imports silent \
 	specifyweb/permissions specifyweb/workbench specifyweb/accounts \
 	specifyweb/specify/schema.py specifyweb/specify/load_datamodel.py \
-	specifyweb/specify/api.py specifyweb/context/user_resources.py
+	specifyweb/specify/api.py specifyweb/context/user_resources.py \
+	specifyweb/export/tasks.py
 
 .FORCE:

--- a/specifyweb/export/feed.py
+++ b/specifyweb/export/feed.py
@@ -71,7 +71,9 @@ def needs_update(path, days):
     try:
         mtime = os.path.getmtime(path)
     except OSError as e:
-        if e.errno != errno.ENOENT:
+        if e.errno == errno.ENOENT:
+            return True
+        else:
             raise
     else:
         update_interval = 24*60*60 * days

--- a/specifyweb/export/tasks.py
+++ b/specifyweb/export/tasks.py
@@ -1,0 +1,70 @@
+import os
+import traceback
+import json
+
+from datetime import datetime
+from typing import Optional, Any
+
+from celery import shared_task # type: ignore
+from celery.utils.log import get_task_logger # type: ignore
+
+from django.conf import settings
+
+from specifyweb.specify import models
+from specifyweb.celery import LogErrorsTask, app
+
+from ..notifications.models import Message
+from ..context.app_resource import get_app_resource
+from . import dwca, feed
+
+Specifyuser = getattr(models, 'Specifyuser')
+Collection = getattr(models, 'Collection')
+
+logger = get_task_logger(__name__)
+
+@app.task(base=LogErrorsTask, bind=True)
+def update_feed(self, user_id: Optional[int], force: bool) -> None:
+    user = Specifyuser.objects.get(pk=user_id) if user_id is not None else None
+
+    try:
+        feed.update_feed(force=force, notify_user=user)
+    except Exception as e:
+        tb = traceback.format_exc()
+        logger.error('update_feed failed: %s', tb)
+        if user is not None:
+            Message.objects.create(user=user, content=json.dumps({
+                'type': 'update-feed-failed',
+                'exception': str(e),
+                'traceback': tb if settings.DEBUG else None,
+            }))
+
+@app.task(base=LogErrorsTask, bind=True)
+def make_dwca(self, collection_id: int, user_id: int, dwca_resource: str, eml_resource: str) -> None:
+    user = Specifyuser.objects.get(pk=user_id)
+    collection = Collection.objects.get(pk=collection_id)
+
+    definition, _ = get_app_resource(collection, user, dwca_resource)
+
+    if eml_resource is not None:
+        eml, _ = get_app_resource(collection, user, eml_resource)
+    else:
+        eml = None
+
+    filename = 'dwca_export_%s.zip' % datetime.now().isoformat()
+    path = os.path.join(settings.DEPOSITORY_DIR, filename)
+
+    try:
+        dwca.make_dwca(collection, user, definition, path, eml=eml)
+    except Exception as e:
+        tb = traceback.format_exc()
+        logger.error('make_dwca failed: %s', tb)
+        Message.objects.create(user=user, content=json.dumps({
+            'type': 'dwca-export-failed',
+            'exception': str(e),
+            'traceback': tb if settings.DEBUG else None,
+        }))
+    else:
+        Message.objects.create(user=user, content=json.dumps({
+            'type': 'dwca-export-complete',
+            'file': filename
+        }))

--- a/specifyweb/settings/__init__.py
+++ b/specifyweb/settings/__init__.py
@@ -234,6 +234,14 @@ JAVA_PATH = '/usr/bin/java'
 DATA_UPLOAD_MAX_MEMORY_SIZE = 419430400  # 300mb
 FILE_UPLOAD_MAX_MEMORY_SIZE = 104857600  # 100mb
 
+CELERY_BEAT_SCHEDULE = {
+    'maybe-update-export-feeds': {
+        'task': 'specifyweb.export.tasks.update_feed',
+        'schedule': 3600.0,
+        'args': (None, False)
+    },
+}
+
 try:
     from .local_logging_settings import LOGGING
 except ImportError:


### PR DESCRIPTION
This PR adds some improvements for the back end for the data export or publishing system. ie Darwin Core Archives and the RSS export feed.

1. It converts the export jobs to Celery tasks so that they execute on the worker process (like workbench uploads) and not as a thread on the main Specify 7 application server.

2. Adds a Celery "beat" definition to check whether the export feeds are due for updates. Previously this relied on cron jobs or Systemd timers to execute a Django management command (https://github.com/specify/specify7/blob/v7.7.5/specifyweb/export/management/commands/update_feed.py)