### PR TITLE
Reset the focused row in Tree View when Tree Type changes

### DIFF
--- a/specifyweb/frontend/js_src/lib/components/TreeView/index.tsx
+++ b/specifyweb/frontend/js_src/lib/components/TreeView/index.tsx
@@ -142,6 +142,10 @@ function TreeView<SCHEMA extends AnyTree>({
   const [focusedRow, setFocusedRow] = React.useState<Row | undefined>(
     undefined
   );
+  React.useEffect(() => {
+    setFocusedRow(undefined);
+  }, [tableName]);
+
   const [actionRow, setActionRow] = React.useState<Row | undefined>(undefined);
 
   const searchBoxRef = React.useRef<HTMLInputElement | null>(null);

--- a/specifyweb/frontend/js_src/lib/components/TreeView/index.tsx
+++ b/specifyweb/frontend/js_src/lib/components/TreeView/index.tsx
@@ -390,6 +390,8 @@ export function TreeViewWrapper(): JSX.Element | null {
     <ProtectedTree action="read" treeName={treeName}>
       {typeof treeDefinition === 'object' ? (
         <TreeView
+          treeDefinition={treeDefinition.definition}
+          treeDefinitionItems={treeDefinition.ranks}
           tableName={treeName}
           /**
            * We're casting this as a generic Specify Resource because
@@ -400,8 +402,6 @@ export function TreeViewWrapper(): JSX.Element | null {
           key={(treeDefinition.definition as SpecifyResource<AnySchema>).get(
             'resource_uri'
           )}
-          treeDefinition={treeDefinition.definition}
-          treeDefinitionItems={treeDefinition.ranks}
         />
       ) : null}
     </ProtectedTree>

--- a/specifyweb/frontend/js_src/lib/components/TreeView/index.tsx
+++ b/specifyweb/frontend/js_src/lib/components/TreeView/index.tsx
@@ -17,6 +17,7 @@ import { Button } from '../Atoms/Button';
 import { DataEntry } from '../Atoms/DataEntry';
 import { deserializeResource } from '../DataModel/helpers';
 import type {
+  AnySchema,
   AnyTree,
   FilterTablesByEndsWith,
   SerializedResource,
@@ -390,7 +391,15 @@ export function TreeViewWrapper(): JSX.Element | null {
       {typeof treeDefinition === 'object' ? (
         <TreeView
           tableName={treeName}
-          key={treeDefinition.definition.get('resource_uri')}
+          /**
+           * We're casting this as a generic Specify Resource because
+           * Typescript complains that the get method for each member of the
+           * union type of AnyTree is not compatible
+           *
+           */
+          key={(treeDefinition.definition as SpecifyResource<AnySchema>).get(
+            'resource_uri'
+          )}
           treeDefinition={treeDefinition.definition}
           treeDefinitionItems={treeDefinition.ranks}
         />

--- a/specifyweb/frontend/js_src/lib/components/TreeView/index.tsx
+++ b/specifyweb/frontend/js_src/lib/components/TreeView/index.tsx
@@ -142,9 +142,6 @@ function TreeView<SCHEMA extends AnyTree>({
   const [focusedRow, setFocusedRow] = React.useState<Row | undefined>(
     undefined
   );
-  React.useEffect(() => {
-    setFocusedRow(undefined);
-  }, [tableName]);
 
   const [actionRow, setActionRow] = React.useState<Row | undefined>(undefined);
 
@@ -393,6 +390,7 @@ export function TreeViewWrapper(): JSX.Element | null {
       {typeof treeDefinition === 'object' ? (
         <TreeView
           tableName={treeName}
+          key={treeDefinition.definition.get('resource_uri')}
           treeDefinition={treeDefinition.definition}
           treeDefinitionItems={treeDefinition.ranks}
         />


### PR DESCRIPTION
Fixes #3578

To Test:

- Focus on a node in any Tree
- Switch to another Tree of a different table
- Make sure the Tree Action Buttons (Query, Edit, Delete, etc.) are disabled until a node in that tree is focused