### PR TITLE
Improve WB import date parsing

### DIFF
--- a/specifyweb/frontend/js_src/lib/components/FormPlugins/PartialDateUi.tsx
+++ b/specifyweb/frontend/js_src/lib/components/FormPlugins/PartialDateUi.tsx
@@ -1,10 +1,6 @@
 import React from 'react';
 
-import {
-  databaseDateFormat,
-  fullDateFormat,
-  monthFormat,
-} from '../../utils/dateFormat';
+import { fullDateFormat, monthFormat } from '../../utils/parser/dateFormat';
 import { dayjs, getDateInputValue } from '../../utils/dayJs';
 import { f } from '../../utils/functools';
 import type { SpecifyResource } from '../DataModel/legacyTypes';
@@ -23,6 +19,7 @@ import { useSaveBlockers } from '../../hooks/resource';
 import { useValidation } from '../../hooks/useValidation';
 import { AnySchema } from '../DataModel/helperTypes';
 import { usePref } from '../UserPreferences/usePref';
+import { databaseDateFormat } from '../../utils/parser/dateConfig';
 
 export function isInputSupported(type: string): boolean {
   const input = document.createElement('input');

--- a/specifyweb/frontend/js_src/lib/components/InitialContext/remotePrefs.ts
+++ b/specifyweb/frontend/js_src/lib/components/InitialContext/remotePrefs.ts
@@ -11,6 +11,7 @@ import type { IR, R, RA } from '../../utils/types';
 import { defined } from '../../utils/types';
 import type { JavaType } from '../DataModel/specifyField';
 import { cachableUrl, contextUnlockedPromise } from './index';
+import { databaseDateFormat } from '../../utils/parser/dateConfig';
 
 const preferences: R<string> = {};
 
@@ -115,7 +116,7 @@ export const remotePrefsDefinitions = f.store(
     ({
       'ui.formatting.scrdateformat': {
         description: 'Full Date format',
-        defaultValue: 'YYYY-MM-DD',
+        defaultValue: databaseDateFormat,
         formatters: [formatter.trim, formatter.toUpperCase],
         // Indicates that this remote pref is shared with Specify 6
         isLegacy: true,

--- a/specifyweb/frontend/js_src/lib/components/WbImport/helpers.ts
+++ b/specifyweb/frontend/js_src/lib/components/WbImport/helpers.ts
@@ -17,6 +17,8 @@ import { fileToText } from '../Molecules/FilePicker';
 import { uniquifyHeaders } from '../WbPlanView/headerHelper';
 import type { Dataset } from '../WbPlanView/Wrapped';
 import { getField } from '../DataModel/helpers';
+import { fullDateFormat } from '../../utils/parser/dateFormat';
+import { databaseDateFormat } from '../../utils/parser/dateConfig';
 
 /** Remove the extension from the file name */
 export const extractFileName = (fileName: string): string =>
@@ -125,7 +127,9 @@ export const parseXls = async (
 ): Promise<RA<RA<string>>> =>
   new Promise((resolve, reject) => {
     const worker = new ImportXLSWorker();
-    worker.postMessage({ file, previewSize: limit });
+    const dateFormat =
+      fullDateFormat() === databaseDateFormat ? undefined : fullDateFormat();
+    worker.postMessage({ file, previewSize: limit, dateFormat });
     worker.addEventListener('message', ({ data }) => {
       const rows = data as RA<RA<string>>;
       if (rows.length === 0 || rows[0].length === 0)

--- a/specifyweb/frontend/js_src/lib/components/WbImport/xls.worker.ts
+++ b/specifyweb/frontend/js_src/lib/components/WbImport/xls.worker.ts
@@ -4,14 +4,16 @@
  * @module
  */
 
-import { type ParsingOptions, read, utils } from 'xlsx';
+import { read, utils } from 'xlsx';
 
 import type { RA } from '../../utils/types';
+import dayjs from 'dayjs';
 
 const context: Worker = self as any;
 
 context.onmessage = function (e) {
   const previewSize: number | null = e.data.previewSize;
+  const dateFormat: number | undefined = e.data.dateFormat;
 
   const reader = new FileReader();
   reader.readAsArrayBuffer(e.data.file);
@@ -25,30 +27,36 @@ context.onmessage = function (e) {
     }
     const fileData = new Uint8Array(loaded.target.result);
 
-    const options: ParsingOptions = {
+    const workbook = read(fileData, {
       type: 'array',
       raw: true,
+      cellDates: true,
       sheetRows: previewSize != null ? previewSize : 0,
-    };
-    const workbook = read(fileData, options);
+    });
 
     const firstSheetName = workbook.SheetNames[0];
     const firstWorkBook = workbook.Sheets[firstSheetName];
     const sheetData = utils.sheet_to_json(firstWorkBook, {
       header: 1,
       blankrows: false,
-      raw: false,
+      raw: true,
     });
 
-    const maxMidth = Math.max(
+    const maxWidth = Math.max(
       ...sheetData.map((row) => (row as RA<string>).length)
     );
 
     const data: RA<RA<string>> = sheetData.map((row) => {
-      const unSparseRow = Array.from(row as RA<string>, (v) => v || '');
-      if (unSparseRow.length < maxMidth) {
+      const unSparseRow = Array.from(row as RA<string | Date>, (value) => {
+        if (typeof value === 'object') {
+          if (typeof dateFormat === 'string')
+            return dayjs(value).format(dateFormat);
+          else return value.toLocaleDateString();
+        } else return value || '';
+      });
+      if (unSparseRow.length < maxWidth) {
         unSparseRow.push(
-          ...Array.from({ length: maxMidth - unSparseRow.length }).fill('')
+          ...Array.from({ length: maxWidth - unSparseRow.length }).fill('')
         );
       }
       return unSparseRow;

--- a/specifyweb/frontend/js_src/lib/utils/parser/__tests__/parse.test.ts
+++ b/specifyweb/frontend/js_src/lib/utils/parser/__tests__/parse.test.ts
@@ -5,7 +5,7 @@ import type { Parser } from '../definitions';
 import { resolveParser } from '../definitions';
 import type { InvalidParseResult, ValidParseResult } from '../parse';
 import { parseValue } from '../parse';
-import { fullDateFormat } from '../../dateFormat';
+import { fullDateFormat } from '../dateFormat';
 
 requireContext();
 

--- a/specifyweb/frontend/js_src/lib/utils/parser/dateConfig.ts
+++ b/specifyweb/frontend/js_src/lib/utils/parser/dateConfig.ts
@@ -1,0 +1,1 @@
+export const databaseDateFormat = 'YYYY-MM-DD';

--- a/specifyweb/frontend/js_src/lib/utils/parser/dateFormat.ts
+++ b/specifyweb/frontend/js_src/lib/utils/parser/dateFormat.ts
@@ -2,9 +2,8 @@
  * Read the preferred date format from remote prefs
  */
 
-import { getPref } from '../components/InitialContext/remotePrefs';
+import { getPref } from '../../components/InitialContext/remotePrefs';
 
-export const databaseDateFormat = 'YYYY-MM-DD';
 export const fullDateFormat = (): string =>
   getPref('ui.formatting.scrdateformat');
 

--- a/specifyweb/frontend/js_src/lib/utils/parser/definitions.ts
+++ b/specifyweb/frontend/js_src/lib/utils/parser/definitions.ts
@@ -15,13 +15,14 @@ import { monthsPickList } from '../../components/PickLists/definitions';
 import { commonText } from '../../localization/common';
 import { formsText } from '../../localization/forms';
 import { queryText } from '../../localization/query';
-import { databaseDateFormat, fullDateFormat } from '../dateFormat';
+import { fullDateFormat } from './dateFormat';
 import { dayjs } from '../dayJs';
 import { f } from '../functools';
 import { parseRelativeDate } from '../relativeDate';
 import type { IR, RA, RR } from '../types';
 import { filterArray } from '../types';
 import { getUserPref } from '../../components/UserPreferences/helpers';
+import { databaseDateFormat } from './dateConfig';
 
 /** Makes sure a wrapped function would receive a string value */
 export const stringGuard =


### PR DESCRIPTION
When importing a spreadsheet though WorkBench, date formats like `10/10/20` are now resolved into the format configured in remote prefs (using the `ui.formatting.scrdateformat` property)

Fixes #2027

Spreadsheet I used for testing: 
[date.format.testing (1).xlsx](https://github.com/specify/specify7/files/10467749/date.format.testing.1.xlsx)
(this is an extended version of the one sent by @danb213)


More information on the date & time parsing in the library we are using: https://docs.sheetjs.com/docs/csf/features/dates/