### PR TITLE
Business rule improvements

### DIFF
--- a/specifyweb/businessrules/accessionagent_rules.py
+++ b/specifyweb/businessrules/accessionagent_rules.py
@@ -5,4 +5,8 @@ from django.utils.translation import gettext as _
 @orm_signal_handler('pre_save', 'Accessionagent')
 def agent_division_must_not_be_null(accessionagent):
     if accessionagent.agent_id is None:
-        raise BusinessRuleException(_("AccessionAgent -> Agent relationship is required."))
+        raise BusinessRuleException({
+            "type": "NOTNULL",
+            "field": "accessionagent.agent",
+            "message": _("AccessionAgent -> Agent relationship is required."),
+        })

--- a/specifyweb/businessrules/agent_rules.py
+++ b/specifyweb/businessrules/agent_rules.py
@@ -5,10 +5,15 @@ from .exceptions import BusinessRuleException
 @orm_signal_handler('pre_delete', 'Agent')
 def agent_delete_blocked_by_related_specifyuser(agent):
     try:
-        Specifyuser.objects.get(agents=agent)
+        user = Specifyuser.objects.get(agents=agent)
     except Specifyuser.DoesNotExist:
         return
-    raise BusinessRuleException("agent cannot be deleted while associated with a specifyuser")
+    raise BusinessRuleException({
+        "type": "DELETE_AGENT_USER",
+        "agentid": agent.id,
+        "userid": user.id,
+        "message": "agent cannot be deleted while associated with a specifyuser"
+    })
 
 # Disabling this rule because system agents must be created separate from divisions
 # @orm_signal_handler('pre_save', 'Agent')
@@ -20,6 +25,10 @@ def agent_delete_blocked_by_related_specifyuser(agent):
 def agent_types_other_and_group_do_not_have_addresses(agent):
     from specifyweb.specify.agent_types import agent_types
     if agent.agenttype is None:
-        raise BusinessRuleException("agenttype cannot be null")
+        raise BusinessRuleException({
+            "type": "NOTNULL",
+            "field": "agent.agenttype",
+            "message": "agenttype cannot be null"
+        })
     if agent_types[agent.agenttype] in ('Other', 'Group'):
         agent.addresses.all().delete()

--- a/specifyweb/businessrules/agentspecialty_rules.py
+++ b/specifyweb/businessrules/agentspecialty_rules.py
@@ -1,5 +1,4 @@
 from .orm_signal_handler import orm_signal_handler
-from .exceptions import BusinessRuleException
 from specifyweb.specify.models import Agentspecialty
 
 from django.db.models import Max

--- a/specifyweb/businessrules/collector_rules.py
+++ b/specifyweb/businessrules/collector_rules.py
@@ -1,4 +1,3 @@
-from .exceptions import BusinessRuleException
 from django.db.models import Max
 from .orm_signal_handler import orm_signal_handler
 from specifyweb.specify.models import Collector

--- a/specifyweb/businessrules/exceptions.py
+++ b/specifyweb/businessrules/exceptions.py
@@ -1,5 +1,11 @@
+from typing import Dict
+
 class BusinessRuleException(Exception):
-    pass
+    http_status = 400
+
+    def to_json(self) -> Dict:
+        return {'BusinessRuleException': self.args[0]}
+
 
 class AbortSave(Exception):
     pass

--- a/specifyweb/businessrules/groupperson_rules.py
+++ b/specifyweb/businessrules/groupperson_rules.py
@@ -6,7 +6,10 @@ from .exceptions import BusinessRuleException
 @orm_signal_handler('pre_save', 'Groupperson')
 def agent_cannot_be_in_self(groupperson):
     if groupperson.member_id == groupperson.group_id:
-        raise BusinessRuleException('a group cannot be made a member of itself')
+        raise BusinessRuleException({
+            "type": "GROUPPERSON_CONTAINS_SELF",
+            "message": 'a group cannot be made a member of itself'
+        })
 
 @orm_signal_handler('pre_save', 'Groupperson')
 def grouppersion_pre_save(groupperson):

