### PR TITLE
API call to replace agent records by AgentID

### DIFF
--- a/specifyweb/frontend/js_src/lib/components/Permissions/definitions.ts
+++ b/specifyweb/frontend/js_src/lib/components/Permissions/definitions.ts
@@ -8,6 +8,7 @@ export const operationPolicies = {
   '/admin/user/invite_link': ['create'],
   '/admin/user/oic_providers': ['read'],
   '/admin/user/sp6/collection_access': ['read', 'update'],
+  '/replace/record': ['update', 'delete'],
   '/report': ['execute'],
   '/export/dwca': ['execute'],
   '/export/feed': ['force_update'],
@@ -81,6 +82,7 @@ export const institutionPermissions = new Set([
   '/export/feed',
   '/permissions/library/roles',
   '/permissions/list_admins',
+  '/report/record'
 ]);
 /**
  * Policies that are respected on the front-end, but ignored by the back-end.

--- a/specifyweb/frontend/js_src/lib/tests/ajax/static/permissions/query.json
+++ b/specifyweb/frontend/js_src/lib/tests/ajax/static/permissions/query.json
@@ -92,6 +92,34 @@
       "matching_role_policies": []
     },
     {
+      "resource": "/replace/record",
+      "action": "update",
+      "allowed": true,
+      "matching_user_policies": [
+        {
+          "collectionid": null,
+          "userid": 2,
+          "resource": "%",
+          "action": "%"
+        }
+      ],
+      "matching_role_policies": []
+    },
+    {
+      "resource": "/replace/record",
+      "action": "delete",
+      "allowed": true,
+      "matching_user_policies": [
+        {
+          "collectionid": null,
+          "userid": 2,
+          "resource": "%",
+          "action": "%"
+        }
+      ],
+      "matching_role_policies": []
+    },
+    {
       "resource": "/report",
       "action": "execute",
       "allowed": true,

--- a/specifyweb/specify/api_tests.py
+++ b/specifyweb/specify/api_tests.py
@@ -560,7 +560,7 @@ class ReplaceRecordTests(ApiTests):
             collectingevent=collecting_event
         )
 
-        # Assert that the api rrequest ran successfully
+        # Assert that the api request ran successfully
         response = c.post(
             f'/api/specify/replace/agent/{agent_1.id}/{agent_2.id}/',
             data=[],

--- a/specifyweb/specify/api_tests.py
+++ b/specifyweb/specify/api_tests.py
@@ -530,3 +530,54 @@ class UserApiTests(ApiTests):
             json.loads(response.content),
             {'AgentInUseException': [self.agent.id]}
         )
+
+class ReplaceRecordTests(ApiTests):
+    def test_replace_agents(self):
+        c = Client()
+        c.force_login(self.specifyuser)
+
+        # Create agents and a collector relationship
+        agent_1 = models.Agent.objects.create(
+            id=7,
+            agenttype=0,
+            firstname="agent",
+            lastname="007",
+            specifyuser=None)
+        agent_2 = models.Agent.objects.create(
+            id=6,
+            agenttype=0,
+            firstname="agent",
+            lastname="006",
+            specifyuser=None)
+        collecting_event = models.Collectingevent.objects.create(
+            discipline=self.discipline
+        )
+        collector = models.Collector.objects.create(
+            id=7,
+            isprimary=True,
+            ordernumber=1,
+            agent=agent_1,
+            collectingevent=collecting_event
+        )
+
+        # Assert that the api rrequest ran successfully
+        response = c.post(
+            f'/api/specify/replace/agent/{agent_1.id}/{agent_2.id}/',
+            data=[],
+            content_type='text/plain')
+        self.assertEqual(response.status_code, 204)
+
+        # Assert that the collector relationship was updated correctly to the new agent
+        collector = models.Collector.objects.get(id=agent_1.id)
+        self.assertEqual(collector.agent.id, 6)
+
+        # Assert that the old agent was deleted
+        with self.assertRaises(models.Agent.DoesNotExist):
+            models.Agent.objects.get(id=7)
+
+        # Assert that a new api request will not find the old agent
+        response = c.post(
+            f'/api/specify/replace/agent/{agent_1.id}/{agent_2.id}/',
+            data=[],
+            content_type='text/plain')
+        self.assertEqual(response.status_code, 404)

--- a/specifyweb/specify/urls.py
+++ b/specifyweb/specify/urls.py
@@ -40,4 +40,7 @@ urlpatterns = [
     url(r'^set_password/(?P<userid>\d+)/$', views.set_password),
     url(r'^set_admin_status/(?P<userid>\d+)/$', views.set_admin_status),
     url(r'^set_agents/(?P<userid>\d+)/$', views.set_user_agents),
+
+    # replace agent
+    url(r'^specify/replace/agent/(?P<old_agent_id>\d+)/(?P<new_agent_id>\d+)/$', views.agent_record_replacement)
 ]

--- a/specifyweb/specify/views.py
+++ b/specifyweb/specify/views.py
@@ -438,11 +438,9 @@ def agent_record_replacement(request: http.HttpRequest, old_agent_id, new_agent_
 
     with transaction.atomic():
         # Check to make sure both the old and new agent IDs exist in the table
-        cursor.execute("SELECT * FROM specify.agent WHERE AgentID = %s;", [old_agent_id])
-        if len(cursor.fetchall()) == 0:
+        if not models.Agent.objects.filter(id=old_agent_id).select_for_update().exists():
             return http.HttpResponseBadRequest("AgentID: " + old_agent_id + " does not exist.")
-        cursor.execute("SELECT * FROM specify.agent WHERE AgentID = %s;", [new_agent_id])
-        if len(cursor.fetchall()) == 0:
+        if not models.Agent.objects.filter(id=new_agent_id).select_for_update().exists():
             return http.HttpResponseBadRequest("AgentID: " + new_agent_id + " does not exist.")
 
         # Get all of the columns in all of the tables of specify the are foreign keys referencing AgentID

--- a/specifyweb/specify/views.py
+++ b/specifyweb/specify/views.py
@@ -20,8 +20,6 @@ from specifyweb.permissions.permissions import PermissionTarget, \
 from specifyweb.workbench.upload.upload_result import FailedBusinessRule
 from . import api, models
 from .specify_jar import specify_jar
-# from .upload_result import UploadResult
-
 
 def login_maybe_required(view):
     @wraps(view)

--- a/specifyweb/specify/views.py
+++ b/specifyweb/specify/views.py
@@ -435,6 +435,7 @@ def agent_record_replacement(request: http.HttpRequest, old_agent_id, new_agent_
 
     # Create database connection cursor
     cursor = connection.cursor()
+    db_name = connection.get_connection_params()['db']
 
     with transaction.atomic():
         # Check to make sure both the old and new agent IDs exist in the table
@@ -448,11 +449,11 @@ def agent_record_replacement(request: http.HttpRequest, old_agent_id, new_agent_
         SELECT TABLE_NAME, COLUMN_NAME
         FROM INFORMATION_SCHEMA.KEY_COLUMN_USAGE
         WHERE
-        REFERENCED_TABLE_SCHEMA = 'specify' AND
+        REFERENCED_TABLE_SCHEMA = '<db_name>' AND
         REFERENCED_TABLE_NAME = 'agent' AND
         REFERENCED_COLUMN_NAME = 'AgentID'
         ORDER BY TABLE_NAME;
-        """
+        """.replace('<db_name>', db_name)
         cursor.execute(sql_get_cols_ref_agent_id)
         foreign_key_cols = cursor.fetchall()
         

--- a/specifyweb/specify/views.py
+++ b/specifyweb/specify/views.py
@@ -421,7 +421,7 @@ def set_admin_status(request, userid):
         },
         "responses": {
             "204": {"description": "Success",},
-            "400": {"description": "The AgentID specified does not exist."}
+            "404": {"description": "The AgentID specified does not exist."}
         }
     },
 })

--- a/specifyweb/specify/views.py
+++ b/specifyweb/specify/views.py
@@ -440,9 +440,9 @@ def agent_record_replacement(request: http.HttpRequest, old_agent_id, new_agent_
     with transaction.atomic():
         # Check to make sure both the old and new agent IDs exist in the table
         if not models.Agent.objects.filter(id=old_agent_id).select_for_update().exists():
-            return http.HttpResponseBadRequest("AgentID: " + old_agent_id + " does not exist.")
+            return http.HttpResponseNotFound("AgentID: " + old_agent_id + " does not exist.")
         if not models.Agent.objects.filter(id=new_agent_id).select_for_update().exists():
-            return http.HttpResponseBadRequest("AgentID: " + new_agent_id + " does not exist.")
+            return http.HttpResponseNotFound("AgentID: " + new_agent_id + " does not exist.")
 
         # Get all of the columns in all of the tables of specify the are foreign keys referencing AgentID
         sql_get_cols_ref_agent_id = """


### PR DESCRIPTION
Replaces all the foreign keys referencing the old AgentID with the new AgentID, and deletes the old agent record.  This is just an API change, front end integration will need to be a later issue.  Further changes to this commit might be to change the api to accept json, and to change the static SQL with SQLalchemy.