### PR TITLE
Fix incorrect comparison for "5A" being equal to "5B"

### DIFF
--- a/specifyweb/frontend/js_src/lib/components/DataModel/resourceApi.js
+++ b/specifyweb/frontend/js_src/lib/components/DataModel/resourceApi.js
@@ -225,8 +225,9 @@ function eventHandlerForToOne(related, field) {
                    * string to number (back-end sends certain numeric fields
                    * as strings. Front-end converts those to numbers)
                    * REFACTOR: this logic should be moved to this.parse()
+                   * TEST: add test for "5A" case
                    */
-                  Number.parseInt(oldValue) === Number.parseInt(newValue)
+                  oldValue.toString() === newValue.toString()
                 )
                     options ??= {silent: true};
                 else if(

--- a/specifyweb/frontend/js_src/lib/components/DataModel/resourceApi.js
+++ b/specifyweb/frontend/js_src/lib/components/DataModel/resourceApi.js
@@ -218,23 +218,18 @@ function eventHandlerForToOne(related, field) {
               typeof (oldValue??'') !== 'object' &&
               typeof (newValue??'') !== 'object'
             ) {
-                if(oldValue === newValue) return this;
-                else if(
+                if(
                   /*
-                   * Don't trigger unload protect if value changed from
-                   * string to number (back-end sends certain numeric fields
-                   * as strings. Front-end converts those to numbers)
+                   * Don't trigger unload protect if:
+                   *  - value didn't change
+                   *  - value changed from string to number (back-end sends
+                   *    decimal numeric fields as string. Front-end converts
+                   *    those to numbers)
+                   *  - value was trimmed
                    * REFACTOR: this logic should be moved to this.parse()
                    * TEST: add test for "5A" case
                    */
-                  oldValue.toString() === newValue.toString()
-                )
-                    options ??= {silent: true};
-                else if(
-                  // Trimming the value shouldn't trigger the unload protect
-                  typeof oldValue === 'string' &&
-                  typeof newValue === 'string' &&
-                  oldValue === newValue.trim()
+                  oldValue?.toString() === newValue?.toString().trim()
                 )
                     options ??= {silent: true};
             }


### PR DESCRIPTION
Fixes #2805

Caused by 24eec2ffc4 (from 8 months ago)
This happens for all fields, but only if the old value for that field starts with a number (`5A`) and the new value of that field starts with a number (`5B`).
**The correct new value is stored in the database**. The bug only affects the visual display.


To test:
- Change the value from `5A` to `5B`. Save button should be triggered
- Open a record that has whitespace in a text field. Trimming white space should not trigger the save button (front-end component might trim the white space automatically)
- Open any record that has a decimal field (with some value in it). The save button should not be triggered