### PR TITLE
Remove additional deletion blocker from import

### DIFF
--- a/specifyweb/specify/views.py
+++ b/specifyweb/specify/views.py
@@ -20,7 +20,6 @@ from specifyweb.permissions.permissions import PermissionTarget, \
 from specifyweb.workbench.upload.upload_result import FailedBusinessRule
 from . import api, models
 from .specify_jar import specify_jar
-from .build_models import ADDITIONAL_DELETE_BLOCKERS
 
 def login_maybe_required(view):
     @wraps(view)


### PR DESCRIPTION
I have no words on how this left over import got through with my merge from #2702. 

The additional delete blockers were moved to #2806 in commit c25ab91 and were supposed to be cleaned up from #2702 in 0387638. 
I am amazed this got past me, the dockerize test, and backend tests. 