### PR TITLE
Add one more link to Discourse localization post

### DIFF
--- a/specifyweb/frontend/js_src/lib/components/Toolbar/Language.tsx
+++ b/specifyweb/frontend/js_src/lib/components/Toolbar/Language.tsx
@@ -28,7 +28,6 @@ import { Button } from '../Atoms/Button';
 import { Select } from '../Atoms/Form';
 import { Link } from '../Atoms/Link';
 import { fail } from '../Errors/Crash';
-import { supportLink } from '../Errors/ErrorDialog';
 import { cachableUrl } from '../InitialContext';
 import { Dialog, dialogClassNames } from '../Molecules/Dialog';
 import { formatUrl } from '../Router/queryString';
@@ -90,7 +89,11 @@ export function LanguageSelection<LANGUAGES extends string>({
           <p>
             <StringToJsx
               components={{
-                emailLink: supportLink,
+                link: (label) => (
+                  <Link.NewTab href="https://discourse.specifysoftware.org/t/get-started-with-specify-7-localization/956">
+                    {label}
+                  </Link.NewTab>
+                ),
               }}
               string={headerText.helpLocalizeSpecifyDescription()}
             />
@@ -112,6 +115,9 @@ export function LanguageSelection<LANGUAGES extends string>({
               </Button.Blue>
             </>
           }
+          className={{
+            container: dialogClassNames.narrowContainer,
+          }}
           header={headerText.incompleteLocalization()}
           onClose={(): void => setWarningLanguage(undefined)}
         >

--- a/specifyweb/frontend/js_src/lib/localization/header.ts
+++ b/specifyweb/frontend/js_src/lib/localization/header.ts
@@ -217,27 +217,27 @@ export const headerText = createDictionary({
   helpLocalizeSpecifyDescription: {
     'en-us': `
       We would be very grateful for your support localizing Specify 7 User
-      Interface. If you are interested, please send an email to <emailLink />
+      Interface. If you are interested, please <link>see the instructions</link>.
     `,
     'ru-ru': `
       Мы будем очень признательны за вашу поддержку в локализации
       пользовательского интерфейса Specify 7. Если вы заинтересованы, отправьте
-      электронное письмо по адресу <emailLink />
+      электронное письмо по адресу <link>см. Инструкции</link>.
     `,
     'es-es': `
       Estaríamos muy agradecidos por su apoyo para localizar la interfaz de
       usuario de Specific 7. Si está interesado, envíe un correo electrónico a
-      <emailLink />
+      <link>ver las instrucciones</link>.
     `,
     'fr-fr': `
       Nous vous serions très reconnaissants de votre aide pour la localisation
       de l'interface utilisateur Spécifiez 7. Si vous êtes intéressé, veuillez
-      envoyer un e-mail à <emailLink />
+      envoyer un e-mail à <link>voir les instructions</link>.
     `,
     'uk-ua': `
       Ми будемо дуже вдячні за вашу підтримку в локалізації інтерфейсу
       користувача Specify 7. Якщо ви зацікавлені, надішліть електронний лист на
-      адресу <emailLink />
+      адресу <link>див. Інструкції</link>.
     `,
   },
   incompleteInline: {


### PR DESCRIPTION
The link was there when picking a language that is not yet finished.

This commit also updates the "Help Localize Specify 7" dialog message to add a link to Discourse post regarding localization