--- a/specifyweb/businessrules/interaction_rules.py
+++ b/specifyweb/businessrules/interaction_rules.py
@@ -34,7 +34,14 @@ def loanprep_quantity_must_be_lte_availability(ipreparation):
         quantity = ipreparation.quantity or 0
         quantityresolved = ipreparation.quantityresolved or 0
         if available < (quantity - quantityresolved):
-            raise BusinessRuleException(f"loan preparation quantity exceeds availability ({ipreparation.id}: {quantity - quantityresolved} {available})")
+            raise BusinessRuleException({
+                "type": "LOAN_PREP_QUANTITY_GT_AVAIL",
+                "id": ipreparation.id,
+                "quantity": quantity,
+                "quantityresolved": quantityresolved,
+                "available": available,
+                "message": f"loan preparation quantity exceeds availability ({ipreparation.id}: {quantity - quantityresolved} {available})"
+            })
 
 @orm_signal_handler('pre_save', 'Giftpreparation')
 def giftprep_quantity_must_be_lte_availability(ipreparation):
@@ -42,7 +49,13 @@ def giftprep_quantity_must_be_lte_availability(ipreparation):
         available = get_availability(ipreparation.preparation, ipreparation.id, "giftpreparationid") or 0
         quantity = ipreparation.quantity or 0
         if available < quantity:
-            raise BusinessRuleException(f"gift preparation quantity exceeds availability ({ipreparation.id}: {quantity} {available})")
+            raise BusinessRuleException({
+                "type": "GIFT_PREP_QUANTITY_GT_AVAIL",
+                "id": ipreparation.id,
+                "quantity": quantity,
+                "available": available,
+                "message": f"gift preparation quantity exceeds availability ({ipreparation.id}: {quantity} {available})"
+            })
 
 @orm_signal_handler('pre_save', 'Exchangeoutprep')
 def exchangeoutprep_quantity_must_be_lte_availability(ipreparation):
@@ -50,4 +63,10 @@ def exchangeoutprep_quantity_must_be_lte_availability(ipreparation):
         available = get_availability(ipreparation.preparation, ipreparation.id, "exchangeoutprepid") or 0
         quantity = ipreparation.quantity or 0
         if available < quantity:
-            raise BusinessRuleException("exchangeout preparation quantity exceeds availability ({ipreparation.id}: {quantity} {available})")
+            raise BusinessRuleException({
+                "type": "EXCHANGEOUT_PREP_QUANTITY_GT_AVAIL",
+                "id": ipreparation.id,
+                "quantity": quantity,
+                "available": available,
+                "message": f"exchangeout preparation quantity exceeds availability ({ipreparation.id}: {quantity} {available})"
+            })

--- a/specifyweb/businessrules/middleware.py
+++ b/specifyweb/businessrules/middleware.py
@@ -1,0 +1,19 @@
+from typing import Optional
+
+from django import http
+
+from .exceptions import BusinessRuleException
+
+class BusinessRuleMiddleware:
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request):
+        response = self.get_response(request)
+        return response
+
+    def process_exception(self, request, exception) -> Optional[http.HttpResponse]:
+        if isinstance(exception, BusinessRuleException):
+            return http.JsonResponse(exception.to_json(), status=exception.http_status, safe=False)
+        else:
+            return None

--- a/specifyweb/businessrules/tree_rules.py
+++ b/specifyweb/businessrules/tree_rules.py
@@ -9,5 +9,9 @@ logger = logging.getLogger(__name__)
 def cannot_delete_root_treedefitem(sender, obj):
     if hasattr(obj, 'treedef'): # is it a treedefitem?
         if sender.objects.get(id=obj.id).parent is None:
-            raise BusinessRuleException("cannot delete root level tree definition item")
+            raise BusinessRuleException({
+                "type": "DELETE_TREE_ROOT",
+                "table": obj.__class__.__name__,
+                "message": "cannot delete root level tree definition item"
+            })
 

