### PR TITLE
Fix query builder not allowing "in" filter on numbers

### DIFF
--- a/specifyweb/frontend/js_src/lib/components/querybuilderfieldfilter.tsx
+++ b/specifyweb/frontend/js_src/lib/components/querybuilderfieldfilter.tsx
@@ -198,6 +198,7 @@ function QueryInputField({
       <Input.Generic
         {...commonProps}
         {...validationAttributes}
+        type={listInput ? 'text' : validationAttributes.type}
         value={value}
         // This is the actual input that is visible to user
         className="!absolute inset-0"


### PR DESCRIPTION
Fixes #2115