### PR TITLE
Fix race condition on multiple stats pages open

### DIFF
--- a/specifyweb/frontend/js_src/lib/components/Statistics/StatItems.tsx
+++ b/specifyweb/frontend/js_src/lib/components/Statistics/StatItems.tsx
@@ -1,21 +1,24 @@
-import type { SpQueryField, Tables } from '../DataModel/types';
+import React from 'react';
+
+import { ajax } from '../../utils/ajax';
+import { throttledAjax } from '../../utils/ajax/throttledAjax';
 import type { RA } from '../../utils/types';
 import type { SerializedResource } from '../DataModel/helperTypes';
-import { StatsResult } from './StatsResult';
-import React from 'react';
+import type { SpecifyResource } from '../DataModel/legacyTypes';
+import type { SpQuery, SpQueryField, Tables } from '../DataModel/types';
 import {
   queryCountPromiseGenerator,
   useCustomStatsSpec,
   useResolvedSpec,
   useResolvedSpecToQueryResource,
 } from './hooks';
-import type { CustomStat, DefaultStat, StatsSpec } from './types';
-import { SpecifyResource } from '../DataModel/legacyTypes';
-import { SpQuery } from '../DataModel/types';
-import { useAsyncState } from '../../hooks/useAsyncState';
-import { throttledAjax } from '../../utils/ajax/throttledAjax';
-import { BackendStatsResult } from './types';
-import { ajax } from '../../utils/ajax';
+import { StatsResult } from './StatsResult';
+import type {
+  BackendStatsResult,
+  CustomStat,
+  DefaultStat,
+  StatsSpec,
+} from './types';
 
 export function StatItem({
   statsSpec,
@@ -53,11 +56,6 @@ export function StatItem({
     | undefined;
   readonly onItemRename: ((newLabel: string) => void) | undefined;
 }): JSX.Element | null {
-  const handleItemValueLoad = React.useCallback(
-    (value: number | string, itemLabel: string) =>
-      handleValueLoad?.(categoryIndex, itemIndex, value, itemLabel),
-    [handleValueLoad, categoryIndex, itemIndex]
-  );
   const customStatsSpec = useCustomStatsSpec(item);
   const pathToValue =
     item.type === 'DefaultStat' && item.itemType === 'BackendStat'
@@ -72,15 +70,28 @@ export function StatItem({
   );
 
   const query = useResolvedSpecToQueryResource(statsSpecCalculated);
+  // TODO: this is just temporary. Needs refactoring
+  const label =
+    (statsSpecCalculated?.type === 'QueryStat'
+      ? statsSpecCalculated?.label
+      : undefined) ?? item.itemLabel;
+  const handleItemValueLoad = React.useCallback(
+    (value: number | string) =>
+      handleValueLoad?.(categoryIndex, itemIndex, value, label),
+    [handleValueLoad, categoryIndex, itemIndex, label]
+  );
 
   return statsSpecCalculated?.type === 'QueryStat' && query !== undefined ? (
     <QueryItem
+      fields={statsSpecCalculated.fields}
       isDefault={item.type === 'DefaultStat'}
       query={query}
       statLabel={statsSpecCalculated?.label}
       statValue={item.itemValue}
+      tableName={statsSpecCalculated.tableName}
       onClick={handleClick}
       onItemRename={handleItemRename}
+      onItemValueLoad={handleItemValueLoad}
       onRemove={handleRemove}
       onSpecChanged={
         handleSpecChanged !== undefined
@@ -89,25 +100,22 @@ export function StatItem({
             }
           : undefined
       }
-      fields={statsSpecCalculated.fields}
-      tableName={statsSpecCalculated.tableName}
-      onItemValueLoad={handleItemValueLoad}
     />
   ) : item.type === 'DefaultStat' &&
     statsSpecCalculated !== undefined &&
     statsSpecCalculated.type === 'BackEndStat' &&
     statsSpecCalculated.pathToValue !== undefined ? (
     <BackEndItem
+      formatter={statsSpecCalculated.formatter}
       isDefault
-      urlToFetch={statsSpecCalculated.urlToFetch}
       pathToValue={statsSpecCalculated.pathToValue}
       statLabel={item.itemLabel}
       statValue={item.itemValue}
+      urlToFetch={statsSpecCalculated.urlToFetch}
       onClick={handleClick}
       onItemRename={handleItemRename}
-      onRemove={handleRemove}
-      formatter={statsSpecCalculated.formatter}
       onItemValueLoad={handleItemValueLoad}
+      onRemove={handleRemove}
     />
   ) : null;
 }
@@ -124,7 +132,7 @@ function BackEndItem({
   onItemRename: handleItemRename,
   onItemValueLoad: handleItemValueLoad,
 }: {
-  readonly statValue: string | number | undefined;
+  readonly statValue: number | string | undefined;
   readonly urlToFetch: string;
   readonly pathToValue: string;
   readonly statLabel: string;
@@ -133,37 +141,32 @@ function BackEndItem({
   readonly onClick: (() => void) | undefined;
   readonly onRemove: (() => void) | undefined;
   readonly onItemRename: ((newLabel: string) => void) | undefined;
-  readonly onItemValueLoad:
-    | ((value: number | string, itemLabel: string) => void)
-    | undefined;
+  readonly onItemValueLoad: ((value: number | string) => void) | undefined;
 }): JSX.Element {
-  const [count] = useAsyncState<number | string | undefined>(
-    React.useCallback(
+  const shouldFetch =
+    statValue === undefined && typeof handleItemValueLoad === 'function';
+  React.useEffect(() => {
+    if (!shouldFetch) return undefined;
+    let destructorCalled = false;
+    throttledAjax<BackendStatsResult, string>(
+      'backendStats',
       async () =>
-        statValue === undefined
-          ? throttledAjax<BackendStatsResult, string>(
-              'backendStats',
-              async () =>
-                ajax<BackendStatsResult>(urlToFetch, {
-                  method: 'GET',
-                  headers: {
-                    Accept: 'application/json',
-                  },
-                }).then(({ data }) => data),
-              urlToFetch
-            ).then((data) => {
-              const rawValue = data[pathToValue as keyof BackendStatsResult];
-              if (rawValue === undefined) return undefined;
-              return formatter(rawValue);
-            })
-          : Promise.resolve(undefined),
-      [statLabel, statValue, handleItemValueLoad, pathToValue, urlToFetch]
-    ),
-    false
-  );
-  if (count !== undefined && statValue === undefined) {
-    handleItemValueLoad?.(count, statLabel);
-  }
+        ajax<BackendStatsResult>(urlToFetch, {
+          method: 'GET',
+          headers: {
+            Accept: 'application/json',
+          },
+        }).then(({ data }) => data),
+      urlToFetch
+    ).then((data) => {
+      const rawValue = data[pathToValue as keyof BackendStatsResult];
+      if (rawValue === undefined || destructorCalled) return;
+      handleItemValueLoad?.(formatter(rawValue));
+    });
+    return (): void => {
+      destructorCalled = true;
+    };
+  }, [statValue, handleItemValueLoad, pathToValue, urlToFetch]);
   return (
     <StatsResult
       isDefault={isDefault}
@@ -191,7 +194,7 @@ function QueryItem({
   isDefault,
   onItemValueLoad: handleItemValueLoad,
 }: {
-  readonly statValue: string | number | undefined;
+  readonly statValue: number | string | undefined;
   readonly tableName: keyof Tables;
   readonly fields: RA<
     Partial<SerializedResource<SpQueryField>> & { readonly path: string }
@@ -210,36 +213,34 @@ function QueryItem({
       ) => void)
     | undefined;
   readonly onItemRename: ((newLabel: string) => void) | undefined;
-  readonly onItemValueLoad:
-    | ((value: number | string, itemLabel: string) => void)
-    | undefined;
+  readonly onItemValueLoad: ((value: number | string) => void) | undefined;
 }): JSX.Element | null {
-  const [count] = useAsyncState<string | number | undefined>(
-    React.useCallback(
-      async () =>
-        statValue === undefined
-          ? throttledAjax<
-              string | number | undefined,
-              {
-                readonly tableName: keyof Tables;
-                readonly fields: RA<
-                  Partial<SerializedResource<SpQueryField>> & {
-                    readonly path: string;
-                  }
-                >;
-              }
-            >('queryStats', queryCountPromiseGenerator(query), {
-              tableName,
-              fields,
-            })
-          : Promise.resolve(undefined),
-      [statValue, tableName, fields, handleItemValueLoad, statLabel]
-    ),
-    false
-  );
-  if (count !== undefined && statValue === undefined) {
-    handleItemValueLoad?.(count, statLabel);
-  }
+  const shouldFetch =
+    statValue === undefined && typeof handleItemValueLoad === 'function';
+  React.useCallback(() => {
+    if (!shouldFetch) return undefined;
+    let destructorCalled = false;
+    throttledAjax<
+      number | string | undefined,
+      {
+        readonly tableName: keyof Tables;
+        readonly fields: RA<
+          Partial<SerializedResource<SpQueryField>> & {
+            readonly path: string;
+          }
+        >;
+      }
+    >('queryStats', queryCountPromiseGenerator(query), {
+      tableName,
+      fields,
+    }).then((value) => {
+      if (value === undefined || destructorCalled) return;
+      handleItemValueLoad?.(value);
+    });
+    return (): void => {
+      destructorCalled = true;
+    };
+  }, [statValue, tableName, fields, handleItemValueLoad]);
   return (
     <StatsResult
       isDefault={isDefault}

--- a/specifyweb/frontend/js_src/lib/components/Statistics/index.tsx
+++ b/specifyweb/frontend/js_src/lib/components/Statistics/index.tsx
@@ -155,9 +155,9 @@ export function StatsPage(): JSX.Element | null {
   ]);
 
   /* Set Default Layout every time page is rendered*/
-  React.useEffect(() => {
-    setDefaultLayout(defaultLayoutSpec);
-  }, [setDefaultLayout, defaultLayoutSpec]);
+  // React.useEffect(() => {
+  //   setDefaultLayout(defaultLayoutSpec);
+  // }, [setDefaultLayout, defaultLayoutSpec]);
 
   const pageLastUpdated = activePage.isCollection
     ? collectionLayout?.[activePage.pageIndex].lastUpdated


### PR DESCRIPTION
To reproduce:
1. Open stats page
2. Open one more in a different tab
3. Click "Update" in one tab
4. Wait for it to finish
5. The tabs should not be making requests/callback calls in a loop

Able to reproduce the bug before the fix that is included in this branch. Unable to reproduce it after the fix. @realVinayak can you please test it to verify it's also fixed for you?