### PR TITLE
Fix the get database name error since django version update issue-2727

### DIFF
--- a/specifyweb/specify/views.py
+++ b/specifyweb/specify/views.py
@@ -442,7 +442,7 @@ def agent_record_replacement(request: http.HttpRequest, old_agent_id, new_agent_
 
     # Create database connection cursor
     cursor = connection.cursor()
-    db_name = connection.get_connection_params()['db']
+    db_name = connection.settings_dict['NAME']
 
     with transaction.atomic():
         # Check to make sure both the old and new agent IDs exist in the table


### PR DESCRIPTION
In the update-deps branch, since the django version update, the function to get the current database name in the agent replace view code no longer works and needs to be updated to the new django standards.