--- a/specifyweb/businessrules/uniqueness_rules.py
+++ b/specifyweb/businessrules/uniqueness_rules.py
@@ -18,6 +18,7 @@ def make_uniqueness_rule(model_name, parent_field, unique_field):
             if conflicts.exists():
                 raise BusinessRuleException({
                     "type": "UNIQUENESS",
+                    "message": "{} must have unique {}".format(model.__name__, unique_field),
                     "table": model.__name__,
                     "field": (unique_field, value),
                     "conflicting": list(conflicts.values_list('id', flat=True)[:100]),
@@ -41,6 +42,7 @@ def make_uniqueness_rule(model_name, parent_field, unique_field):
             if conflicts.exists():
                 raise BusinessRuleException({
                     "type": "UNIQUENESS",
+                    "message": "{} must have unique {} in {}".format(model.__name__, unique_field, parent_field),
                     "table": model.__name__,
                     "field": (unique_field, value),
                     "within": (parent_field, parent),

--- a/specifyweb/businessrules/user_rules.py
+++ b/specifyweb/businessrules/user_rules.py
@@ -42,9 +42,12 @@ def deleting_user(sender, instance, **kwargs):
 
     nonpersonal_appresources = user.spappresources.filter(spappresourcedir__ispersonal=False)
     if nonpersonal_appresources.exists():
-        raise BusinessRuleException(
-            f"user {user.name} owns nonpersonal appresources {[r.name for r in nonpersonal_appresources]}"
-        )
+        raise BusinessRuleException({
+            "type": "DELETE_FK",
+            "table": user.__class__.__name__,
+            "id": user.id,
+            "message": f"user {user.name} owns nonpersonal appresources {[r.name for r in nonpersonal_appresources]}"
+        })
 
     cursor = connection.cursor()
     cursor.execute('delete from specifyuser_spprincipal where SpecifyUserID = %s', [user.id])

--- a/specifyweb/settings/__init__.py
+++ b/specifyweb/settings/__init__.py
@@ -184,6 +184,7 @@ MIDDLEWARE = [
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'specifyweb.context.middleware.ContextMiddleware',
     'specifyweb.permissions.middleware.PermissionsMiddleware',
+    'specifyweb.businessrules.middleware.BusinessRuleMiddleware',
 ]
 
 ROOT_URLCONF = 'specifyweb.urls'

--- a/specifyweb/specify/tree_extras.py
+++ b/specifyweb/specify/tree_extras.py
@@ -156,7 +156,7 @@ def adding_node(node):
         override = re.search(pattern, remote_prefs, re.MULTILINE)
         if override is None or override.group(1).lower() != "true":
             raise BusinessRuleException({
-                "type": "SYNONIMIZED_PARENT",
+                "type": "SYNONYMIZED_PARENT",
                 "nodeid": node.id,
                 "parentid": parent.id,
                 "message": f'Adding node "{node.fullname}" to synonymized parent "{parent.fullname}".'

--- a/specifyweb/specify/tree_extras.py
+++ b/specifyweb/specify/tree_extras.py
@@ -69,10 +69,22 @@ class Tree(models.Model):
         try:
             model.objects.get(id=self.id, parent__rankid__lt=F('rankid'))
         except model.DoesNotExist:
-            raise BusinessRuleException("Tree node's parent has rank greater than itself.")
+            raise BusinessRuleException({
+                "type": "TREE_RANK_INVARIANT_PARENT",
+                "tree": self.__class__.__name__,
+                "nodeid": self.id,
+                "node_rank": self.rankid,
+                "parent_rank": self.parent.rankid,
+                "message": "Tree node's parent has rank greater than itself."
+            })
 
         if model.objects.filter(parent=self, parent__rankid__gte=F('rankid')).count() > 0:
-            raise BusinessRuleException("Tree node's rank is greater than some of its children.")
+            raise BusinessRuleException({
+                "type": "TREE_RANK_INVARIANT_CHILDREN",
+                "tree": self.__class__.__name__,
+                "nodeid": self.id,
+                "message": "Tree node's rank is greater than some of its children."
+            })
 
         if prev_self is None:
              reset_fullnames(self.definition, null_only=True)
@@ -143,7 +155,12 @@ def adding_node(node):
         pattern = r'^sp7\.allow_adding_child_to_synonymized_parent\.' + node.specify_model.name + '=(.+)'
         override = re.search(pattern, remote_prefs, re.MULTILINE)
         if override is None or override.group(1).lower() != "true":
-            raise BusinessRuleException(f'Adding node "{node.fullname}" to synonymized parent "{parent.fullname}".')
+            raise BusinessRuleException({
+                "type": "SYNONIMIZED_PARENT",
+                "nodeid": node.id,
+                "parentid": parent.id,
+                "message": f'Adding node "{node.fullname}" to synonymized parent "{parent.fullname}".'
+            })
 
     insertion_point = open_interval(model, parent.nodenumber, 1)
     node.highestchildnodenumber = node.nodenumber = insertion_point
@@ -155,8 +172,12 @@ def moving_node(to_save):
     size = current.highestchildnodenumber - current.nodenumber + 1
     new_parent = model.objects.select_for_update().get(id=to_save.parent.id)
     if new_parent.accepted_id is not None:
-        raise BusinessRuleException('Moving node "{node.fullname}" to synonymized parent "parent.fullname".'
-                                    .format(node=to_save, parent=new_parent))
+        raise BusinessRuleException({
+            "type": "SYNONYMIZED_PARENT",
+            "nodeid": to_save.id,
+            "parentid": new_parent.id,
+            "message": f'Moving node "{to_save.fullname}" to synonymized parent "{new_parent.fullname}".'
+        })
 
     insertion_point = open_interval(model, new_parent.nodenumber, size)
     # node interval will have moved if it is to the right of the insertion point
@@ -182,8 +203,13 @@ def merge(node, into, agent):
     target = model.objects.select_for_update().get(id=into.id)
     assert node.definition_id == target.definition_id, "merging across trees"
     if into.accepted_id is not None:
-        raise BusinessRuleException('Merging node "{node.fullname}" with synonymized node "{into.fullname}".'
-                                    .format(node=node, into=into))
+        raise BusinessRuleException({
+            "type": "SYNONYMIZED_PARENT",
+            "nodeid": node.id,
+            "parentid": into.id,
+            "message": f'Merging node "{node.fullname}" with synonymized node "{into.fullname}".'
+        })
+
     target_children = target.children.select_for_update()
     for child in node.children.select_for_update():
         matched = [target_child for target_child in target_children
@@ -217,14 +243,23 @@ def synonymize(node, into, agent):
     target = model.objects.select_for_update().get(id=into.id)
     assert node.definition_id == target.definition_id, "synonymizing across trees"
     if target.accepted_id is not None:
-        raise BusinessRuleException('Synonymizing "{node.fullname}" to synonymized node "{into.fullname}".'
-                                    .format(node=node, into=into))
+        raise BusinessRuleException({
+            "type": "DOUBLE_SYNONYM",
+            "nodeid": node.id,
+            "acceptedid": into.id,
+            "message": f'Synonymizing "{node.fullname}" to synonymized node "{into.fullname}".'
+        })
+
     node.accepted_id = target.id
     node.isaccepted = False
     node.save()
     if node.children.count() > 0:
-        raise BusinessRuleException('Synonymizing node "{node.fullname}" which has children.'
-                                    .format(node=node))
+        raise BusinessRuleException({
+            "type": "SYNONYMIZED_PARENT",
+            "parentid": node.id,
+            "message": f'Synonymizing node "{node.fullname}" which has children.'
+        })
+
     node.acceptedchildren.update(**{node.accepted_id_attr().replace('_id', ''): target})
     #assuming synonym can't be synonymized
     mutation_log(TREE_SYNONYMIZE, node, agent, node.parent,


### PR DESCRIPTION
In the production version of Specify 7, when business rules are violated a BusinessRuleException is raised which contains only a string type message. This exception is caught by Django and results in an http 500. This PR begins to address this by adding structure to BusinessRuleException instances (at least a type which could be interpreted by the frontend, and a message which is analogous to the old string type message). It also adds Django middleware to catch these exceptions and return the structured data in the response with status of 400 instead so they may be distinguished by the frontend from generic server errors.