### PR TITLE
Add crash report visualizer

### DIFF
--- a/specifyweb/frontend/js_src/lib/components/Developer/CrashReportMapper.tsx
+++ b/specifyweb/frontend/js_src/lib/components/Developer/CrashReportMapper.tsx
@@ -1,0 +1,172 @@
+import React from 'react';
+
+import type { IR, RA } from '../../utils/types';
+import { ErrorIframe } from '../Errors/FormatError';
+import { DateElement } from '../Molecules/DateElement';
+import { CrashReportLines } from './CrashReportVisualizer';
+import { developmentText } from '../../localization/development';
+
+export const crashReportMapper: IR<
+  (props: { readonly value: unknown }) => JSX.Element
+> = {
+  consoleLog({ value }) {
+    return Array.isArray(value) ? (
+      <div className="divide-y divide-gray-500">
+        {value.map((line, index) =>
+          typeof line === 'object' ? (
+            <LogLine key={index} line={line as IR<unknown>} />
+          ) : (
+            <CrashReportFallback key={index} value={line} />
+          )
+        )}
+      </div>
+    ) : (
+      <CrashReportFallback value={value} />
+    );
+  },
+  message({ value }) {
+    return Array.isArray(value) ? (
+      <>
+        {value.map((line, index) => (
+          <CrashReportFallback key={index} value={line} />
+        ))}
+      </>
+    ) : (
+      <CrashReportFallback value={value} />
+    );
+  },
+  href({ value }) {
+    return typeof value === 'string' ? (
+      <pre>{decodeURI(value)}</pre>
+    ) : (
+      <CrashReportFallback value={value} />
+    );
+  },
+  pageHtml({ value }) {
+    return typeof value === 'string' ? (
+      <div className="h-[70vh] resize overflow-hidden">
+        <ErrorIframe>{value}</ErrorIframe>
+      </div>
+    ) : (
+      <CrashReportFallback value={value} />
+    );
+  },
+  schema: GenericObject,
+  remotePrefs: GenericObject,
+  userInformation: GenericObject,
+  localStorage: GenericObject,
+  eventLog({ value }) {
+    return typeof value === 'object' && Array.isArray(value) ? (
+      <div className="flex flex-col gap-2">
+        {value.map((value, index) => (
+          <EventLine key={index} value={value} />
+        ))}
+      </div>
+    ) : (
+      <CrashReportFallback value={value} />
+    );
+  },
+  navigator: GenericObject,
+};
+
+function GenericObject({
+  value,
+  expanded = true,
+}: {
+  readonly value: unknown;
+  readonly expanded?: boolean;
+}): JSX.Element {
+  return typeof value === 'object' ? (
+    <div className="pl-4">
+      <CrashReportLines expanded={expanded} parsed={value as IR<unknown>} />
+    </div>
+  ) : (
+    <CrashReportFallback value={value} />
+  );
+}
+
+const gray = 'bg-gray-100 text-gray-800 dark:bg-gray-800 dark:text-gray-100';
+const colorMapper = {
+  error: 'bg-red-100 text-red-800 dark:bg-red-800 dark:text-red-100',
+  warn: 'bg-yellow-100 text-yellow-800 dark:bg-yellow-800 dark:text-yellow-100',
+  info: 'bg-blue-100 text-blue-800 dark:bg-blue-800 dark:text-blue-100',
+  group: gray,
+  groupCollapsed: gray,
+  groupEnd: gray,
+  log: gray,
+};
+
+function LogLine({ line }: { readonly line: IR<unknown> }): JSX.Element {
+  return (
+    <div
+      className={`
+        flex gap-2 p-1
+        ${colorMapper[line.type as 'info'] ?? colorMapper.info}
+      `}
+    >
+      <div className="flex-1">
+        {Array.isArray(line.message) ? (
+          <LogLineFormatted message={line.message} />
+        ) : (
+          <CrashReportFallback value={line.message} />
+        )}
+      </div>
+      {typeof line.date === 'string' && <DateElement date={line.date} />}
+    </div>
+  );
+}
+
+function LogLineFormatted({
+  message: rawMessage,
+}: {
+  readonly message: RA<unknown>;
+}): JSX.Element {
+  const message = rawMessage.filter(excludeFormatting);
+  return message.length === 1 ? (
+    <JsonifyChild value={message[0]} />
+  ) : (
+    <div>
+      <JsonifyChild value={message[0]} />
+      <details>
+        <summary>{developmentText.details()}</summary>
+        {message.slice(1).map((message, index) => (
+          <JsonifyChild key={index} value={message} />
+        ))}
+      </details>
+    </div>
+  );
+}
+
+/** Exclude values used to enable color output in the console */
+const excludeFormatting = (value: unknown): boolean =>
+  typeof value !== 'string' ||
+  (!value.startsWith('%c') && !value.startsWith('color: '));
+
+function JsonifyChild({ value }: { readonly value: unknown }): JSX.Element {
+  if (typeof value === 'string')
+    try {
+      const parsed = JSON.parse(value);
+      return <CrashReportFallback value={parsed} />;
+    } catch {}
+  return <CrashReportFallback value={value} />;
+}
+
+function EventLine({ value }: { readonly value: unknown }): JSX.Element {
+  if (typeof value === 'object') {
+    const { name, ...rest } = value as IR<unknown> & { readonly name: string };
+    const newValue = { href: name, moreInformation: rest };
+    return <GenericObject value={newValue} expanded={false} />;
+  } else return <CrashReportFallback value={value} />;
+}
+
+export function CrashReportFallback({
+  value,
+}: {
+  readonly value: unknown;
+}): JSX.Element {
+  return (
+    <pre>
+      {typeof value === 'string' ? value : JSON.stringify(value, null, 2)}
+    </pre>
+  );
+}

