### PR TITLE
V7.8.7 hotfix

### DIFF
--- a/specifyweb/frontend/js_src/lib/components/InitialContext/treeRanks.ts
+++ b/specifyweb/frontend/js_src/lib/components/InitialContext/treeRanks.ts
@@ -23,15 +23,17 @@ import { schema, strictGetModel } from '../DataModel/schema';
 import { fetchContext as fetchDomain } from '../DataModel/schemaBase';
 import type { Tables } from '../DataModel/types';
 
-export const getDomainResource = <
+export function getDomainResource<
   LEVEL extends keyof typeof schema.domainLevelIds
->(
-  level: LEVEL
-): SpecifyResource<Tables[Capitalize<LEVEL>]> | undefined =>
-  f.maybe(schema.domainLevelIds[level], (id) => {
-    const model = strictGetModel(level);
-    return new model.Resource({ id });
-  });
+>(level: LEVEL): SpecifyResource<Tables[Capitalize<LEVEL>]> | undefined {
+  const id = schema.domainLevelIds?.[level];
+  if (id === undefined)
+    console.error(
+      `Trying to access domain resource ${level} before domain is loaded`
+    );
+  const model = strictGetModel(level);
+  return new model.Resource({ id });
+}
 
 let treeDefinitions: {
   readonly [TREE_NAME in AnyTree['tableName']]: {

--- a/specifyweb/frontend/js_src/lib/components/InitialContext/userInformation.ts
+++ b/specifyweb/frontend/js_src/lib/components/InitialContext/userInformation.ts
@@ -37,6 +37,9 @@ export const fetchContext = load<
     await import('../DataModel/schema').then(
       async ({ fetchContext }) => fetchContext
     );
+    await import('../DataModel/schemaBase').then(
+      async ({ fetchContext }) => fetchContext
+    );
     userInfo.availableCollections = availableCollections.map(serializeResource);
     setDevelopmentGlobal('_user', userInfo);
   }

--- a/specifyweb/frontend/js_src/lib/utils/cache/index.ts
+++ b/specifyweb/frontend/js_src/lib/utils/cache/index.ts
@@ -115,8 +115,15 @@ export const setCache = <
 >(
   category: CATEGORY,
   key: KEY,
-  cacheValue: CacheDefinitions[CATEGORY][KEY]
-) => genericSet<CacheDefinitions[CATEGORY][KEY]>(category, key, cacheValue);
+  cacheValue: CacheDefinitions[CATEGORY][KEY],
+  triggerChange = true
+) =>
+  genericSet<CacheDefinitions[CATEGORY][KEY]>(
+    category,
+    key,
+    cacheValue,
+    triggerChange
+  );
 
 export const cacheEvents = eventListener<{
   readonly change: { readonly category: string; readonly key: string };
@@ -126,7 +133,8 @@ function genericSet<T>(
   category: string,
   key: string,
   // Any serializable value
-  value: T
+  value: T,
+  triggerChange = true
 ): T {
   if (!eventListenerIsInitialized) initialize();
 
@@ -141,7 +149,7 @@ function genericSet<T>(
     JSON.stringify(value)
   );
 
-  cacheEvents.trigger('change', { category, key });
+  if (triggerChange) cacheEvents.trigger('change', { category, key });
 
   return value;
 }


### PR DESCRIPTION
- Fixed exception if `/context/user.json` is fetched before `/context/domain.json`
- Fixed infinite loop due to cache sync when multiple tabs are open
  - Fixes #2955