### PR TITLE
Show quotes after auto-generated query names

### DIFF
--- a/specifyweb/frontend/js_src/lib/localization/query.ts
+++ b/specifyweb/frontend/js_src/lib/localization/query.ts
@@ -269,12 +269,12 @@ export const queryText = createDictionary({
   },
   treeQueryName: {
     comment: 'Used in query builder header when querying on tree node usages',
-    'en-us': '{tableName:string} using "{nodeFullName:string}"',
-    'ru-ru': '{tableName:string} с использованием «{nodeFullName:string}»',
-    'es-es': '{tableName:string} usando "{nodeFullName:string}"',
-    'fr-fr': '{tableName:string} en utilisant "{nodeFullName:string}"',
-    'uk-ua': '{tableName:string} за допомогою "{nodeFullName:string}"',
-    'de-ch': '{tableName:string} mit „{nodeFullName:string}“',
+    'en-us': `{tableName:string} using "{nodeFullName:string}"`,
+    'ru-ru': `{tableName:string} с использованием «{nodeFullName:string}»`,
+    'es-es': `{tableName:string} usando "{nodeFullName:string}"`,
+    'fr-fr': `{tableName:string} en utilisant "{nodeFullName:string}"`,
+    'uk-ua': `{tableName:string} за допомогою "{nodeFullName:string}"`,
+    'de-ch': `{tableName:string} mit „{nodeFullName:string}“`,
   },
   newButtonDescription: {
     'en-us': 'Add New Field',


### PR DESCRIPTION
Solves #3126

Changed
```
    'en-us': '{tableName:string} using "{nodeFullName:string}"',
```

to this

```
    'en-us': `{tableName:string} using "{nodeFullName:string}"`,
```

Will this have any implications for Weblate? In my testing it solves the quote issue.