### PR TITLE
Issue 2669 - Record merging endpoint fix

### DIFF
--- a/specifyweb/frontend/js_src/lib/components/Permissions/definitions.ts
+++ b/specifyweb/frontend/js_src/lib/components/Permissions/definitions.ts
@@ -5,7 +5,7 @@ export const operationPolicies = {
   '/admin/user/password': ['update'],
   '/admin/user/agents': ['update'],
   '/admin/user/sp6/is_admin': ['update'],
-  '/replace/record': ['update', 'delete'],
+  '/record/replace': ['update', 'delete'],
   '/admin/user/invite_link': ['create'],
   '/admin/user/oic_providers': ['read'],
   '/admin/user/sp6/collection_access': ['read', 'update'],

--- a/specifyweb/frontend/js_src/lib/tests/ajax/static/permissions/query.json
+++ b/specifyweb/frontend/js_src/lib/tests/ajax/static/permissions/query.json
@@ -92,7 +92,7 @@
       "matching_role_policies": []
     },
     {
-      "resource": "/replace/record",
+      "resource": "/record/replace",
       "action": "update",
       "allowed": true,
       "matching_user_policies": [
@@ -106,7 +106,7 @@
       "matching_role_policies": []
     },
     {
-      "resource": "/replace/record",
+      "resource": "/record/replace",
       "action": "delete",
       "allowed": true,
       "matching_user_policies": [

--- a/specifyweb/specify/api_tests.py
+++ b/specifyweb/specify/api_tests.py
@@ -562,7 +562,7 @@ class ReplaceRecordTests(ApiTests):
 
         # Assert that the api request ran successfully
         response = c.post(
-            f'/api/specify/replace/agent/{agent_1.id}/{agent_2.id}/',
+            f'/api/specify/agent/replace/{agent_1.id}/{agent_2.id}/',
             data=[],
             content_type='text/plain')
         self.assertEqual(response.status_code, 204)
@@ -577,7 +577,7 @@ class ReplaceRecordTests(ApiTests):
 
         # Assert that a new api request will not find the old agent
         response = c.post(
-            f'/api/specify/replace/agent/{agent_1.id}/{agent_2.id}/',
+            f'/api/specify/agent/replace/{agent_1.id}/{agent_2.id}/',
             data=[],
             content_type='text/plain')
         self.assertEqual(response.status_code, 404)

--- a/specifyweb/specify/urls.py
+++ b/specifyweb/specify/urls.py
@@ -42,5 +42,5 @@ urlpatterns = [
     url(r'^set_agents/(?P<userid>\d+)/$', views.set_user_agents),
 
     # replace agent
-    url(r'^specify/replace/agent/(?P<old_agent_id>\d+)/(?P<new_agent_id>\d+)/$', views.agent_record_replacement)
+    url(r'^specify/agent/replace/(?P<old_agent_id>\d+)/(?P<new_agent_id>\d+)/$', views.agent_record_replacement)
 ]

--- a/specifyweb/specify/urls.py
+++ b/specifyweb/specify/urls.py
@@ -8,6 +8,9 @@ from . import tree_views
 from . import views
 
 urlpatterns = [
+    # replace agent
+    url(r'^specify/agent/replace/(?P<old_agent_id>\d+)/(?P<new_agent_id>\d+)/$', views.agent_record_replacement),
+
     # the main business data API
     url(r'^specify_schema/openapi.json$', schema.openapi),
     url(r'^specify_schema/(?P<model>\w+)/$', schema.view),
@@ -39,8 +42,5 @@ urlpatterns = [
     # set a user's password
     url(r'^set_password/(?P<userid>\d+)/$', views.set_password),
     url(r'^set_admin_status/(?P<userid>\d+)/$', views.set_admin_status),
-    url(r'^set_agents/(?P<userid>\d+)/$', views.set_user_agents),
-
-    # replace agent
-    url(r'^specify/agent/replace/(?P<old_agent_id>\d+)/(?P<new_agent_id>\d+)/$', views.agent_record_replacement)
+    url(r'^set_agents/(?P<userid>\d+)/$', views.set_user_agents)
 ]

--- a/specifyweb/specify/views.py
+++ b/specifyweb/specify/views.py
@@ -395,7 +395,7 @@ def set_admin_status(request, userid):
         return http.HttpResponse('false', content_type='text/plain')
 
 class ReplaceRecordPT(PermissionTarget):
-    resource = "/replace/record"
+    resource = "/record/replace"
     update = PermissionTargetAction()
     delete = PermissionTargetAction()
 

--- a/specifyweb/specify/views.py
+++ b/specifyweb/specify/views.py
@@ -479,6 +479,6 @@ def agent_record_replacement(request: http.HttpRequest, old_agent_id, new_agent_
             return http.HttpResponseNotAllowed(str(e))
 
         # Dedupe by deleting the agent that is being replaced and updating the old AgentID to the new one
-        cursor.execute("DELETE FROM agent WHERE AgentID=%s", old_agent_id)
+        cursor.execute("DELETE FROM agent WHERE AgentID=%s", [old_agent_id])
         
         return http.HttpResponse('', status=204)


### PR DESCRIPTION
For the replace agent endpoint, fix string formatting error the the sql delete statement.  Also, change replace agent endpoint url so that will not conflict with any future endpoints, such as a table name "replace".
Fixes: https://github.com/specify/specify7/issues/2669