--- a/specifyweb/frontend/js_src/lib/components/Developer/CrashReportVisualizer.tsx
+++ b/specifyweb/frontend/js_src/lib/components/Developer/CrashReportVisualizer.tsx
@@ -1,0 +1,127 @@
+import React from 'react';
+
+import { developmentText } from '../../localization/development';
+import { f } from '../../utils/functools';
+import type { IR } from '../../utils/types';
+import { camelToHuman } from '../../utils/utils';
+import { Container, H2 } from '../Atoms';
+import { Button } from '../Atoms/Button';
+import { LoadingContext } from '../Core/Contexts';
+import { downloadFile, FilePicker, fileToText } from '../Molecules/FilePicker';
+import { CrashReportFallback, crashReportMapper } from './CrashReportMapper';
+
+export function CrashReportVisualizer(): JSX.Element {
+  const [fileName, setFileName] = React.useState<string>('');
+  const [file, setFile] = React.useState<string | undefined>(undefined);
+
+  const loading = React.useContext(LoadingContext);
+  return (
+    <Container.Full>
+      <div className="flex items-center gap-2">
+        <H2>{developmentText.crashReportVisualizer()}</H2>
+        <span className="-ml-2 flex-1" />
+        {typeof file === 'string' && (
+          <Button.Blue
+            onClick={(): void =>
+              loading(
+                downloadFile(
+                  `${fileName || 'Crash Report'}.html`,
+                  document.documentElement.outerHTML
+                )
+              )
+            }
+          >
+            {developmentText.downloadAsHtml()}
+          </Button.Blue>
+        )}
+      </div>
+      {file === undefined ? (
+        <FilePicker
+          acceptedFormats={['txt', 'json']}
+          onSelected={(file): void => {
+            setFileName(file.name);
+            loading(fileToText(file, 'utf8').then(setFile));
+          }}
+        />
+      ) : (
+        <JsonParser string={file} />
+      )}
+    </Container.Full>
+  );
+}
+
+function JsonParser({ string }: { readonly string: string }): JSX.Element {
+  const parsed = React.useMemo(() => {
+    try {
+      return JSON.parse(string) as unknown;
+    } catch (error) {
+      return (error as Error).toString();
+    }
+  }, [string]);
+
+  return typeof parsed === 'object' && parsed !== null ? (
+    <>
+      {/* This allows to get back the JSON version of the crash report */}
+      <noscript>{string}</noscript>
+      <CrashReportLines parsed={parsed as IR<unknown>} />
+    </>
+  ) : (
+    <CrashReportFallback value={parsed} />
+  );
+}
+
+export function CrashReportLines({
+  parsed,
+  expanded = false,
+}: {
+  readonly parsed: IR<unknown>;
+  readonly expanded?: boolean;
+}): JSX.Element {
+  return (
+    <div className="flex flex-col gap-2">
+      {Object.entries(parsed).map(([key, value]) => (
+        <Line expanded={expanded} key={key} name={key} value={value} />
+      ))}
+    </div>
+  );
+}
+
+const nameMapper = {
+  href: 'URL',
+  userAgent: 'Browser and Operating System',
+  navigator: 'Environment',
+};
+
+const mainSections = new Set([
+  'message',
+  'href',
+  'errorContext',
+  'pageHtml',
+  'consoleLog',
+  'navigator',
+]);
+
+const reSimpleName = /\w+/u;
+
+function Line({
+  name,
+  value,
+  expanded,
+}: {
+  readonly name: string;
+  readonly value: unknown;
+  readonly expanded: boolean;
+}): JSX.Element {
+  const Element = crashReportMapper[name] ?? CrashReportFallback;
+  return (
+    <details open={expanded || f.has(mainSections, name)}>
+      <summary>
+        {nameMapper[name as 'href'] ??
+          (reSimpleName.test(name) ? camelToHuman(name) : name)}
+      </summary>
+      <div className="flex flex-col gap-2">
+        <Element value={value} />
+      </div>
+    </details>
+  );
+}

