### PR TITLE
Improve WorkBench's "Disambiguate All" performance

### DIFF
--- a/specifyweb/frontend/js_src/lib/components/WorkBench/wbView.js
+++ b/specifyweb/frontend/js_src/lib/components/WorkBench/wbView.js
@@ -12,17 +12,44 @@
 
 import '../../../css/workbench.css';
 
+import Handsontable from 'handsontable';
 import $ from 'jquery';
 import React from 'react';
 import _ from 'underscore';
-import {Backbone} from '../DataModel/backbone';
-import Handsontable from 'handsontable';
 
-import {Button} from '../Atoms/Button';
-import {Link} from '../Atoms/Link';
-import {getModel, schema, strictGetModel} from '../DataModel/schema';
-import {DataSetNameView} from './DataSetMeta';
-import {WBUtils} from './wbUtils';
+import { backEndText } from '../../localization/backEnd';
+import { commonText } from '../../localization/common';
+import { whitespaceSensitive } from '../../localization/utils';
+import { LANGUAGE } from '../../localization/utils/config';
+import { wbPlanText } from '../../localization/wbPlan';
+import { wbText } from '../../localization/workbench';
+import { ajax } from '../../utils/ajax';
+import { Http } from '../../utils/ajax/definitions';
+import { ping } from '../../utils/ajax/ping';
+import { getCache, setCache } from '../../utils/cache';
+import { f } from '../../utils/functools';
+import { filterArray } from '../../utils/types';
+import { capitalize, clamp, mappedFind } from '../../utils/utils';
+import { Button } from '../Atoms/Button';
+import { iconClassName, legacyNonJsxIcons } from '../Atoms/Icons';
+import { Link } from '../Atoms/Link';
+import { legacyLoadingContext } from '../Core/Contexts';
+import { Backbone } from '../DataModel/backbone';
+import { serializeResource } from '../DataModel/helpers';
+import { getModel, schema, strictGetModel } from '../DataModel/schema';
+import { crash, raise } from '../Errors/Crash';
+import { getIcon, unknownIcon } from '../InitialContext/icons';
+import { strictGetTreeDefinitionItems } from '../InitialContext/treeRanks';
+import { loadingBar } from '../Molecules';
+import { Dialog } from '../Molecules/Dialog';
+import {
+  hasPermission,
+  hasTablePermission,
+  hasTreeAccess,
+} from '../Permissions/helpers';
+import { fetchPickList } from '../PickLists/fetch';
+import { getUserPref } from '../UserPreferences/helpers';
+import { pathStartsWith } from '../WbPlanView/helpers';
 import {
   formatToManyIndex,
   formatTreeRank,
@@ -30,47 +57,20 @@ import {
   mappingPathToString,
   valueIsTreeRank,
 } from '../WbPlanView/mappingHelpers';
-import {parseUploadPlan} from '../WbPlanView/uploadPlanParser';
-import {capitalize, clamp, mappedFind} from '../../utils/utils';
-import {getTableFromMappingPath} from '../WbPlanView/navigator';
-import {getIcon, unknownIcon} from '../InitialContext/icons';
-import {wbText} from '../../localization/workbench';
-import {commonText} from '../../localization/common';
-import {Dialog} from '../Molecules/Dialog';
-import {iconClassName, legacyNonJsxIcons} from '../Atoms/Icons';
-import {whitespaceSensitive} from '../../localization/utils';
-import {filterArray} from '../../utils/types';
-import {strictGetTreeDefinitionItems} from '../InitialContext/treeRanks';
-import {serializeResource} from '../DataModel/helpers';
-import {fetchPickList} from '../PickLists/fetch';
-import {ajax} from '../../utils/ajax';
-import {ping} from '../../utils/ajax/ping';
-import {
-  hasPermission,
-  hasTablePermission,
-  hasTreeAccess,
-} from '../Permissions/helpers';
-import {wbViewTemplate} from './Template';
-import {legacyLoadingContext} from '../Core/Contexts';
-import {getCache, setCache} from '../../utils/cache';
-import {f} from '../../utils/functools';
-import {pathStartsWith} from '../WbPlanView/helpers';
-import {getUserPref} from '../UserPreferences/helpers';
-import {WbStatus} from './Status';
-import {crash, raise} from '../Errors/Crash';
-import {loadingBar} from '../Molecules';
-import {Http} from '../../utils/ajax/definitions';
-import {downloadDataSet} from './helpers';
-import {CreateRecordSetButton} from './RecordSet';
-import {WbUploaded} from './Results';
-import {getSelectedLast, getSelectedRegions} from './hotHelpers';
-import {DevShowPlan} from './DevShowPlan';
-import {RollbackConfirmation} from './Components';
-import {DisambiguationDialog} from './Disambiguation';
-import {LANGUAGE} from '../../localization/utils/config';
-import {resolveValidationMessage} from './resultsParser';
-import {backEndText} from '../../localization/backEnd';
-import {wbPlanText} from '../../localization/wbPlan';
+import { getTableFromMappingPath } from '../WbPlanView/navigator';
+import { parseUploadPlan } from '../WbPlanView/uploadPlanParser';
+import { RollbackConfirmation } from './Components';
+import { DataSetNameView } from './DataSetMeta';
+import { DevShowPlan } from './DevShowPlan';
+import { DisambiguationDialog } from './Disambiguation';
+import { downloadDataSet } from './helpers';
+import { getSelectedLast, getSelectedRegions } from './hotHelpers';
+import { CreateRecordSetButton } from './RecordSet';
+import { WbUploaded } from './Results';
+import { resolveValidationMessage } from './resultsParser';
+import { WbStatus } from './Status';
+import { wbViewTemplate } from './Template';
+import { WBUtils } from './wbUtils';
 
 const metaKeys = [
   'isNew',
@@ -258,8 +258,6 @@ export const WBView = Backbone.View.extend({
             ) {
               const dialog = this.options.display(
                 <Dialog
-                  header={wbPlanText.noUploadPlan()}
-                  onClose={() => dialog()}
                   buttons={
                     <>
                       <Button.DialogClose>
@@ -272,6 +270,8 @@ export const WBView = Backbone.View.extend({
                       </Link.Blue>
                     </>
                   }
+                  header={wbPlanText.noUploadPlan()}
+                  onClose={() => dialog()}
                 >
                   {wbPlanText.noUploadPlanDescription()}
                 </Dialog>
@@ -458,7 +458,7 @@ export const WBView = Backbone.View.extend({
                     isCommand: false,
                     renderer: (_hot, wrapper) => {
                       const { endRow: visualRow, endCol: visualCol } =
-                        getSelectedRegions(this.hot).slice(-1)[0];
+                        getSelectedRegions(this.hot).at(-1);
                       const physicalRow = this.hot.toPhysicalRow(visualRow);
                       const physicalCol = this.hot.toPhysicalColumn(visualCol);
 
@@ -692,7 +692,7 @@ export const WBView = Backbone.View.extend({
       this.mappings.tableNames
         .map((tableName, index) => ({
           tableName,
-          fieldName: this.mappings.lines[index].mappingPath.slice(-1)[0],
+          fieldName: this.mappings.lines[index].mappingPath.at(-1),
           headerName: this.mappings.lines[index].headerName,
         }))
         .map(async ({ tableName, fieldName, headerName }) => {
@@ -749,14 +749,14 @@ export const WBView = Backbone.View.extend({
         }))
         .filter(
           ({ mappingPath, index }) =>
-            valueIsTreeRank(mappingPath.slice(-2)[0]) &&
-            mappingPath.slice(-1)[0] === 'name' &&
+            valueIsTreeRank(mappingPath.at(-2)) &&
+            mappingPath.at(-1) === 'name' &&
             hasTreeAccess(this.mappings.tableNames[index], 'read')
         )
         .map(({ mappingPath, headerName, index }) => ({
           mappingGroup: mappingPathToString(mappingPath.slice(0, -2)),
           tableName: this.mappings.tableNames[index],
-          rankName: getNameFromTreeRankName(mappingPath.slice(-2)[0]),
+          rankName: getNameFromTreeRankName(mappingPath.at(-2)),
           physicalCol: this.dataset.columns.indexOf(headerName),
         }))
         .map(({ mappingGroup, tableName, rankName, physicalCol }) => ({
@@ -794,7 +794,8 @@ export const WBView = Backbone.View.extend({
    * .issues are handled automatically by the comments plugin.
    * This is why, afterRenderer only has to handle the isModified and isNew
    * cases
-   * */
+   *
+   */
   afterRenderer(td, visualRow, visualCol, property, _value) {
     if (this.hot === undefined) {
       td.classList.add('text-gray-500');
@@ -931,7 +932,8 @@ export const WBView = Backbone.View.extend({
    *
    * This logic wasn't be put into beforePaste because it receives
    * arguments that are inconvenient to work with
-   * */
+   *
+   */
   beforeChange(unfilteredChanges, source) {
     if (source !== 'CopyPaste.paste') return true;
 
@@ -979,7 +981,8 @@ export const WBView = Backbone.View.extend({
           /*
            * Ignore cases where value didn't change
            * (happens when double click a cell and then click on another cell)
-           * */
+           *
+           */
           oldValue !== newValue &&
           // Or where value changed from null to empty
           (oldValue !== null || newValue !== '') &&
@@ -1248,14 +1251,15 @@ export const WBView = Backbone.View.extend({
   },
   // Do not scroll the viewport to the last column after inserting a row
   afterPaste(data, coords) {
-    const lastCoords = coords.slice(-1)[0];
+    const lastCoords = coords.at(-1);
     if (data.some((row) => row.length === this.dataset.columns.length))
       this.hot.scrollViewportTo(lastCoords.endRow, lastCoords.startCol);
   },
   /*
    * Reposition the comment box if it is overflowing
    * See https://github.com/specify/specify7/issues/932
-   * */
+   *
+   */
   afterOnCellMouseOver(_event, coordinates, cell) {
     const physicalRow = this.hot.toPhysicalRow(coordinates.row);
     const physicalCol = this.hot.toPhysicalColumn(coordinates.col);
@@ -1568,8 +1572,8 @@ export const WBView = Backbone.View.extend({
       if (resources.length === 0) {
         const dialog = this.options.display(
           <Dialog
-            header={wbText.noDisambiguationResults()}
             buttons={commonText.close()}
+            header={wbText.noDisambiguationResults()}
             onClose={() => dialog()}
           >
             {wbText.noDisambiguationResultsDescription()}
@@ -1584,24 +1588,24 @@ export const WBView = Backbone.View.extend({
        * This is because we don't know all matches until validation is done
        */
       /*
-      let applyAllAvailable = true;
-      const applyAllButton = content.find('#applyAllButton');
-
-      const updateIt = () => {
-        const newState = this.liveValidationStack.length === 0;
-        if (newState !== applyAllAvailable) {
-          applyAllAvailable = newState;
-          applyAllButton.disabled = !newState;
-          applyAllButton[newState ? 'removeAttribute' : 'setAttribute'](
-            'title',
-            wbText.applyAllUnavailable()
-          );
-        }
-      };
-
-      const interval = globalThis.setInterval(updateIt, 100);
-      // onClose: globalThis.clearInterval(interval);
-      */
+       *Let applyAllAvailable = true;
+       *const applyAllButton = content.find('#applyAllButton');
+       *
+       *const updateIt = () => {
+       *  const newState = this.liveValidationStack.length === 0;
+       *  if (newState !== applyAllAvailable) {
+       *    applyAllAvailable = newState;
+       *    applyAllButton.disabled = !newState;
+       *    applyAllButton[newState ? 'removeAttribute' : 'setAttribute'](
+       *      'title',
+       *      wbText.applyAllUnavailable()
+       *    );
+       *  }
+       *};
+       *
+       *const interval = globalThis.setInterval(updateIt, 100);
+       * // onClose: globalThis.clearInterval(interval);
+       */
 
       const dialog = this.options.display(
         <DisambiguationDialog
@@ -1666,9 +1670,9 @@ export const WBView = Backbone.View.extend({
     if (this.liveValidationStack.length > 0) {
       const dialog = this.options.display(
         <Dialog
+          buttons={commonText.close()}
           header={commonText.results()}
           onClose={() => dialog()}
-          buttons={commonText.close()}
         >
           {wbText.unavailableWhileValidating()}
         </Dialog>
@@ -1806,10 +1810,10 @@ export const WBView = Backbone.View.extend({
     const container = document.createElement('div');
     this.uploadedView = this.options.display(
       <WbUploaded
-        recordCounts={this.uploadResults.recordCounts}
-        isUploaded={this.isUploaded}
         dataSetId={this.dataset.id}
         dataSetName={this.dataset.name}
+        isUploaded={this.isUploaded}
+        recordCounts={this.uploadResults.recordCounts}
         onClose={() => this.uploadedView()}
       />,
       container,
@@ -1828,11 +1832,11 @@ export const WBView = Backbone.View.extend({
       <DevShowPlan
         dataSetId={this.dataset.id}
         uploadPlan={this.dataset.uploadplan}
-        onClose={() => dialog()}
         onChanged={(plan) => {
           this.dataset.uploadplan = plan;
           this.trigger('refresh');
         }}
+        onClose={() => dialog()}
         onDeleted={this.options.onDeleted}
       />
     );
@@ -1841,8 +1845,10 @@ export const WBView = Backbone.View.extend({
     this.datasetmeta.changeOwner();
   },
 
-  // Actions
-  // aka Rollback
+  /*
+   * Actions
+   * aka Rollback
+   */
   unupload() {
     const dialog = this.options.display(
       <RollbackConfirmation
@@ -1861,8 +1867,6 @@ export const WBView = Backbone.View.extend({
       if (mode === 'upload') {
         const dialog = this.options.display(
           <Dialog
-            header={wbText.startUpload()}
-            onClose={() => dialog()}
             buttons={
               <>
                 <Button.DialogClose>{commonText.cancel()}</Button.DialogClose>
@@ -1876,6 +1880,8 @@ export const WBView = Backbone.View.extend({
                 </Button.Blue>
               </>
             }
+            header={wbText.startUpload()}
+            onClose={() => dialog()}
           >
             {wbText.startUploadDescription()}
           </Dialog>
@@ -1884,8 +1890,6 @@ export const WBView = Backbone.View.extend({
     } else {
       const dialog = this.options.display(
         <Dialog
-          header={wbPlanText.noUploadPlan()}
-          onClose={() => dialog()}
           buttons={
             <>
               <Button.DialogClose>{commonText.close()}</Button.DialogClose>
@@ -1894,6 +1898,8 @@ export const WBView = Backbone.View.extend({
               </Link.Blue>
             </>
           }
+          header={wbPlanText.noUploadPlan()}
+          onClose={() => dialog()}
         >
           {wbPlanText.noUploadPlanDescription()}
         </Dialog>
@@ -1955,8 +1961,6 @@ export const WBView = Backbone.View.extend({
   revertChanges() {
     const dialog = this.options.display(
       <Dialog
-        header={wbText.revertChanges()}
-        onClose={() => dialog()}
         buttons={
           <>
             <Button.DialogClose>{commonText.cancel()}</Button.DialogClose>
@@ -1965,6 +1969,8 @@ export const WBView = Backbone.View.extend({
             </Button.Red>
           </>
         }
+        header={wbText.revertChanges()}
+        onClose={() => dialog()}
       >
         {wbText.revertChangesDescription()}
       </Dialog>
@@ -1973,7 +1979,7 @@ export const WBView = Backbone.View.extend({
   saveClicked() {
     this.save();
   },
-  save() {
+  async save() {
     // Clear validation
     this.dataset.rowresults = null;
     this.stopLiveValidation();
@@ -1982,9 +1988,9 @@ export const WBView = Backbone.View.extend({
     // Show saving progress bar
     const dialog = this.options.display(
       <Dialog
+        buttons={undefined}
         header={wbText.saving()}
         onClose={() => dialog()}
-        buttons={undefined}
       >
         {loadingBar}
       </Dialog>
@@ -2023,7 +2029,7 @@ export const WBView = Backbone.View.extend({
     this.cellMeta = [];
 
     switch (this.validationMode) {
-      case 'live':
+      case 'live': {
         this.liveValidationStack = Array.from(
           { length: this.hot.countRows() },
           (_, visualRow) => this.hot.toPhysicalRow(visualRow)
@@ -2033,18 +2039,21 @@ export const WBView = Backbone.View.extend({
         this.wbutils.toggleCellTypes('invalidCells', 'remove');
         event.target.setAttribute('aria-pressed', true);
         break;
-      case 'static':
+      }
+      case 'static': {
         this.getValidationResults();
         this.wbutils.toggleCellTypes('invalidCells', 'remove');
         this.liveValidationStack = [];
         this.liveValidationActive = false;
         event.target.setAttribute('aria-pressed', false);
         break;
-      case 'off':
+      }
+      case 'off': {
         this.liveValidationStack = [];
         this.liveValidationActive = false;
         event.target.setAttribute('aria-pressed', false);
         break;
+      }
     }
 
     this.hot.render();
@@ -2129,7 +2138,7 @@ export const WBView = Backbone.View.extend({
   },
   resolveValidationColumns(initialColumns, inferColumnsCallback = undefined) {
     // See https://github.com/specify/specify7/issues/810
-    let columns = initialColumns.filter((column) => column);
+    let columns = initialColumns.filter(Boolean);
     if (typeof inferColumnsCallback === 'function' && columns.length === 0)
       columns = inferColumnsCallback();
     if (columns.length === 0) columns = this.dataset.columns;
@@ -2473,8 +2482,6 @@ export const WBView = Backbone.View.extend({
 
     const dialog = this.options.display(
       <Dialog
-        header={messages[this.refreshInitiatedBy].header}
-        onClose={() => dialog()}
         buttons={
           <>
             {cellCounts.invalidCells === 0 &&
@@ -2482,13 +2489,15 @@ export const WBView = Backbone.View.extend({
               <CreateRecordSetButton
                 dataSetId={this.dataset.id}
                 dataSetName={this.dataset.name}
-                onClose={() => dialog()}
                 small={false}
+                onClose={() => dialog()}
               />
             ) : undefined}
             <Button.DialogClose>{commonText.close()}</Button.DialogClose>
           </>
         }
+        header={messages[this.refreshInitiatedBy].header}
+        onClose={() => dialog()}
       >
         {messages[this.refreshInitiatedBy].message}
       </Dialog>
@@ -2502,6 +2511,7 @@ export const WBView = Backbone.View.extend({
 
     const dialog = this.options.display(
       <Dialog
+        buttons={commonText.close()}
         header={
           this.refreshInitiatedBy === 'validate'
             ? wbText.validationCanceled()
@@ -2510,7 +2520,6 @@ export const WBView = Backbone.View.extend({
             : wbText.uploadCanceled()
         }
         onClose={() => dialog()}
-        buttons={commonText.close()}
       >
         {this.refreshInitiatedBy === 'validate'
           ? wbText.validationCanceledDescription()


### PR DESCRIPTION
Clicking on "Apply All" in the disambiguation dialog in the WorkBench when there are ~1000+ ambiguities of that kind freezes the page for up to a minute.

This might fix it