### PR TITLE
Handle multiple spappresourcedirs in reports and resource end points

### DIFF
--- a/specifyweb/context/collection_resources.py
+++ b/specifyweb/context/collection_resources.py
@@ -85,6 +85,8 @@ collection_resources = openapi(schema={
                 'spappresourcedir__usertype__isnull': True,
 }, _spappresourcefilterpost=lambda request: {
     'specifyuser': request.specify_user
+},_spappresourcedircreate=lambda request:{
+    'ispersonal': False
 }))
 
 

--- a/specifyweb/context/resources.py
+++ b/specifyweb/context/resources.py
@@ -31,11 +31,21 @@ class Resources(View):
     def post(self, request) -> http.HttpResponse:
         post_data = json.loads(request.body)
         with transaction.atomic():
-            directory, _ = Spappresourcedir.objects.get_or_create(
+            directories_matched = Spappresourcedir.objects.filter(
                 collection=request.specify_collection,
                 discipline=request.specify_collection.discipline,
                 **self._spappresourcedirfilter(request)
             )
+
+            if len(directories_matched) == 0:
+                directory = Spappresourcedir.objects.create(
+                collection=request.specify_collection,
+                discipline=request.specify_collection.discipline,
+                **self._spappresourcedirfilter(request)
+                )
+            else:
+                directory = directories_matched[0]
+
             resource = Spappresource.objects.create(
                 spappresourcedir=directory,
                 level=0,

--- a/specifyweb/context/resources.py
+++ b/specifyweb/context/resources.py
@@ -30,18 +30,17 @@ class Resources(View):
 
     def post(self, request) -> http.HttpResponse:
         post_data = json.loads(request.body)
+        _spappresource_filter_or_create = self._spappresourcedirfilter(request)
+        _spappresource_filter_or_create['collection'] = request.specify_collection
+        _spappresource_filter_or_create['discipline'] = request.specify_collection.discipline
         with transaction.atomic():
             directories_matched = Spappresourcedir.objects.filter(
-                collection=request.specify_collection,
-                discipline=request.specify_collection.discipline,
-                **self._spappresourcedirfilter(request)
+                **_spappresource_filter_or_create
             )
 
             if len(directories_matched) == 0:
                 directory = Spappresourcedir.objects.create(
-                collection=request.specify_collection,
-                discipline=request.specify_collection.discipline,
-                **self._spappresourcedirfilter(request)
+                    **_spappresource_filter_or_create
                 )
             else:
                 directory = directories_matched[0]

--- a/specifyweb/context/user_resources.py
+++ b/specifyweb/context/user_resources.py
@@ -6,6 +6,11 @@ from specifyweb.context.resources import Resource, Resources
 Spappresource = getattr(models, 'Spappresource')
 Spappresourcedir = getattr(models, 'Spappresourcedir')
 
+user_resource_dir_filter_gen = lambda request: {
+                'specifyuser': request.specify_user,
+                'ispersonal': True,
+                'usertype': get_usertype(request.specify_user),
+}
 
 user_resources = openapi(schema={
     "get": {
@@ -75,16 +80,14 @@ user_resources = openapi(schema={
             }
         }
     }
-})(Resources.as_view(_spappresourcedirfilter= lambda request: {
-                'specifyuser': request.specify_user,
-                'ispersonal': True,
-                'usertype': get_usertype(request.specify_user),
-}, _spappresourcefilter= lambda request: {
+})(Resources.as_view(_spappresourcedirfilter= user_resource_dir_filter_gen,
+                     _spappresourcefilter= lambda request: {
                 'spappresourcedir__specifyuser': request.specify_user,
                 'spappresourcedir__ispersonal':True
 }, _spappresourcefilterpost=lambda request: {
                 'specifyuser': request.specify_user
-}))
+},_spappresourcedircreate=user_resource_dir_filter_gen
+                     ))
 
 
 user_resource = openapi(schema={

--- a/specifyweb/report_runner/views.py
+++ b/specifyweb/report_runner/views.py
@@ -129,10 +129,12 @@ def create_report(user_id, discipline_id, query_id, mimetype, name):
         "Can not create report: mimetype not 'jrxml/label' or 'jrxml/report'", 
         {"localizationKey" : "invalidReportMimetype"})
     query = Spquery.objects.get(id=query_id)
-    try:
-        spappdir = Spappresourcedir.objects.get(discipline_id=discipline_id, collection_id=None)
-    except Spappresourcedir.DoesNotExist:
+
+    spappdirs_matched = Spappresourcedir.objects.filter(discipline_id=discipline_id, collection_id=None)
+    if len(spappdirs_matched) == 0:
         spappdir = Spappresourcedir.objects.create(discipline_id=discipline_id)
+    else:
+        spappdir = spappdirs_matched[0]
 
     appresource = spappdir.sppersistedappresources.create(
         version=0,


### PR DESCRIPTION
At least at two places backend assumes that there is just one spappresourcedir. Hence, it uses django get() which raises exception on more than one dir returned. 
Since the app resources use a filter. Fixed by using filter() and then taking arbitrary appresourcedir. Since appresourcedirs are essentially identical (that's why you got them more in the first place), arbitrary selection would work.

Also fixes a bug for statspage that @carlosmbe reported