### PR TITLE
Make popup box disappear after adding unassociated item in New Loan Form

### DIFF
--- a/specifyweb/frontend/js_src/lib/components/Interactions/InteractionDialog.tsx
+++ b/specifyweb/frontend/js_src/lib/components/Interactions/InteractionDialog.tsx
@@ -234,9 +234,10 @@ export function InteractionDialog({
               <Button.DialogClose>{commonText.close()}</Button.DialogClose>
               {typeof itemCollection === 'object' ? (
                 <Button.Blue
-                  onClick={(): void =>
-                    availablePrepsReady(undefined, undefined, [])
-                  }
+                  onClick={(): void => {
+                    availablePrepsReady(undefined, undefined, []);
+                    handleClose();
+                  }}
                 >
                   {interactionsText.addUnassociated()}
                 </Button.Blue>


### PR DESCRIPTION
Fixes #2164