### PR TITLE
Display properly the color picker in Safari 

### DIFF
--- a/specifyweb/frontend/js_src/lib/components/UserPreferences/Renderers.tsx
+++ b/specifyweb/frontend/js_src/lib/components/UserPreferences/Renderers.tsx
@@ -50,7 +50,7 @@ export const ColorPickerPreferenceItem: PreferenceItemComponent<string> =
           }}
         />
         <Input.Generic
-          className="sr-only"
+          className="sr-only !top-[unset] bottom-0 h-auto opacity-0"
           isReadOnly={isReadOnly}
           maxLength={7}
           minLength={7}


### PR DESCRIPTION
Fixed #2215 