### PR TITLE
Don't trigger unload protect when setting lat/long

### DIFF
--- a/specifyweb/frontend/js_src/lib/components/FormPlugins/LatLongUi.tsx
+++ b/specifyweb/frontend/js_src/lib/components/FormPlugins/LatLongUi.tsx
@@ -98,8 +98,15 @@ function Coordinate({
     );
 
     isChanging.current = true;
-    resource.set(coordinateField, parsed?.asFloat() ?? null);
-    resource.set(coordinateTextField, trimmedValue || null);
+
+    /**
+     * Do not set unload protect because very precise coodinateFields
+     * may experience a change of precision during the conversion from
+     * string to float
+     */
+    resource.set(coordinateField, parsed?.asFloat() ?? null, { silent: true });
+
+    resource.set(coordinateTextField, trimmedValue);
     // Since these fields are no used by sp7, they shouldn't trigger unload protect
     resource.set(
       'srcLatLongUnit',


### PR DESCRIPTION
Fixes #3584

To Test:
- Create and save a new Locality
  - Refresh the page; the Save button should be disabled
  - Try inputting values in the Latitude and Longitude coordinate boxes and ensure there is no abnormalities in Form behavior
- Query on Locality and find one (or more) that has very precise Latitude 1 and Longitude 1 values
  - Ensure the Save button is disabled when opening the form
  - Repeat the steps under the (Create and save a new Locality) steps

@maxxxxxdlp As shown in the code comments, while not related to #3584, I stumbled across another issue. When rendering the Coordinate components, Specify parses the value (initially a string) to a Coord and then converts the Coord to a float and tries to set the once-string value to the new float. 
If the value was precise, there may be a loss of precision during the conversion. While most institutions would likely never _need_ values that precise, data integrity is still data integrity. 
I was looking at possible solutions, and am considering Number().toFixed(), because we know the database precision for the field. I'll need to look into this more if it is that important of a problem.
