### PR TITLE
Expand synonymized actions with remote pref

### DIFF
--- a/specifyweb/frontend/js_src/lib/components/TreeView/Actions.tsx
+++ b/specifyweb/frontend/js_src/lib/components/TreeView/Actions.tsx
@@ -23,6 +23,7 @@ import { useBooleanState } from '../../hooks/useBooleanState';
 import { AnySchema, AnyTree } from '../DataModel/helperTypes';
 import { LocalizedString } from 'typesafe-i18n';
 import { queryText } from '../../localization/query';
+import { getPref } from '../InitialContext/remotePrefs';
 
 type Action = 'add' | 'desynonymize' | 'edit' | 'merge' | 'move' | 'synonymize';
 
@@ -113,7 +114,18 @@ export function TreeViewActions<SCHEMA extends AnyTree>({
             addNew
             disabled={
               focusedRow === undefined ||
-              typeof focusedRow.acceptedId === 'number' ||
+              (getPref(
+                `sp7.allow_adding_child_to_synonymized_parent.${
+                  tableName as
+                    | 'GeologicTimePeriod'
+                    | 'Taxon'
+                    | 'Geography'
+                    | 'LithoStrat'
+                    | 'Storage'
+                }`
+              )
+                ? false
+                : typeof focusedRow.acceptedId === 'number') ||
               // Forbid adding children to the lowest rank
               ranks.at(-1) === focusedRow.rankId
             }
@@ -154,7 +166,18 @@ export function TreeViewActions<SCHEMA extends AnyTree>({
             disabled={
               disableButtons ||
               isRoot ||
-              (!isSynonym && focusedRow.children > 0)
+              (getPref(
+                `sp7.allow_adding_child_to_synonymized_parent.${
+                  tableName as
+                    | 'GeologicTimePeriod'
+                    | 'Taxon'
+                    | 'Geography'
+                    | 'LithoStrat'
+                    | 'Storage'
+                }`
+              )
+                ? false
+                : !isSynonym && focusedRow.children > 0)
             }
             onClick={(): void =>
               setAction(isSynonym ? 'desynonymize' : 'synonymize')

--- a/specifyweb/frontend/js_src/lib/components/TreeView/Actions.tsx
+++ b/specifyweb/frontend/js_src/lib/components/TreeView/Actions.tsx
@@ -58,6 +58,12 @@ export function TreeViewActions<SCHEMA extends AnyTree>({
   const resourceName = `/tree/edit/${toLowerCase(tableName)}` as const;
   const isSynonym = typeof focusedRow?.acceptedId === 'number';
 
+  const doExpandSynonymActionsPref = getPref(
+    `sp7.allow_adding_child_to_synonymized_parent.${
+      tableName as AnyTree['tableName']
+    }`
+  );
+
   const disableButtons =
     focusedRow === undefined || typeof currentAction === 'string';
   return currentAction === undefined ||
@@ -114,18 +120,7 @@ export function TreeViewActions<SCHEMA extends AnyTree>({
             addNew
             disabled={
               focusedRow === undefined ||
-              (getPref(
-                `sp7.allow_adding_child_to_synonymized_parent.${
-                  tableName as
-                    | 'GeologicTimePeriod'
-                    | 'Taxon'
-                    | 'Geography'
-                    | 'LithoStrat'
-                    | 'Storage'
-                }`
-              )
-                ? false
-                : typeof focusedRow.acceptedId === 'number') ||
+              (doExpandSynonymActionsPref ? false : isSynonym) ||
               // Forbid adding children to the lowest rank
               ranks.at(-1) === focusedRow.rankId
             }
@@ -166,16 +161,7 @@ export function TreeViewActions<SCHEMA extends AnyTree>({
             disabled={
               disableButtons ||
               isRoot ||
-              (getPref(
-                `sp7.allow_adding_child_to_synonymized_parent.${
-                  tableName as
-                    | 'GeologicTimePeriod'
-                    | 'Taxon'
-                    | 'Geography'
-                    | 'LithoStrat'
-                    | 'Storage'
-                }`
-              )
+              (doExpandSynonymActionsPref
                 ? false
                 : !isSynonym && focusedRow.children > 0)
             }


### PR DESCRIPTION
Fixes #751

From https://github.com/specify/specify7/issues/1735#issuecomment-1164705260:

> Specify 7 now looks for a remote pref to override the business rule that prevents children from being added to synonymized nodes. The remote pref is of the form `sp7.allow_adding_child_to_synonymized_parent.TREENAME=true` where TREENAME is Taxon, Geography, etc.

This pull request includes the frontend implementation of this remote preference. 

Since there seemed to be a conflict within #751 title (Can't synonimize taxa with children) and the actual pref name, I have let the frontend use _both_ behaviors. 
With the pref set to true, you should be able to synonymize a node with children _and_ add children to a synonymized node.
 
We can restrict this behavior further if needed. 