### PR TITLE
Improving documentation for management commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ under GNU General Public License 2 (GPL2).
             - [Restarting Apache](#restarting-apache)
     - [Updating Specify 7](#updating-specify-7)
     - [Updating the database (Specify 6) version](#updating-the-database-specify-6-version)
+    - [Management commands](#management-commands)
     - [Localizing Specify 7](#localizing-specify-7)
 
 ## Changelog
@@ -514,6 +515,36 @@ the [Installing Specify 6](#installing-specify-6) section of this guide for the
 new version of Specify 6.
 
 [![analytics](https://www.google-analytics.com/collect?v=1&t=pageview&dl=https%3A%2F%2Fgithub.com%2Fspecify%2Fspecify7&uid=readme&tid=UA-169822764-3)]()
+
+## Management commands
+
+Several command line actions are available to run various tasks in Specify.
+
+The syntax for each command is like this:
+
+```bash
+python manage.py <command_name>
+```
+
+Example:
+
+```bash
+python manage.py update_feed
+```
+
+To see the list of all available commands, run:
+
+```bash
+python manage.py --help
+```
+
+In addition, to see documentation for each command, run:
+
+```bash
+python manage.py update_feed --help
+```
+
+(where `update_feed` can be replaced with a different command name)
 
 ## Localizing Specify 7
 

--- a/specifyweb/export/management/commands/update_feed.py
+++ b/specifyweb/export/management/commands/update_feed.py
@@ -1,8 +1,15 @@
-from django.core.management.base import BaseCommand, CommandError
+from django.core.management.base import BaseCommand
 
 from specifyweb.export.feed import update_feed, MissingFeedResource
 
+
 class Command(BaseCommand):
+    help="""
+    This will update all export feeds that need updating (based on the "days"
+    interval in the export feed definition file).
+    
+    You can configure a CRON job to run this command at a regular interval.
+    """
 
     def add_arguments(self, parser):
         parser.add_argument(

--- a/specifyweb/frontend/js_src/lib/README.md
+++ b/specifyweb/frontend/js_src/lib/README.md
@@ -106,7 +106,7 @@ The benefit of using several types of comments rather than just `TODO`:
 
 ## Comment style
 
-Most of these things are enforced though ESLint rules, but mentioning them here
+Most of these things are enforced through ESLint rules, but mentioning them here
 just in case you don't have ESLint enabled (please don't do that):
 
 - Comments must always begin with upper case letter

--- a/specifyweb/frontend/js_src/lib/README.md
+++ b/specifyweb/frontend/js_src/lib/README.md
@@ -103,3 +103,56 @@ The benefit of using several types of comments rather than just `TODO`:
   category your `TODO` belosngs to.
 - Can visually scan a `TODO` and immediately know what it involves doing
   (testing / bug fixing / refactoring / adding a feature)
+
+## Comment style
+
+Most of these things are enforced though ESLint rules, but mentioning them here
+just in case you don't have ESLint enabled (please don't do that):
+
+- Comments must always begin with upper case letter
+
+  Reasoning: it's always consistent, and for multi-line comments this make it
+  easy to see whether the comment is a single sentence or multiple sentences.
+
+- Lines should not be longer than 80 characters
+
+  Reasoning: this is the same requirement we have for all code files. Comments
+  should be consistent with that (to avoid the need for horizontal scrolling).
+
+- Single line comments can use `//`
+
+  Example:
+
+  ```js
+  // Console log 5 times
+  Array.from({ length: 5 }).map(console.log);
+  ```
+
+- Any multi line comments must use `/*`:
+
+  ```js
+  /*
+   * First line.
+   * Second line
+   */
+  ```
+
+- For comments that describe a function, a class, a global/exported variable or
+  a comment at the top of the file, instead of `/*` use `/**`. Like this:
+
+  ```js
+  /**
+   * First line.
+   * Second line
+   */
+  ```
+
+  See more examples across our codebase. `/**` is a special syntax (powered by
+  TSDoc). It adds fancy features and even allows rendering markdown. For syntax
+  see https://tsdoc.org/
+
+  For example, here is my IDE rendering such a comments:
+
+  ![](https://user-images.githubusercontent.com/40512816/234322371-99b339c0-224b-433f-9ae8-ee5862852817.png)
+
+  ![](https://user-images.githubusercontent.com/40512816/234322822-afbcd42d-5b4b-444d-8d98-f9af57cbfd1f.png)


### PR DESCRIPTION
Specify 7 supports command line commands for management and various actions (i.e, updating export feed or resetting password)

Unfortunately, they are not very well documented - we need to improve that as those are useful commands for people to know about

See https://docs.djangoproject.com/en/4.2/howto/custom-management-commands/ for information on how to provide documentation. See an example change I provided where I added a description for one command in one folder (there are `commands` folders in different subdirectories). Descriptions for command arguments can also be added (see the code in that file)