### PR TITLE
Do not trigger unload protect if value did not change

### DIFF
--- a/specifyweb/frontend/js_src/lib/components/DataModel/resourceApi.js
+++ b/specifyweb/frontend/js_src/lib/components/DataModel/resourceApi.js
@@ -218,7 +218,8 @@ function eventHandlerForToOne(related, field) {
               typeof (oldValue??'') !== 'object' &&
               typeof (newValue??'') !== 'object'
             ) {
-                if(
+                if (oldValue === newValue) return this;
+                else if(
                   /*
                    * Don't trigger unload protect if:
                    *  - value didn't change


### PR DESCRIPTION
Fixes #2868

A value should only be added to a Resource's attributes (the values sent to the backend) if it was changed. A bug in https://github.com/specify/specify7/commit/9e7e3cec2c8c5797915a0112b105e9bb303484f9 caused many more fields on all forms to register as 'changed' even if they have not, causing #2868. 

See https://github.com/specify/specify7/issues/2868#issuecomment-1401287927 for an example of how unchanged values were being added objects' responses. 