--- a/specifyweb/frontend/js_src/lib/components/Errors/FormatError.tsx
+++ b/specifyweb/frontend/js_src/lib/components/Errors/FormatError.tsx
@@ -197,7 +197,7 @@ export function handleAjaxError(
 }
 
 /** Create an iframe from HTML string */
-function ErrorIframe({
+export function ErrorIframe({
   children: error,
 }: {
   readonly children: string;
@@ -214,7 +214,7 @@ function ErrorIframe({
 
   return (
     <iframe
-      className="h-full"
+      className="h-full w-full"
       ref={iframeRef}
       title={mainText.errorOccurred()}
     />

--- a/specifyweb/frontend/js_src/lib/components/Errors/FormatError.tsx
+++ b/specifyweb/frontend/js_src/lib/components/Errors/FormatError.tsx
@@ -205,11 +205,7 @@ export function ErrorIframe({
   const iframeRef = React.useRef<HTMLIFrameElement | null>(null);
   React.useEffect(() => {
     if (iframeRef.current === null) return;
-    const iframeDocument =
-      iframeRef.current.contentDocument ??
-      iframeRef.current.contentWindow?.document;
-    if (iframeDocument === undefined) return;
-    iframeDocument.body.innerHTML = error;
+    iframeRef.current.srcdoc = error;
   }, [error]);
 
   return (

--- a/specifyweb/frontend/js_src/lib/components/Router/Routes.tsx
+++ b/specifyweb/frontend/js_src/lib/components/Router/Routes.tsx
@@ -12,6 +12,7 @@ import { headerText } from '../../localization/header';
 import { userText } from '../../localization/user';
 import { preferencesText } from '../../localization/preferences';
 import { attachmentsText } from '../../localization/attachments';
+import { developmentText } from '../../localization/development';
 
 // FEATURE: go over non-dynamic routes in all routers to make sure they have titles
 /* eslint-disable @typescript-eslint/promise-function-async */
@@ -397,6 +398,19 @@ export const routes: RA<EnhancedRoute> = [
         element: () =>
           import('../RouterCommands/CacheBuster').then(
             ({ CacheBuster }) => CacheBuster
+          ),
+      },
+    ],
+  },
+  {
+    path: 'developer',
+    children: [
+      {
+        path: 'crash-report-visualizer',
+        title: developmentText.crashReportVisualizer(),
+        element: () =>
+          import('../Developer/CrashReportVisualizer').then(
+            ({ CrashReportVisualizer }) => CrashReportVisualizer
           ),
       },
     ],

--- a/specifyweb/frontend/js_src/lib/localization/development.ts
+++ b/specifyweb/frontend/js_src/lib/localization/development.ts
@@ -1,0 +1,22 @@
+/**
+ * Strings used by developer tools and error messages. Low priority for
+ * localization
+ *
+ * @module
+ */
+
+import { createDictionary } from './utils';
+
+// Refer to "Guidelines for Programmers" in ./README.md before editing this file
+
+export const developmentText = createDictionary({
+  crashReportVisualizer: {
+    'en-us': 'Crash Report Visualizer',
+  },
+  downloadAsHtml: {
+    'en-us': 'Download as HTML',
+  },
+  details: {
+    'en-us': 'Details',
+  },
+} as const);


### PR DESCRIPTION
Fixes #2183

It will be available with each specify instance at the following URL: `/specify/developer/crash-report-visualizer`. It's loaded dynamically so including it in production instances does not pose a performance problem.
I decided to include it in Specify 7 rather than develop it separately as it allowed me to piggy back on Specify's front-end infrastructure and thus speed up the development by a lot (took just 2 hours to do this)

Features:
- Visualizes the HTML snapshot of Specify 7 at the moment of the crash. The preview is resizable.
- Can download the visualized crash report as an HTML page to be shared with someone else. The downloaded HTML page works offline and with no JavaScript. The downloaded HTML page also includes the original JSON crash report as a hidden `<noscript>` element in case you ever need to get back the original crash report. The only problem seems to be that the downloaded HTML page does not display the HTML snapshot and does not remember which sections were collapsed/expanded. If it's a big deal, can be fixed in the future. Didn't want to spend too much time on this as don't know how useful the feature would be.
- Labels in the crash report are automatically converted to a more human-friendly form.
- Crash report visualizer can handle any kind of JSON crash report (even if it came from an older or newer version of Specify or contains unknown keys or was edited by hand - as long as it's a valid JSON document)