### PR TITLE
Occurrence export

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,5 @@
+[mypy]
+plugins = mypy_django_plugin.main
+    
+[mypy.plugins.django-stubs]
+django_settings_module = "specifyweb.settings"

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,5 @@ SQLAlchemy==1.2.11
 requests==2.2.1
 pycryptodome==3.9.7
 django-auth-ldap==1.2.15
+mypy==0.770
+django-stubs

--- a/specifyweb/export/dwca.py
+++ b/specifyweb/export/dwca.py
@@ -110,7 +110,7 @@ class Stanza(NamedTuple):
         for efield in self.export_fields:
             if efield.term is not None:
                 field_node = ET.SubElement(output_node, 'field')
-                field_node.set('index', str(efield.index))
+                field_node.set('index', str(efield.idx))
                 field_node.set('term', efield.term)
 
         for cfield in self.constant_fields:

--- a/specifyweb/export/feed.py
+++ b/specifyweb/export/feed.py
@@ -8,11 +8,15 @@ from xml.etree import ElementTree as ET
 
 from django.conf import settings
 
-from ..specify.models import Spappresourcedata, Collection, Specifyuser
+from ..specify import models
 from ..context.app_resource import get_app_resource
 from ..notifications.models import Message
 
 from .dwca import make_dwca
+
+Spappresourcedata = getattr(models, 'Spappresourcedata')
+Collection = getattr(models, 'Collection')
+Specifyuser = getattr(models, 'Specifyuser')
 
 logger = logging.getLogger(__name__)
 

--- a/specifyweb/export/management/commands/extract_query_for_dwca.py
+++ b/specifyweb/export/management/commands/extract_query_for_dwca.py
@@ -1,8 +1,9 @@
 from django.core.management.base import BaseCommand, CommandError
 
-from specifyweb.specify.models import Spquery
+from specifyweb.specify import models
 from specifyweb.export.extract_query import extract_query
 
+Spquery = getattr(models, 'Spquery')
 
 class Command(BaseCommand):
     def add_arguments(self, parser):

--- a/specifyweb/export/management/commands/make_dwca.py
+++ b/specifyweb/export/management/commands/make_dwca.py
@@ -2,10 +2,13 @@ import logging
 
 from django.core.management.base import BaseCommand, CommandError
 
+from specifyweb.specify import models
 from specifyweb.context.app_resource import get_app_resource
-from specifyweb.specify.models import Specifyuser, Collection
 
 from specifyweb.export.dwca import make_dwca
+
+Collection = getattr(models, 'Collection')
+Specifyuser = getattr(models, 'Specifyuser')
 
 logger = logging.getLogger(__name__)
 

--- a/specifyweb/export/urls.py
+++ b/specifyweb/export/urls.py
@@ -2,10 +2,13 @@ from django.conf.urls import url
 
 from . import views
 
+GUID_RE = r'[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}'
+
 urlpatterns = [
     url(r'^rss/$', views.rss_feed),
     url(r'^extract_eml/(?P<filename>.+)$', views.extract_eml),
     url(r'^make_dwca/$', views.export),
-    url(r'extract_query/(?P<query_id>\d+)/$', views.extract_query),
-    url(r'force_update/$', views.force_update),
+    url(r'^extract_query/(?P<query_id>\d+)/$', views.extract_query),
+    url(r'^force_update/$', views.force_update),
+    url(r'^occurrence/(?P<dataset_id>[^/]+)/(?P<occurrence_id>[^/]+)/$', views.occurrence),
 ]

--- a/specifyweb/export/urls.py
+++ b/specifyweb/export/urls.py
@@ -10,5 +10,5 @@ urlpatterns = [
     url(r'^make_dwca/$', views.export),
     url(r'^extract_query/(?P<query_id>\d+)/$', views.extract_query),
     url(r'^force_update/$', views.force_update),
-    url(r'^occurrence/(?P<dataset_id>[^/]+)/(?P<occurrence_id>[^/]+)/$', views.occurrence),
+    url(r'^record/(?P<dataset_id>[^/]+)/(?P<record_id>[^/]+)/$', views.record),
 ]

--- a/specifyweb/export/views.py
+++ b/specifyweb/export/views.py
@@ -93,7 +93,7 @@ def extract_eml(request, filename):
 
 @require_GET
 @never_cache
-def occurrence(request, dataset_id, occurrence_id):
+def record(request, dataset_id, record_id):
     feed_resource = get_feed_resource()
     if feed_resource is None:
         raise Http404('No export feed defined.')
@@ -111,7 +111,7 @@ def occurrence(request, dataset_id, occurrence_id):
     except KeyError:
         raise Http404('No such dataset.')
 
-    record = by_core_id(item_def.attrib['collectionId'], item_def.attrib['userId'], item_def.attrib['definition'], occurrence_id)
+    record = by_core_id(item_def.attrib['collectionId'], item_def.attrib['userId'], item_def.attrib['definition'], record_id)
     if not record:
         raise Http404('No such record.')
 


### PR DESCRIPTION
This experimental branch added an API endpoint for accessing the DwCA data for a single occurrence based on the export definitions for a collection, but the data is returned as JSON and is queried from the database in real time. The idea is that the DwCA export that get ingested by an aggregator represents a snapshot of the entire collection. Using this endpoint and the occurrenceId from an aggregator Specify Network or other API client could fetch any updates to that occurrence since the last export.