### PR TITLE
Cascade permissions for dependent relationships

### DIFF
--- a/specifyweb/frontend/js_src/lib/components/FormSliders/IntegratedRecordSelector.tsx
+++ b/specifyweb/frontend/js_src/lib/components/FormSliders/IntegratedRecordSelector.tsx
@@ -227,7 +227,7 @@ export function IntegratedRecordSelector({
                 ) : undefined}
                 {hasTablePermission(
                   relationship.relatedModel.name,
-                  isDependent ? 'create' : 'read'
+                  isDependent ? 'delete' : 'read'
                 ) && typeof handleRemove === 'function' ? (
                   <DataEntry.Remove
                     disabled={


### PR DESCRIPTION
Fixes #2007

The code for this was seemingly already in place (unless there is something about this issue I am understanding incorrectly), there was just a minor bug which had the `remove` button use the `create` permission rather than `delete` permission.