### PR TITLE
fix query result table formatting to use correct formatter.

### DIFF
--- a/specifyweb/stored_queries/format.py
+++ b/specifyweb/stored_queries/format.py
@@ -42,7 +42,7 @@ class ObjectFormatter(object):
         def getFormatterFromSchema():
             try:
                 formatter_name = Splocalecontainer.objects.get(
-                    name=specify_model.name.lower,
+                    name=specify_model.name.lower(),
                     schematype=0,
                     discipline=self.collection.discipline
                 ).format


### PR DESCRIPTION
The correct formatter being the one selected in the schema config.

fixes #2270