### PR TITLE
Use timestampcreated instead of cataloged date

### DIFF
--- a/specifyweb/frontend/js_src/lib/components/Statistics/StatsSpec.tsx
+++ b/specifyweb/frontend/js_src/lib/components/Statistics/StatsSpec.tsx
@@ -371,7 +371,7 @@ export const statsSpec: StatsSpec = {
                     path: formattedEntry,
                   },
                   {
-                    path: 'catalogedDate',
+                    path: 'timestampCreated',
                     operStart: queryFieldFilters.greaterOrEqual.id,
                     startValue: `${today} - 1 week`,
                   },
@@ -390,7 +390,7 @@ export const statsSpec: StatsSpec = {
                     path: formattedEntry,
                   },
                   {
-                    path: 'catalogedDate',
+                    path: 'timestampCreated',
                     operStart: queryFieldFilters.greaterOrEqual.id,
                     startValue: `${today} - 1 month`,
                   },
@@ -409,7 +409,7 @@ export const statsSpec: StatsSpec = {
                     path: formattedEntry,
                   },
                   {
-                    path: 'catalogedDate',
+                    path: 'timestampCreated',
                     operStart: queryFieldFilters.greaterOrEqual.id,
                     startValue: `${today} - 1 year`,
                   },


### PR DESCRIPTION
Uses timestamp created for cataloged stats. Since some users don't use cataloged date, this will be a better indicator.