### PR TITLE
Handle invalid field names gracefully

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Fixed
 
 - Fix "Create Invite Link" having incorrect condition ([#2140](https://github.com/specify/specify7/pull/2140))
+- Using invalid field names in checkboxes no longer breaks the form
+  ([#2200](https://github.com/specify/specify7/issue/2200))
 
 ## [7.7.2](https://github.com/specify/specify7/compare/v7.7.1...v7.7.2) (12 September 2022)
 

--- a/specifyweb/frontend/js_src/lib/components/hooks.tsx
+++ b/specifyweb/frontend/js_src/lib/components/hooks.tsx
@@ -5,7 +5,7 @@
 
 import React from 'react';
 
-import { error, tap } from '../assert';
+import { tap } from '../assert';
 import type { AnySchema } from '../datamodelutils';
 import { getDateInputValue } from '../dayjs';
 import { listen } from '../events';
@@ -404,17 +404,18 @@ export function useResourceValue<
 
   const [value, setValue] = React.useState<T | undefined>(undefined);
 
-  const field = React.useMemo(
-    () =>
-      typeof fieldName === 'string'
-        ? resource.specifyModel.getField(fieldName) ??
-          error(
-            `${fieldName} does not exist on ${resource.specifyModel.name}`,
-            { resource }
-          )
-        : undefined,
-    [fieldName, resource]
-  );
+  const field = React.useMemo(() => {
+    if (typeof fieldName === 'string') {
+      const field = resource.specifyModel.getField(fieldName);
+      if (field === undefined)
+        console.error(
+          `${fieldName} does not exist on ${resource.specifyModel.name}`,
+          { resource }
+        );
+      return field;
+    } else return undefined;
+  }, [fieldName, resource]);
+
 
   const [{ triedToSubmit }] = React.useContext(FormContext);
 


### PR DESCRIPTION
Don't crash the form on invalid field name

Fixes #2194