### PR TITLE
Add pref to display author name in Taxon tree viewer

### DIFF
--- a/specifyweb/frontend/js_src/lib/components/InitialContext/remotePrefs.ts
+++ b/specifyweb/frontend/js_src/lib/components/InitialContext/remotePrefs.ts
@@ -189,6 +189,13 @@ export const remotePrefsDefinitions = f.store(
         parser: 'java.lang.Long',
         isLegacy: true,
       },
+      'TaxonTreeEditor.DisplayAuthor' : {
+        description:
+        "Display Authors of Taxons' next to nodes in the Tree Viewer",
+        defaultValue: false,
+        parser: 'java.lang.Boolean',
+        isLegacy: true,
+      },
       'attachment.is_public_default': {
         description: 'Whether new Attachments are public by default',
         defaultValue: true,

--- a/specifyweb/frontend/js_src/lib/components/TreeView/Row.tsx
+++ b/specifyweb/frontend/js_src/lib/components/TreeView/Row.tsx
@@ -9,6 +9,7 @@ import type { RA } from '../../utils/types';
 import { Button } from '../Atoms/Button';
 import { icons } from '../Atoms/Icons';
 import { useId } from '../../hooks/useId';
+import { getPref } from '../InitialContext/remotePrefs';
 
 export function TreeRow({
   row,
@@ -27,6 +28,7 @@ export function TreeRow({
   onAction: handleAction,
   setFocusedRow,
   synonymColor,
+  treeName,
 }: {
   readonly row: Row;
   readonly getRows: (parentId: number | 'null') => Promise<RA<Row>>;
@@ -49,6 +51,7 @@ export function TreeRow({
   readonly onAction: (action: Exclude<KeyAction, 'child' | 'toggle'>) => void;
   readonly setFocusedRow: (row: Row) => void;
   readonly synonymColor: string;
+  readonly treeName: string;
 }): JSX.Element {
   const [rows, setRows] = React.useState<RA<Row> | undefined>(undefined);
   const [childStats, setChildStats] = React.useState<Stats | undefined>(
@@ -124,6 +127,8 @@ export function TreeRow({
   const parentRankId = path.at(-1)?.rankId;
   const id = useId('tree-node');
   const isAction = actionRow === row;
+
+  const doIncludeAuthorPref = getPref(`TaxonTreeEditor.DisplayAuthor`);
 
   const handleRef = React.useCallback(
     (element: HTMLButtonElement | null): void => {
@@ -218,7 +223,11 @@ export function TreeRow({
                       : undefined
                   }
                 >
-                  {row.name}
+                  {doIncludeAuthorPref &&
+                  treeName === 'Taxon' &&
+                  typeof row.author === 'string'
+                    ? row.name + ' (' + row.author + ')'
+                    : row.name}
                   {typeof row.acceptedId === 'number' && (
                     <span className="sr-only">
                       <br />
@@ -295,6 +304,7 @@ export function TreeRow({
               row={childRow}
               setFocusedRow={setFocusedRow}
               synonymColor={synonymColor}
+              treeName={treeName}
               onAction={(action): void => {
                 if (action === 'next')
                   if (typeof rows[index + 1] === 'object')

--- a/specifyweb/frontend/js_src/lib/components/TreeView/helpers.ts
+++ b/specifyweb/frontend/js_src/lib/components/TreeView/helpers.ts
@@ -22,7 +22,8 @@ export const fetchRows = async (fetchUrl: string) =>
         number,
         number | null,
         string | null,
-        number
+        string,
+        number,
       ]
     >
   >(fetchUrl, {
@@ -40,7 +41,8 @@ export const fetchRows = async (fetchUrl: string) =>
           rankId,
           acceptedId = undefined,
           acceptedName = undefined,
-          children,
+          author = undefined,
+          children
         ],
         index,
         { length }
@@ -53,6 +55,7 @@ export const fetchRows = async (fetchUrl: string) =>
         rankId,
         acceptedId,
         acceptedName,
+        author,
         children,
         isLastChild: index + 1 === length,
       })

--- a/specifyweb/frontend/js_src/lib/components/TreeView/index.tsx
+++ b/specifyweb/frontend/js_src/lib/components/TreeView/index.tsx
@@ -104,10 +104,11 @@ function TreeView<SCHEMA extends AnyTree>({
   const baseUrl = `/api/specify_tree/${tableName.toLowerCase()}/${
     treeDefinition.id
   }`;
+  const doIncludeAuthorPref = getPref(`TaxonTreeEditor.DisplayAuthor`);
 
   const getRows = React.useCallback(
     async (parentId: number | 'null') =>
-      fetchRows(`${baseUrl}/${parentId}/${sortField}`),
+      fetchRows(`${baseUrl}/${parentId}/${sortField}/${doIncludeAuthorPref}`),
     [baseUrl, sortField]
   );
 
@@ -291,6 +292,7 @@ function TreeView<SCHEMA extends AnyTree>({
               row={row}
               setFocusedRow={setFocusedRow}
               synonymColor={synonymColor}
+              treeName={tableName}
               onAction={(action): void => {
                 if (action === 'next')
                   if (rows[index + 1] === undefined) return undefined;

--- a/specifyweb/specify/tree_views.py
+++ b/specifyweb/specify/tree_views.py
@@ -35,7 +35,8 @@ def tree_mutation(mutation):
 
 @login_maybe_required
 @require_GET
-def tree_view(request, treedef, tree, parentid, sortfield):
+def tree_view(request, treedef, tree, parentid, sortfield, includeAuthor=False):
+
     """Returns a list of <tree> nodes with parent <parentid> restricted to
     the tree defined by treedefid = <treedef>. The nodes are sorted
     according to <sortfield>.
@@ -60,6 +61,7 @@ def tree_view(request, treedef, tree, parentid, sortfield):
                               node.rankId,
                               node.AcceptedID,
                               accepted.fullName,
+                              node.author if (includeAuthor and tree=="taxon") else "NULL",
                               sql.functions.count(child_id)) \
                         .outerjoin(child, child.ParentID == id_col) \
                         .outerjoin(accepted, node.AcceptedID == getattr(accepted, node._id)) \
@@ -68,7 +70,6 @@ def tree_view(request, treedef, tree, parentid, sortfield):
                         .filter(node.ParentID == parentid) \
                         .order_by(orderby)
         results = list(query)
-
     return HttpResponse(toJson(results), content_type='application/json')
 
 @login_maybe_required

--- a/specifyweb/specify/urls.py
+++ b/specifyweb/specify/urls.py
@@ -32,7 +32,7 @@ urlpatterns = [
         url(r'^(?P<id>\d+)/desynonymize/$', tree_views.desynonymize),
         url(r'^(?P<parentid>\d+)/predict_fullname/$', tree_views.predict_fullname),
         url(r'^(?P<treedef>\d+)/(?P<parentid>\w+)/stats/$', tree_views.tree_stats),
-        url(r'^(?P<treedef>\d+)/(?P<parentid>\w+)/(?P<sortfield>\w+)/$', tree_views.tree_view),
+        url(r'^(?P<treedef>\d+)/(?P<parentid>\w+)/(?P<sortfield>\w+)/(?P<includeAuthor>\w+)$', tree_views.tree_view),
         url(r'^repair/$', tree_views.repair_tree),
     ])),
 


### PR DESCRIPTION
Fixes #1121

Addes a new remote preference `TaxonTreeEditor.DisplayAuthor`, which when enabled displays the author next to the full name in the Taxon TreeViewer 