### PR TITLE
Make WorkBench tables appear as WB instead of Wor

### DIFF
--- a/specifyweb/frontend/js_src/lib/components/Molecules/SvgIcon.tsx
+++ b/specifyweb/frontend/js_src/lib/components/Molecules/SvgIcon.tsx
@@ -151,6 +151,7 @@ const endsWith = <T,>(
 
 const nameMapper = f.store<Partial<RR<keyof Tables, string>>>(() => ({
   ...startsWith('Accession', 'Acc'),
+  ...startsWith('Workbench', 'WB'),
   ...startsWith('Attachment', 'Att'),
   ...startsWith('Disposal', 'Dsp'),
   ...startsWith('CollectingEventAttr', 'CeA'),


### PR DESCRIPTION
Not a fan of pushing to production. 