### PR TITLE
Ignore synonymized nodes when checking tree structure

### DIFF
--- a/specifyweb/specify/tree_extras.py
+++ b/specifyweb/specify/tree_extras.py
@@ -409,6 +409,7 @@ def validate_tree_numbering(table):
     cursor.execute((
         "select count(*) from {table} t join {table} p on t.parentid = p.{table}id\n"
         "where t.rankid <= p.rankid\n"
+        "and t.acceptedid is null" if table == 'taxon' else ""
     ).format(table=table))
     bad_ranks_count, = cursor.fetchone()
     assert bad_ranks_count == 0, \
@@ -454,6 +455,7 @@ def renumber_tree(table):
         "select count(*) from {table} t\n"
         "join {table} p on t.parentid = p.{table}id\n"
         "where t.rankid <= p.rankid\n"
+        "and t.acceptedid is null" if table == 'taxon' else ""
     ).format(table=table))
     assert (0, ) == cursor.fetchone(), "bad tree structure"
 


### PR DESCRIPTION
Fixes #2707
If synonymized nodes exist as pointers to non-synonymized nodes, is it _that_ important to take these nodes into consideration when accounting for tree structure? At a minimum, perhaps a warning (in some way) can be raised instead. 

>  it's not valid in a taxonomic sense to have a child that is at a higher rank than the parent.
> 
> However, this gets messy with synonymy, as we often see taxonomic changes result in the child of one taxon getting elevated to a different taxonomic rank, which could be equal to or higher than its former parent.
> In short, synonyms do not need to be at the same rank. Differences in opinion of the relative distinctiveness of a given taxon often result in one taxon being recognized at different ranks.

-From Garth at the University of Michigan. 