### PR TITLE
Fix SpecifyUser not updating properly on user Save 

### DIFF
--- a/specifyweb/frontend/js_src/lib/components/contexts.tsx
+++ b/specifyweb/frontend/js_src/lib/components/contexts.tsx
@@ -41,7 +41,7 @@ export function Contexts({
 
   const handle = React.useCallback(
     (promise: Promise<unknown>): void => {
-      const holderId = holders.current.length;
+      const holderId = Math.max(-1, ...holders.current) + 1;
       holders.current = [...holders.current, holderId];
       handleLoading();
       promise

--- a/specifyweb/frontend/js_src/lib/components/toolbar/security.tsx
+++ b/specifyweb/frontend/js_src/lib/components/toolbar/security.tsx
@@ -213,12 +213,11 @@ export function SecurityPanel(): JSX.Element | null {
                 ...users,
                 [changedUser.id.toString()]: changedUser,
               });
-              if (typeof newUser === 'object')
-                setState({
-                  type: 'UserState',
-                  initialCollection: state.initialCollection,
-                  user: newUser,
-                });
+              setState({
+                type: 'UserState',
+                initialCollection: state.initialCollection,
+                user: newUser ?? changedUser,
+              });
             }}
             onOpenRole={(collectionId, roleId): void =>
               setState({

--- a/specifyweb/frontend/js_src/lib/components/userinvitelinkplugin.tsx
+++ b/specifyweb/frontend/js_src/lib/components/userinvitelinkplugin.tsx
@@ -45,7 +45,9 @@ export function UserInviteLinkPlugin({
               )
             : setLink('')
         }
-        disabled={typeof identityProviders === 'undefined'}
+        disabled={
+          typeof identityProviders === 'undefined' || user.id === undefined
+        }
       >
         {adminText('createInviteLink')}
       </Button.Small>


### PR DESCRIPTION
Fixes #2257 

To test:
1. Create new user
2. "Create Invite Link" should be disabled
3. Save User
4. The loading dialog is visible while user is being saved
5. "Create invite link" should become enabled even without page restart.
6. Clicking on it should create an invite link without an error