### PR TITLE
Fix attachment viewer not working inside of FormTable

### DIFF
--- a/specifyweb/frontend/js_src/lib/components/Attachments/Plugin.tsx
+++ b/specifyweb/frontend/js_src/lib/components/Attachments/Plugin.tsx
@@ -11,6 +11,7 @@ import { useTriggerState } from '../../hooks/useTriggerState';
 import { attachmentsText } from '../../localization/attachments';
 import { formsText } from '../../localization/forms';
 import { f } from '../../utils/functools';
+import type { GetOrSet } from '../../utils/types';
 import { Progress } from '../Atoms';
 import { LoadingContext } from '../Core/Contexts';
 import { toTable } from '../DataModel/helpers';
@@ -25,7 +26,6 @@ import { FilePicker } from '../Molecules/FilePicker';
 import { ProtectedTable } from '../Permissions/PermissionDenied';
 import { attachmentSettingsPromise, uploadFile } from './attachments';
 import { AttachmentViewer } from './Viewer';
-import { GetOrSet } from '../../utils/types';
 
 export function AttachmentsPlugin(
   props: Parameters<typeof ProtectedAttachmentsPlugin>[0]

--- a/specifyweb/frontend/js_src/lib/components/Attachments/Plugin.tsx
+++ b/specifyweb/frontend/js_src/lib/components/Attachments/Plugin.tsx
@@ -25,6 +25,7 @@ import { FilePicker } from '../Molecules/FilePicker';
 import { ProtectedTable } from '../Permissions/PermissionDenied';
 import { attachmentSettingsPromise, uploadFile } from './attachments';
 import { AttachmentViewer } from './Viewer';
+import { GetOrSet } from '../../utils/types';
 
 export function AttachmentsPlugin(
   props: Parameters<typeof ProtectedAttachmentsPlugin>[0]
@@ -39,16 +40,11 @@ export function AttachmentsPlugin(
   );
 }
 
-function ProtectedAttachmentsPlugin({
-  resource,
-  mode = 'edit',
-}: {
-  readonly resource: SpecifyResource<AnySchema> | undefined;
-  readonly mode: FormMode;
-}): JSX.Element | null {
-  const [attachment, setAttachment] = useAsyncState<
-    SpecifyResource<Attachment> | false
-  >(
+/** Retrieve attachment related to a given resource */
+export function useAttachment(
+  resource: SpecifyResource<AnySchema> | undefined
+): GetOrSet<SpecifyResource<Attachment> | false | undefined> {
+  return useAsyncState(
     React.useCallback(
       async () =>
         f.maybe(resource, (resource) => toTable(resource, 'Attachment')) ??
@@ -58,6 +54,16 @@ function ProtectedAttachmentsPlugin({
     ),
     true
   );
+}
+
+function ProtectedAttachmentsPlugin({
+  resource,
+  mode = 'edit',
+}: {
+  readonly resource: SpecifyResource<AnySchema> | undefined;
+  readonly mode: FormMode;
+}): JSX.Element | null {
+  const [attachment, setAttachment] = useAttachment(resource);
   useErrorContext('attachment', attachment);
 
   const filePickerContainer = React.useRef<HTMLDivElement | null>(null);

--- a/specifyweb/frontend/js_src/lib/components/FormCells/FormTable.tsx
+++ b/specifyweb/frontend/js_src/lib/components/FormCells/FormTable.tsx
@@ -12,6 +12,8 @@ import { Button } from '../Atoms/Button';
 import { className } from '../Atoms/className';
 import { columnDefinitionsToCss, DataEntry } from '../Atoms/DataEntry';
 import { icons } from '../Atoms/Icons';
+import { useAttachment } from '../Attachments/Plugin';
+import { AttachmentViewer } from '../Attachments/Viewer';
 import type { AnySchema } from '../DataModel/helperTypes';
 import type { SpecifyResource } from '../DataModel/legacyTypes';
 import type { Relationship } from '../DataModel/specifyField';
@@ -19,6 +21,7 @@ import type { SpecifyModel } from '../DataModel/specifyModel';
 import { FormMeta } from '../FormMeta';
 import type { FormMode } from '../FormParse';
 import type { FormCellDefinition, SubViewSortField } from '../FormParse/cells';
+import { attachmentView } from '../FormParse/webOnlyViews';
 import { SearchDialog } from '../Forms/SearchDialog';
 import { SpecifyForm } from '../Forms/SpecifyForm';
 import { useViewDefinition } from '../Forms/useViewDefinition';
@@ -312,30 +315,40 @@ export function FormTable<SCHEMA extends AnySchema>({
                           {icons.chevronRight}
                         </Button.Small>
                       </div>
-                      {viewDefinition.rows[0].map(
-                        (
-                          { colSpan, align, visible, id: cellId, ...cellData },
-                          index
-                        ) => (
-                          <DataEntry.Cell
-                            align={align}
-                            colSpan={colSpan}
-                            key={index}
-                            role="cell"
-                            visible={visible}
-                          >
-                            <FormCell
+                      {viewDefinition.name === attachmentView ? (
+                        <Attachment resource={resource} />
+                      ) : (
+                        viewDefinition.rows[0].map(
+                          (
+                            {
+                              colSpan,
+                              align,
+                              visible,
+                              id: cellId,
+                              ...cellData
+                            },
+                            index
+                          ) => (
+                            <DataEntry.Cell
                               align={align}
-                              cellData={cellData}
-                              formatId={(suffix: string): string =>
-                                id(`${index}-${suffix}`)
-                              }
-                              formType="formTable"
-                              id={cellId}
-                              mode={viewDefinition.mode}
-                              resource={resource}
-                            />
-                          </DataEntry.Cell>
+                              colSpan={colSpan}
+                              key={index}
+                              role="cell"
+                              visible={visible}
+                            >
+                              <FormCell
+                                align={align}
+                                cellData={cellData}
+                                formatId={(suffix: string): string =>
+                                  id(`${index}-${suffix}`)
+                                }
+                                formType="formTable"
+                                id={cellId}
+                                mode={viewDefinition.mode}
+                                resource={resource}
+                              />
+                            </DataEntry.Cell>
+                          )
                         )
                       )}
                     </>
@@ -446,5 +459,28 @@ export function FormTable<SCHEMA extends AnySchema>({
     >
       {children}
     </Dialog>
+  );
+}
+
+function Attachment({
+  resource,
+}: {
+  readonly resource: SpecifyResource<AnySchema> | undefined;
+}): JSX.Element | null {
+  const related = React.useState<SpecifyResource<AnySchema> | undefined>(
+    undefined
+  );
+  const [attachment] = useAttachment(resource);
+  return typeof attachment === 'object' ? (
+    <AttachmentViewer
+      attachment={attachment}
+      related={related}
+      showMeta={false}
+      onViewRecord={undefined}
+    />
+  ) : attachment === false ? (
+    <p>{formsText.noData()}</p>
+  ) : (
+    loadingGif
   );
 }

--- a/specifyweb/frontend/js_src/lib/components/FormParse/webOnlyViews.ts
+++ b/specifyweb/frontend/js_src/lib/components/FormParse/webOnlyViews.ts
@@ -20,7 +20,21 @@ export const webOnlyViews = f.store(() =>
     /*
      * This is a special view that would be replaced by the <AttachmentPlugin />
      */
-    [attachmentView]: { columns: [], rows: [] },
+    [attachmentView]: {
+      columns: [undefined],
+      rows: [
+        [
+          {
+            id: undefined,
+            align: 'left',
+            colSpan: 1,
+            visible: true,
+            ariaLabel: schema.models.Attachment.label,
+            type: 'Blank',
+          },
+        ],
+      ],
+    },
     SpecifyUser: autoGenerateViewDefinition(
       schema.models.SpecifyUser,
       'form',


### PR DESCRIPTION
Fixes #3087

The bug happens when Specify tries to display an attachment viewer in a form table (This broke in 7.8.7 when we added the new attachment viewer)

To test: render a table like CollectionObjectAttachment in a form table