### PR TITLE
Fix Login button not working for annonomous users

### DIFF
--- a/specifyweb/accounts/urls.py
+++ b/specifyweb/accounts/urls.py
@@ -7,10 +7,10 @@ from . import views
 
 urlpatterns = [
     path('login/',
-         views.oic_login
-         if settings.OAUTH_LOGIN_PROVIDERS
-         else auth_views.LoginView.as_view(template_name='login.html')
-         ),
+        views.oic_login
+        if settings.OAUTH_LOGIN_PROVIDERS
+        else auth_views.LoginView.as_view(template_name='login.html')
+    ),
 
     # Login with Specify username and password:
     path('legacy_login/', auth_views.LoginView.as_view(template_name='login.html')),

--- a/specifyweb/frontend/js_src/lib/components/ChooseCollection/index.tsx
+++ b/specifyweb/frontend/js_src/lib/components/ChooseCollection/index.tsx
@@ -27,16 +27,16 @@ export function ChooseCollection(): JSX.Element {
     () => (
       <Wrapped
         errors={[
-          parseDjangoDump<string>('form-errors'),
-          parseDjangoDump<string>('collection-errors'),
+          parseDjangoDump<string>('form-errors') ?? [],
+          parseDjangoDump<string>('collection-errors') ?? [],
         ]
           .flat()
           .filter(Boolean)}
         availableCollections={JSON.parse(
-          parseDjangoDump('available-collections')
+          parseDjangoDump('available-collections') ?? '[]'
         )}
         // REFACTOR: store this on the front-end?
-        initialValue={parseDjangoDump('initial-value')}
+        initialValue={parseDjangoDump('initial-value') ?? null}
         nextUrl={parseDjangoDump<string>('next-url') ?? '/specify/'}
       />
     ),

--- a/specifyweb/frontend/js_src/lib/components/Core/Entrypoint.tsx
+++ b/specifyweb/frontend/js_src/lib/components/Core/Entrypoint.tsx
@@ -19,7 +19,8 @@ function entrypoint(): void {
 
   console.group('Specify App Starting');
   const entrypointName =
-    parseDjangoDump<ReturnType<typeof getEntrypointName>>('entrypoint-name');
+    parseDjangoDump<ReturnType<typeof getEntrypointName>>('entrypoint-name') ??
+    'main';
   console.log(entrypointName);
   unlockInitialContext(entrypointName);
 

--- a/specifyweb/frontend/js_src/lib/components/Core/Main.tsx
+++ b/specifyweb/frontend/js_src/lib/components/Core/Main.tsx
@@ -107,7 +107,10 @@ export function Main(): JSX.Element | null {
               {userInformation.isauthenticated ? (
                 <UserTools />
               ) : (
-                <Link.Default href="/accounts/login/">
+                <Link.Default
+                  href="/accounts/login/"
+                  className={className.navigationHandled}
+                >
                   {commonText('logIn')}
                 </Link.Default>
               )}

--- a/specifyweb/frontend/js_src/lib/components/Login/OicLogin.tsx
+++ b/specifyweb/frontend/js_src/lib/components/Login/OicLogin.tsx
@@ -16,6 +16,7 @@ import { Link } from '../Atoms/Link';
 import { Submit } from '../Atoms/Submit';
 import { Button } from '../Atoms/Button';
 import { SplashScreen } from '../Core/SplashScreen';
+import { className } from '../Atoms/className';
 
 export type OicProvider = {
   readonly provider: string;
@@ -82,6 +83,7 @@ export function OicLogin({
             href={formatUrl('/accounts/legacy_login/', {
               next,
             })}
+            className={className.navigationHandled}
           >
             {commonText('legacyLogin')}
           </Link.Fancy>

--- a/specifyweb/frontend/js_src/lib/components/Login/index.tsx
+++ b/specifyweb/frontend/js_src/lib/components/Login/index.tsx
@@ -22,14 +22,14 @@ import { SplashScreen } from '../Core/SplashScreen';
 export function Login(): JSX.Element {
   return React.useMemo(() => {
     const nextUrl = parseDjangoDump<string>('next-url') ?? '/specify/';
-    const providers = parseDjangoDump<RA<OicProvider>>('providers');
+    const providers = parseDjangoDump<RA<OicProvider>>('providers') ?? [];
     return providers.length > 0 ? (
       <OicLogin
         data={{
-          inviteToken: parseDjangoDump('invite-token'),
+          inviteToken: parseDjangoDump('invite-token') ?? '',
           providers,
-          languages: parseDjangoDump('languages'),
-          csrfToken: parseDjangoDump('csrf-token'),
+          languages: parseDjangoDump('languages') ?? [],
+          csrfToken: parseDjangoDump('csrf-token') ?? '',
         }}
         nextUrl={
           // REFACTOR: use parseUrl() and formatUrl() instead
@@ -41,12 +41,12 @@ export function Login(): JSX.Element {
     ) : (
       <LegacyLogin
         data={{
-          formErrors: parseDjangoDump('form-errors'),
-          inputErrors: parseDjangoDump('input-errors'),
-          externalUser: parseDjangoDump('external-user'),
-          passwordErrors: parseDjangoDump('password-errors'),
-          languages: parseDjangoDump('languages'),
-          csrfToken: parseDjangoDump('csrf-token'),
+          formErrors: parseDjangoDump('form-errors') ?? [],
+          inputErrors: parseDjangoDump('input-errors') ?? [],
+          externalUser: parseDjangoDump('external-user') ?? '',
+          passwordErrors: parseDjangoDump('password-errors') ?? [],
+          languages: parseDjangoDump('languages') ?? [],
+          csrfToken: parseDjangoDump('csrf-token') ?? '',
         }}
         nextUrl={
           nextUrl.startsWith(nextDestination)

--- a/specifyweb/frontend/js_src/lib/components/PasswordChange/index.tsx
+++ b/specifyweb/frontend/js_src/lib/components/PasswordChange/index.tsx
@@ -19,10 +19,10 @@ export function PasswordChange(): JSX.Element {
     () => (
       <ChangePassword
         data={{
-          formErrors: parseDjangoDump('form-errors'),
-          oldPasswordErrors: parseDjangoDump('old-password-errors'),
-          newPasswordErrors: parseDjangoDump('new-password-errors'),
-          repeatPasswordErrors: parseDjangoDump('repeat-password-errors'),
+          formErrors: parseDjangoDump('form-errors') ?? [],
+          oldPasswordErrors: parseDjangoDump('old-password-errors') ?? [],
+          newPasswordErrors: parseDjangoDump('new-password-errors') ?? [],
+          repeatPasswordErrors: parseDjangoDump('repeat-password-errors') ?? [],
         }}
       />
     ),

--- a/specifyweb/frontend/js_src/lib/components/Router/EntrypointRouter.tsx
+++ b/specifyweb/frontend/js_src/lib/components/Router/EntrypointRouter.tsx
@@ -18,6 +18,11 @@ export const entrypointRoutes: RA<EnhancedRoute> = [
         element: () => import('../Login').then(({ Login }) => Login),
       },
       {
+        path: 'legacy_login',
+        title: commonText('login'),
+        element: () => import('../Login').then(({ Login }) => Login),
+      },
+      {
         path: 'choose_collection',
         title: commonText('chooseCollection'),
         element: () =>

--- a/specifyweb/frontend/js_src/lib/utils/ajax/csrfToken.ts
+++ b/specifyweb/frontend/js_src/lib/utils/ajax/csrfToken.ts
@@ -6,15 +6,19 @@
 
 import { setDevelopmentGlobal } from '../types';
 import { readCookie } from './cookies';
+import { f } from '../functools';
 
 /**
  * Back-end passes initial data to front-end though templates as JSON in
  * <script> tags
  */
-export const parseDjangoDump = <T>(id: string): T =>
-  JSON.parse(globalThis.document?.getElementById(id)?.textContent ?? '[]');
+export function parseDjangoDump<T>(id: string): T | undefined {
+  const value =
+    globalThis.document?.getElementById(id)?.textContent ?? undefined;
+  return f.maybe(value, JSON.parse);
+}
 
 export const csrfToken =
-  readCookie('csrftoken') ?? parseDjangoDump<string>('csrf-token');
+  readCookie('csrftoken') ?? parseDjangoDump<string>('csrf-token') ?? '';
 
 setDevelopmentGlobal('_csrf', csrfToken);

--- a/specifyweb/frontend/templates/login.html
+++ b/specifyweb/frontend/templates/login.html
@@ -20,11 +20,11 @@
 
   {% get_available_languages as LANGUAGES %}
   {{ LANGUAGES|json_script:'languages' }}
+  {{ next|json_script:'next-url' }}
   {{ request.session.external_user|json_script:'external-user' }}
   {{ form.non_field_errors|json_script:'form-errors' }}
   {{ form.username.errors|json_script:'username-errors' }}
   {{ form.password.errors|json_script:'password-errors' }}
-  {{ next|json_script:'next-url' }}
   <script id="csrf-token">"{{ csrf_token }}"</script>
 </body>
 </html>

--- a/specifyweb/frontend/templates/oic_login.html
+++ b/specifyweb/frontend/templates/oic_login.html
@@ -19,10 +19,10 @@
   <div id="portal-root"></div>
 
   {% get_available_languages as LANGUAGES %}
-  {{ providers|json_script:'providers' }}
   {{ LANGUAGES|json_script:'languages' }}
-  {{ request.session.invite_token|json_script:'invite-token' }}
   {{ next|json_script:'next-url' }}
+  {{ providers|json_script:'providers' }}
+  {{ request.session.invite_token|json_script:'invite-token' }}
   <script id="csrf-token">"{{ csrf_token }}"</script>
 </body>
 </html>


### PR DESCRIPTION
Fixes #2651 

## To test

### On the test panel:
1. Log in
2. Choose collection
3. Log out
4. Change password

### On a local deployment

@grantfitzsimmons could you do this part?

1. Change sp7 settings file to allow anonymous access - https://github.com/specify/specify7/blob/eb435eaca00b5715a71f2812c7683aabd026d16a/specifyweb/settings/specify_settings.py#L50
3. Test the "Login" button in the heading
4. Change sp7 settings to setup oAuth using Phantauth - just uncomment the example configuration - https://github.com/specify/specify7/blob/eb435eaca00b5715a71f2812c7683aabd026d16a/specifyweb/settings/specify_settings.py#L102-L109
5. Test the `/accounts/login/` and `/accounts/legacy_login/` pages