### PR TITLE
Fix Weblate's "fuzzy" flags getting lost

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -136,11 +136,6 @@ jobs:
           npm run typecheck && \
           npm run unitTests -- --maxWorkers ${{ steps.cpu-cores.outputs.count }}
 
-      - name: Localization Tests
-        working-directory: specifyweb/frontend/js_src
-        run: |
-          npm run localizationTests -- --emit ./localization-strings
-
       - name: Clone branch that stores localization strings
         # Listen for changes to production branch
         if: github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
@@ -151,14 +146,15 @@ jobs:
           ref: weblate-localization
           fetch-depth: 0
 
+      - name: Localization Tests
+        working-directory: specifyweb/frontend/js_src
+        run: |
+          npm run localizationTests -- --emit ../../../../weblate-localization/strings
+
       - name: Sync localization strings with Weblate (only on production branch)
-        # Only run this step if previous step was not skipped
-        if: steps.weblate.outcome == 'success'
+        if: github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
         working-directory: weblate-localization
         run: |
-          # Replace old localization strings
-          rm -rf strings
-          mv -f ../specifyweb/frontend/js_src/localization-strings strings
           git add strings
 
           if git diff-index --quiet HEAD --; then
@@ -176,6 +172,7 @@ jobs:
           fi
 
       - name: Make sure Weblate settings are up to date
+        # Only run this step if previous step was not skipped
         if: steps.weblate.outcome == 'success'
         working-directory: specifyweb/frontend/js_src
         env:

--- a/specifyweb/frontend/js_src/lib/localization/utils/validateWeblate.ts
+++ b/specifyweb/frontend/js_src/lib/localization/utils/validateWeblate.ts
@@ -58,8 +58,16 @@ export async function checkComponents(
     (name) => !localComponents.includes(name)
   );
   unusedComponents.forEach((name) =>
+    /*
+     * Maybe there is a better way to handle this, but for now this forces
+     * developer's intervention to manually resolve the issue.
+     * I.e, delete the old component from Weblate, or fix the naming
+     * inconsistency
+     */
     error(
-      `Found a project ${name} in the remote, but it's not present on the current branch`
+      `Found a project "${name}" in Weblate, but it's not present on ` +
+        `the current branch. If you intentionally removed it, make sure to also ` +
+        `remove it from Weblate.`
     )
   );
 
@@ -72,6 +80,12 @@ export async function checkComponents(
 const createMissingComponents = async (names: RA<string>): Promise<void> =>
   Promise.all(names.map(async (name) => createComponent(name))).then(f.void);
 
+/**
+ * Note, if this fails with "File not found error", it means the *.po file for
+ * a given component is not on the weblate-localization branch. The test.yml
+ * GitHub action on production branch is responsible for creating the *.po
+ * file.
+ */
 async function createComponent(name: string): Promise<void> {
   warn(`Creating a component for "${name}"`);
   const { addons, ...settings } = getComponentSettings(name);
@@ -119,6 +133,7 @@ const getComponentSettings = (name: string): IR<unknown> => ({
   license_url: 'https://spdx.org/licenses/GPL-2.0-only.html',
   merge_style: 'rebase',
   name,
+  new_lang: 'url',
   push_branch: weblateBranch,
   push_on_commit: true,
   repo: 'https://github.com/specify/specify7/',


### PR DESCRIPTION
Strings in Weblate can be marked as "Fuzzy". This means they require editing.

However, exporting strings from Specify 7 to Weblate seems to lose (and even override) this information.

This pull requests fixes that.