### PR TITLE
Add a warning when selecting incomplete language

### DIFF
--- a/specifyweb/frontend/js_src/lib/components/Login/index.tsx
+++ b/specifyweb/frontend/js_src/lib/components/Login/index.tsx
@@ -8,13 +8,8 @@ import type { LocalizedString } from 'typesafe-i18n';
 import { useValidation } from '../../hooks/useValidation';
 import { userText } from '../../localization/user';
 import type { Language } from '../../localization/utils/config';
-import {
-  devLanguage,
-  disabledLanguages,
-  LANGUAGE,
-} from '../../localization/utils/config';
+import { devLanguage, LANGUAGE } from '../../localization/utils/config';
 import { parseDjangoDump } from '../../utils/ajax/csrfToken';
-import { f } from '../../utils/functools';
 import type { RA } from '../../utils/types';
 import { ErrorMessage } from '../Atoms';
 import { Form, Input, Label } from '../Atoms/Form';
@@ -74,11 +69,8 @@ export function LoginLanguageChooser({
   const loading = React.useContext(LoadingContext);
   return (
     <LanguageSelection<Language>
-      languages={Object.fromEntries(
-        languages.filter(
-          ([code]) => !f.has(disabledLanguages, code) || code === LANGUAGE
-        )
-      )}
+      languages={Object.fromEntries(languages)}
+      isForInterface
       value={(devLanguage as Language) ?? LANGUAGE}
       onChange={(language): void =>
         loading(

--- a/specifyweb/frontend/js_src/lib/components/Toolbar/Language.tsx
+++ b/specifyweb/frontend/js_src/lib/components/Toolbar/Language.tsx
@@ -3,39 +3,41 @@
  */
 
 import React from 'react';
+import type { LocalizedString } from 'typesafe-i18n';
 
 import { useAsyncState } from '../../hooks/useAsyncState';
 import { commonText } from '../../localization/common';
 import { headerText } from '../../localization/header';
 import { StringToJsx } from '../../localization/utils';
+import type { Language } from '../../localization/utils/config';
+import {
+  completeLanguages,
+  devLanguage as developmentLanguage,
+  devLanguages as developmentLanguages,
+  LANGUAGE,
+  languages,
+} from '../../localization/utils/config';
 import { ajax } from '../../utils/ajax';
 import { csrfToken } from '../../utils/ajax/csrfToken';
+import { Http } from '../../utils/ajax/definitions';
 import { ping } from '../../utils/ajax/ping';
 import { f } from '../../utils/functools';
 import type { IR, RA } from '../../utils/types';
 import { sortFunction } from '../../utils/utils';
+import { Button } from '../Atoms/Button';
 import { Select } from '../Atoms/Form';
+import { Link } from '../Atoms/Link';
 import { fail } from '../Errors/Crash';
 import { supportLink } from '../Errors/ErrorDialog';
 import { cachableUrl } from '../InitialContext';
 import { Dialog, dialogClassNames } from '../Molecules/Dialog';
+import { formatUrl } from '../Router/queryString';
+import { languageSeparator } from '../SchemaConfig/Languages';
 import type {
   PreferenceItem,
   PreferenceItemComponent,
 } from '../UserPreferences/Definitions';
 import { PreferencesContext, prefEvents } from '../UserPreferences/Hooks';
-import { LocalizedString } from 'typesafe-i18n';
-import {
-  devLanguage,
-  devLanguages,
-  disabledLanguages,
-  Language,
-  LANGUAGE,
-  languages,
-} from '../../localization/utils/config';
-import { formatUrl } from '../Router/queryString';
-import { Http } from '../../utils/ajax/definitions';
-import { languageSeparator } from '../SchemaConfig/Languages';
 
 export const handleLanguageChange = async (language: Language): Promise<void> =>
   ping(
@@ -57,15 +59,22 @@ export function LanguageSelection<LANGUAGES extends string>({
   languages,
   onChange: handleChange,
   isReadOnly = false,
-  showDevLanguages = process.env.NODE_ENV === 'development',
+  showDevLanguages: showDevelopmentLanguages = process.env.NODE_ENV ===
+    'development',
+  // Whether the language picker is for the UI language (rather than schema)
+  isForInterface,
 }: {
   readonly value: LANGUAGES;
   readonly languages: IR<string> | undefined;
   readonly onChange: (language: LANGUAGES) => void;
   readonly isReadOnly?: boolean;
   readonly showDevLanguages?: boolean;
+  readonly isForInterface: boolean;
 }): JSX.Element {
   const [showSupportDialog, setShowSupportDialog] = React.useState(false);
+  const [warningLanguage, setWarningLanguage] = React.useState<
+    LANGUAGES | undefined
+  >(undefined);
 
   return (
     <>
@@ -88,28 +97,68 @@ export function LanguageSelection<LANGUAGES extends string>({
           </p>
         </Dialog>
       )}
+      {typeof warningLanguage === 'string' && (
+        <Dialog
+          buttons={
+            <>
+              <Button.DialogClose>{commonText.cancel()}</Button.DialogClose>
+              <Button.Blue
+                onClick={(): void => {
+                  handleChange(warningLanguage);
+                  setWarningLanguage(undefined);
+                }}
+              >
+                {commonText.proceed()}
+              </Button.Blue>
+            </>
+          }
+          header={headerText.incompleteLocalization()}
+          onClose={(): void => setWarningLanguage(undefined)}
+        >
+          <p>
+            <StringToJsx
+              components={{
+                link: (label) => (
+                  <Link.NewTab href="https://discourse.specifysoftware.org/t/get-started-with-specify-7-localization/956">
+                    {label}
+                  </Link.NewTab>
+                ),
+              }}
+              string={headerText.incompleteLocalizationDescription()}
+            />
+          </p>
+        </Dialog>
+      )}
       {typeof languages === 'object' ? (
         <Select
           aria-label={commonText.language()}
           disabled={isReadOnly}
           value={value}
-          onChange={({ target }): void =>
-            target.value === 'supportLocalization'
+          onValueChange={(value): void =>
+            value === 'supportLocalization'
               ? setShowSupportDialog(true)
-              : handleChange(target.value as LANGUAGES)
+              : f.has(completeLanguages, value)
+              ? handleChange(value as LANGUAGES)
+              : setWarningLanguage(value as LANGUAGES)
           }
         >
           {Object.entries(languages).map(([code, nameLocal]) => (
             <option key={code} value={code}>
-              {nameLocal} ({code})
+              {`${nameLocal} (${code}) ${
+                f.has(completeLanguages, code)
+                  ? ''
+                  : headerText.incompleteInline()
+              }`}
             </option>
           ))}
-          <option value="supportLocalization">
-            {headerText.helpLocalizeSpecify()}
-          </option>
-          {showDevLanguages && (
+          {isForInterface && (
+            <option value="supportLocalization">
+              {headerText.helpLocalizeSpecify()}
+            </option>
+          )}
+          {showDevelopmentLanguages && (
             <optgroup label="Development languages">
-              {Object.entries(devLanguages).map(([code, name]) => (
+              {Object.entries(developmentLanguages).map(([code, name]) => (
                 <option key={code} value={code}>
                   {name}
                 </option>
@@ -150,10 +199,6 @@ export const LanguagePreferencesItem: PreferenceItemComponent<Language> =
           }).then(({ data }) =>
             Object.fromEntries(
               Object.entries(data)
-                .filter(
-                  ([code]) =>
-                    !f.has(disabledLanguages, code) || code === language
-                )
                 // eslint-disable-next-line @typescript-eslint/naming-convention
                 .map(([code, { name_local }]) => [code, name_local])
             )
@@ -163,7 +208,7 @@ export const LanguagePreferencesItem: PreferenceItemComponent<Language> =
       false
     );
     const [language, setLanguage] = React.useState(
-      (devLanguage as Language) ?? LANGUAGE
+      (developmentLanguage as Language) ?? LANGUAGE
     );
 
     /**
@@ -173,6 +218,7 @@ export const LanguagePreferencesItem: PreferenceItemComponent<Language> =
     const isRedirecting = React.useContext(PreferencesContext) !== undefined;
     return (
       <LanguageSelection<Language>
+        isForInterface
         isReadOnly={isReadOnly || isRedirecting || languages === undefined}
         languages={languages ?? { loading: commonText.loading() }}
         value={language}
@@ -218,7 +264,9 @@ export function useSchemaLanguages(
               data.map(
                 ({ country, language }) =>
                   `${language}${
-                    country === null || country === '' ? '' : `${languageSeparator}${country}`
+                    country === null || country === ''
+                      ? ''
+                      : `${languageSeparator}${country}`
                   }`
               )
             )
@@ -255,11 +303,12 @@ export const SchemaLanguagePreferenceItem: PreferenceItemComponent<string> =
     const languages = useSchemaLanguages(false);
     return (
       <LanguageSelection<string>
+        isForInterface={false}
         isReadOnly={isReadOnly || languages === undefined}
         languages={languages ?? { loading: commonText.loading() }}
+        showDevLanguages={false}
         value={value}
         onChange={handleChange}
-        showDevLanguages={false}
       />
     );
   };

--- a/specifyweb/frontend/js_src/lib/localization/header.ts
+++ b/specifyweb/frontend/js_src/lib/localization/header.ts
@@ -237,6 +237,20 @@ export const headerText = createDictionary({
       адресу <emailLink />
     `,
   },
+  incompleteInline: {
+    'en-us': '(incomplete)',
+  },
+  incompleteLocalization: {
+    'en-us': 'Incomplete localization',
+  },
+  incompleteLocalizationDescription: {
+    'en-us': `
+      Translation to this language is not yet complete. Some elements may be
+      missing localization, or have incorrect localization. If you are
+      interested in helping us complete localization, please <link>follow the
+      instructions.</link>
+    `,
+  },
   tableApi: {
     'en-us': 'Tables API',
     'ru-ru': 'API таблиц',

--- a/specifyweb/frontend/js_src/lib/localization/utils/config.ts
+++ b/specifyweb/frontend/js_src/lib/localization/utils/config.ts
@@ -7,8 +7,15 @@ import { setDevelopmentGlobal } from '../../utils/types';
  * (weblate uses unconventional codes)
  *
  * To add new language, define it in this list
+ *
  */
 export const languageCodeMapper = {
+  /*
+   * IMPORTANT
+   * On any changes here, also update the "LANGUAGES" array in
+   * /specifyweb/settings/__init__.py. Otherwise, Django won't let select newly
+   * added language
+   */
   'en-us': 'en_US',
   'ru-ru': 'ru',
   'uk-ua': 'uk',
@@ -18,10 +25,11 @@ export const languageCodeMapper = {
 
 export const languages = Object.keys(languageCodeMapper);
 
-/** This allows to hide unfinished localizations in production */
-export const disabledLanguages = new Set(
-  process.env.NODE_ENV === 'development' ? [] : ['uk-ua', 'fr-fr', 'es-es']
-);
+/**
+ * If user choose any language not in this list, a warning would be shown
+ * saying the localization is not yet complete.
+ */
+export const completeLanguages = new Set(['en-us', 'ru-ru']);
 
 /**
  * These languages are available in development only. Used for testing

--- a/specifyweb/settings/__init__.py
+++ b/specifyweb/settings/__init__.py
@@ -92,9 +92,14 @@ LOCALE_PATHS = (
     ),
 )
 
+# On any changes here, also update languageCodeMapper in
+# /specifyweb/frontend/js_src/lib/localization/utils/config.ts
 LANGUAGES = [
     ('en-us', 'English'),
     ('ru-ru', 'русский'),
+    ('uk-ua', 'українська'),
+    ('fr-fr', 'français'),
+    ('es-es', 'español'),
 ]
 
 SITE_ID = 1


### PR DESCRIPTION
For languages that are not yet fully localized.

Prior, incomplete languages were hidden when not in development.

Test both the login screen and the settings language picker.

The schema language picker in settings should not be affected by this change.