### PR TITLE
Fix system information not being included in stack trace

### DIFF
--- a/specifyweb/frontend/js_src/lib/components/Developer/CrashReportVisualizer.tsx
+++ b/specifyweb/frontend/js_src/lib/components/Developer/CrashReportVisualizer.tsx
@@ -96,6 +96,7 @@ const mainSections = new Set([
   'message',
   'href',
   'errorContext',
+  'systemInformation',
   'pageHtml',
   'consoleLog',
   'navigator',

--- a/specifyweb/frontend/js_src/lib/components/Errors/stackTrace.ts
+++ b/specifyweb/frontend/js_src/lib/components/Errors/stackTrace.ts
@@ -1,38 +1,40 @@
 import { errorContext } from '../../hooks/useErrorContext';
-import { f } from '../../utils/functools';
-import type { IR } from '../../utils/types';
+import type { R } from '../../utils/types';
 import { jsonStringify, removeKey } from '../../utils/utils';
 import { consoleLog } from './interceptLogs';
 
-let resolvedStackTrace: IR<unknown> = { stackTrace: 'loading' };
-f.all({
-  tablePermissions: import('../Permissions').then(({ getTablePermissions }) =>
-    getTablePermissions()
-  ),
-  systemInformation: import('../InitialContext/systemInfo').then(
-    ({ getSystemInfo }) => getSystemInfo()
-  ),
-  operationPermissions: import('../Permissions').then(
-    ({ getOperationPermissions }) => getOperationPermissions()
-  ),
-  errorContext: Array.from(errorContext),
-  schema: import('../DataModel/schema').then(({ schema }) =>
-    removeKey(schema, 'models')
-  ),
-  remotePrefs: import('../InitialContext/remotePrefs').then(
-    ({ remotePrefs }) => remotePrefs
-  ),
-  userPreferences: import('../UserPreferences/helpers').then(
-    ({ getRawUserPreferences }) => getRawUserPreferences()
-  ),
-  userInformation: import('../InitialContext/userInformation').then(
-    ({ userInformation }) => userInformation
-  ),
-})
-  .then((data) => {
-    resolvedStackTrace = data;
-    return data;
+const resolvedStackTrace: R<unknown> = {};
+Promise.all(
+  Object.entries({
+    systemInformation: import('../InitialContext/systemInfo').then(
+      async ({ fetchContext, getSystemInfo }) =>
+        fetchContext.then(getSystemInfo)
+    ),
+    tablePermissions: import('../Permissions').then(
+      async ({ getTablePermissions, fetchContext }) =>
+        fetchContext.then(getTablePermissions)
+    ),
+    operationPermissions: import('../Permissions').then(
+      async ({ getOperationPermissions, fetchContext }) =>
+        fetchContext.then(getOperationPermissions)
+    ),
+    schema: import('../DataModel/schema')
+      .then(async ({ fetchContext }) => fetchContext)
+      .then((schema) => removeKey(schema, 'models')),
+    remotePrefs: import('../InitialContext/remotePrefs').then(
+      ({ fetchContext }) => fetchContext
+    ),
+    userPreferences: import('../UserPreferences/helpers').then(
+      ({ preferencesPromise, getRawUserPreferences }) =>
+        preferencesPromise.then(() => getRawUserPreferences())
+    ),
+    userInformation: import('../InitialContext/userInformation').then(
+      ({ fetchContext }) => fetchContext
+    ),
+  }).map(async ([key, promise]) => {
+    resolvedStackTrace[key] = await promise;
   })
+)
   // Can't use softFail here because of circular dependency
   .catch(console.error);
 
@@ -45,6 +47,7 @@ export const produceStackTrace = (message: unknown): string =>
     ...resolvedStackTrace,
     href: globalThis.location.href,
     consoleLog,
+    errorContext: Array.from(errorContext),
     pageHtml: document.documentElement.outerHTML,
     localStorage: { ...localStorage },
     // Network log and page load telemetry

--- a/specifyweb/frontend/js_src/lib/components/InitialContext/userInformation.ts
+++ b/specifyweb/frontend/js_src/lib/components/InitialContext/userInformation.ts
@@ -42,6 +42,7 @@ export const fetchContext = load<
     );
     userInfo.availableCollections = availableCollections.map(serializeResource);
     setDevelopmentGlobal('_user', userInfo);
+    return userInfo;
   }
 );
 


### PR DESCRIPTION
Because it's not loaded by the time stack trace is created
Along with a few other keys

To test:
Open http://localhost/specify/command/test-error/ (or any other way of generating a stack trace)
Download the error message
Make sure "systemInformation" key is present in the object