### PR TITLE
Restrict creating Host Taxons

### DIFF
--- a/specifyweb/frontend/js_src/lib/components/DataModel/schemaOverrides.ts
+++ b/specifyweb/frontend/js_src/lib/components/DataModel/schemaOverrides.ts
@@ -110,6 +110,9 @@ const globalFieldOverrides: {
   Attachment: {
     tableID: 'optional',
   },
+  CollectingEventAttribute: {
+    hostTaxon: 'readOnly',
+  },
   Taxon: {
     parent: 'required',
     isAccepted: 'readOnly',

--- a/specifyweb/frontend/js_src/lib/components/FormFields/QueryComboBox.tsx
+++ b/specifyweb/frontend/js_src/lib/components/FormFields/QueryComboBox.tsx
@@ -64,6 +64,7 @@ export function QueryComboBox({
   typeSearch: initialTypeSearch,
   forceCollection,
   relatedModel: initialRelatedModel,
+  disableCanAdd = false,
 }: {
   readonly id: string | undefined;
   readonly resource: SpecifyResource<AnySchema> | undefined;
@@ -75,6 +76,7 @@ export function QueryComboBox({
   readonly typeSearch: Element | string | undefined;
   readonly forceCollection: number | undefined;
   readonly relatedModel?: SpecifyModel | undefined;
+  readonly disableCanAdd: boolean;
 }): JSX.Element {
   React.useEffect(() => {
     if (resource === undefined || !resource.isNew()) return;
@@ -344,7 +346,8 @@ export function QueryComboBox({
 
   const canAdd =
     !RESTRICT_ADDING.has(field.relatedModel.name) &&
-    hasTablePermission(field.relatedModel.name, 'create');
+    hasTablePermission(field.relatedModel.name, 'create') &&
+    !disableCanAdd;
 
   return (
     <div className="flex w-full min-w-[theme(spacing.40)] items-center sm:min-w-[unset]">

--- a/specifyweb/frontend/js_src/lib/components/FormPlugins/HostTaxon.tsx
+++ b/specifyweb/frontend/js_src/lib/components/FormPlugins/HostTaxon.tsx
@@ -44,19 +44,19 @@ export function HostTaxon({
               .maybe(records[0], deserializeResource)
               ?.rgetPromise('rightSideCollection')
           )
-          .then((collection) => collection?.get('id')),
+          .then((collection) => collection),
       [relationship]
     ),
     false
   );
-  return rightSideCollection === undefined ? (
+  return rightSideCollection === null || rightSideCollection === undefined ? (
     <Input.Text isReadOnly />
   ) : hasTreeAccess('Taxon', 'read') ? (
     <QueryComboBox
       field={schema.models.CollectingEventAttribute.strictGetRelationship(
         'hostTaxon'
       )}
-      forceCollection={rightSideCollection}
+      forceCollection={rightSideCollection.get('id')}
       formType={formType}
       id={id}
       isRequired={isRequired}
@@ -64,6 +64,9 @@ export function HostTaxon({
       relatedModel={schema.models.Taxon}
       resource={resource}
       typeSearch={hostTaxonTypeSearch}
+      disableCanAdd={
+        rightSideCollection.get('discipline') !== resource.get('discipline')
+      }
     />
   ) : null;
 }


### PR DESCRIPTION
This restriction needs to be put into place until a proper fix for the Host Taxon relationship is implemented

The issue is that any Host Taxon uploaded through the WorkBench or created using the `+` button on the QueryCombobox will always be created in the current discipline. 

This was solved by removing the HostTaxon relationship from CollectingEventAtrribute in the Workbench and removing the `+` button for the HostTaxon QueryCombobox when the rightSideCollection as specified in the form definition is different then the current collection

Related: https://github.com/specify/specify7/pull/3240#issuecomment-1492001799, https://github.com/specify/specify7/issues/2675