### PR TITLE
Fix placeholder date format showing for readonly date fields

### DIFF
--- a/specifyweb/frontend/js_src/lib/components/FormPlugins/PartialDateUi.tsx
+++ b/specifyweb/frontend/js_src/lib/components/FormPlugins/PartialDateUi.tsx
@@ -249,7 +249,7 @@ export function PartialDateUi<SCHEMA extends AnySchema>({
   ]);
 
   React.useEffect(() => {
-    if (isReadOnly) return;
+    // if (isReadOnly) return;
     /*
      * If resource changes, a new moment is set, but its value won't get
      * propagated on the first call to this useEffect.

--- a/specifyweb/frontend/js_src/lib/components/FormPlugins/PartialDateUi.tsx
+++ b/specifyweb/frontend/js_src/lib/components/FormPlugins/PartialDateUi.tsx
@@ -249,7 +249,7 @@ export function PartialDateUi<SCHEMA extends AnySchema>({
   ]);
 
   React.useEffect(() => {
-    // if (isReadOnly) return;
+    if (isReadOnly) return;
     /*
      * If resource changes, a new moment is set, but its value won't get
      * propagated on the first call to this useEffect.
@@ -387,6 +387,7 @@ export function PartialDateUi<SCHEMA extends AnySchema>({
                     type: monthType,
                     placeholder: monthFormat(),
                     title: moment?.format(monthFormat()),
+                    value: moment?.format(inputMonthFormat),
                     ...(monthSupported
                       ? {}
                       : {
@@ -398,6 +399,7 @@ export function PartialDateUi<SCHEMA extends AnySchema>({
                     type: dateType,
                     placeholder: fullDateFormat(),
                     title: moment?.format(fullDateFormat()),
+                    value: moment?.format(inputFullFormat),
                     ...(dateSupported
                       ? {}
                       : {

--- a/specifyweb/frontend/js_src/lib/components/FormPlugins/PartialDateUi.tsx
+++ b/specifyweb/frontend/js_src/lib/components/FormPlugins/PartialDateUi.tsx
@@ -203,7 +203,6 @@ export function PartialDateUi<SCHEMA extends AnySchema>({
   // Unparsed raw input
   const [inputValue, setInputValue] = React.useState('');
 
-  const isSettingInitialMoment = React.useRef<boolean>(true);
   const isInitialized = React.useRef<boolean>(false);
 
   React.useEffect(() => {
@@ -212,7 +211,6 @@ export function PartialDateUi<SCHEMA extends AnySchema>({
         silent: true,
       });
 
-    isSettingInitialMoment.current = true;
     isInitialized.current = false;
 
     const destructor = resourceOn(
@@ -249,7 +247,6 @@ export function PartialDateUi<SCHEMA extends AnySchema>({
   ]);
 
   React.useEffect(() => {
-    if (isReadOnly) return;
     /*
      * If resource changes, a new moment is set, but its value won't get
      * propagated on the first call to this useEffect.
@@ -257,8 +254,6 @@ export function PartialDateUi<SCHEMA extends AnySchema>({
      */
     if (!isInitialized.current) {
       isInitialized.current = true;
-      isSettingInitialMoment.current =
-        typeof resource.get(dateField) === 'string';
       return;
     }
     if (moment === undefined) {
@@ -279,16 +274,7 @@ export function PartialDateUi<SCHEMA extends AnySchema>({
       )
         resource.set(precisionField, precisions[precision] as never);
 
-      if (isSettingInitialMoment.current)
-        /*
-         * Don't set the value on the first run
-         * If this isn't done, unload protect would be needlessly triggered if
-         * current value in the date field does not exactly match the formatted
-         * value (i.e, happens for timestampModified fields since those include
-         * time, whereas formatted date doesn't)
-         */
-        isSettingInitialMoment.current = false;
-      else resource.set(dateField, value as never);
+      if (!isReadOnly) resource.set(dateField, value as never);
       resource.saveBlockers?.remove(`invaliddate:${dateField}`);
 
       if (precision === 'full') setInputValue(moment.format(inputFullFormat));
@@ -387,7 +373,6 @@ export function PartialDateUi<SCHEMA extends AnySchema>({
                     type: monthType,
                     placeholder: monthFormat(),
                     title: moment?.format(monthFormat()),
-                    value: moment?.format(inputMonthFormat),
                     ...(monthSupported
                       ? {}
                       : {
@@ -399,7 +384,6 @@ export function PartialDateUi<SCHEMA extends AnySchema>({
                     type: dateType,
                     placeholder: fullDateFormat(),
                     title: moment?.format(fullDateFormat()),
-                    value: moment?.format(inputFullFormat),
                     ...(dateSupported
                       ? {}
                       : {


### PR DESCRIPTION
Fixes #2438 (see also #2428)
Ultimately, Read-only date fields are not being assigned  a value in their value element in the HTML., which is defaulting to showing the placeholder format instead of the actual date. 

I believe the issue arises because where it was normally set, it is returning (see the first commit). 
Another potential fix would be to manually set the value of the value HTML element within the <Input.Generic> (see second commit)

P.S.
In regards to the first commit, that change was implemented within [fcf850766e](https://github.com/specify/specify7/commit/fcf850766e)