### PR TITLE
Disable default form table ordering

### DIFF
--- a/specifyweb/frontend/js_src/lib/components/Forms/generateFormDefinition.ts
+++ b/specifyweb/frontend/js_src/lib/components/Forms/generateFormDefinition.ts
@@ -52,6 +52,7 @@ export function getFieldsForAutoView<SCHEMA extends AnySchema>(
   const filteredFields = baseFields.filter(
     (field) => !field.isHidden && !field.isReadOnly
   );
+  // BUG: if displayed as a dependent sub view, should hide relationship to parent
   const relationships = model.relationships
     .filter(
       (field) =>

--- a/specifyweb/specify/build_models.py
+++ b/specifyweb/specify/build_models.py
@@ -1,12 +1,13 @@
 from django.db import models
 
 from specifyweb.businessrules.exceptions import AbortSave
-
 from . import model_extras
-from .case_insensitive_bool import BooleanField, NullBooleanField
 
 appname = __name__.split('.')[-2]
 
+# REFACTOR: generate this on the fly based on presence of
+#    ordinal/ordernumber/position etc field in a table. This way it will
+#    automatically work for any newly added table
 orderings = {
     'Picklistitem': ('ordinal', ),
     'Recordsetitem': ('recordid', ),
@@ -14,6 +15,13 @@ orderings = {
     'Determination': ('-iscurrent',),
     'Author': ('ordernumber',),
     'Collector': ('ordernumber',),
+    'AgentSpecialty': ('ordernumber',),
+    'Determiner': ('ordernumber',),
+    'Extractor': ('ordernumber',),
+    'FieldNotebookPageSet': ('ordernumber',),
+    'FundingAgent': ('ordernumber',),
+    'GroupPerson': ('ordernumber',),
+    'PcrPerson': ('ordernumber',),
 }
 
 def make_model(module, table, datamodel):


### PR DESCRIPTION
Turns our resources are already ordered on the back-end, so the default ordering on the front-end was only causing problems

Fixes #2981