### PR TITLE
Add wiki link in console only in production mode

### DIFF
--- a/specifyweb/frontend/js_src/lib/components/Core/Entrypoint.tsx
+++ b/specifyweb/frontend/js_src/lib/components/Core/Entrypoint.tsx
@@ -17,7 +17,7 @@ function entrypoint(): void {
   interceptLogs();
 
   console.group('Specify App Starting');
-  if (process.env.NODE_ENV === 'development') {
+  if (process.env.NODE_ENV === 'production') {
     console.log(
       '%cDocumentation for Developers:\n',
       'font-weight: bold',


### PR DESCRIPTION
Fixes previous commit that logs link only in development mode.