### PR TITLE
Don't add XML Declaration when running report

### DIFF
--- a/specifyweb/frontend/js_src/lib/components/Reports/Run.tsx
+++ b/specifyweb/frontend/js_src/lib/components/Reports/Run.tsx
@@ -54,7 +54,7 @@ export function RunReport({
         type="hidden"
       />
       <input
-        defaultValue={xmlToString(definition.documentElement)}
+        defaultValue={xmlToString(definition.documentElement, false)}
         name="report"
         type="hidden"
       />


### PR DESCRIPTION
Fixes #3690 

The issue was caused because in https://github.com/specify/specify7/commit/d09f70f157#diff-1503b42bbfa34c58a6baefb81b117d23fe66c0b01b21d15ac9efce9151addbe0R29-R60 we try and add an xml declaration if one does not exist.

The problem is that we are calling a function (parseXML) to parse the xml from the report: https://github.com/specify/specify7/blob/6fd4d042b38e0743f15f88fd0becec537eccd8f9/specifyweb/frontend/js_src/lib/components/Reports/Report.tsx#L90-L96

parseXML uses the built-in DOMParser `parseFromString(...)` method. 
https://github.com/specify/specify7/blob/6fd4d042b38e0743f15f88fd0becec537eccd8f9/specifyweb/frontend/js_src/lib/components/AppResources/codeMirrorLinters.ts#L69-L73

A downside of using this built-in is that the XML Declaration is not included in the serialization. 
Thus, we will _always_ add an XML declaration when call `xmlToString(...)` because the report will never have a declaration. 

However, if the report had an XML declaration, it will now have _two_ declarations when sent to the report runner, [which is not allowed](https://stackoverflow.com/a/20251895) 

So reports that omitted the xml declaration ran correctly while those that included the declaration threw the error. 
While the latter is much more common the former, I've decided to lean in its favor.

- - - 

## To Test
Background: an XML Declaration should be present at the top of every XML file, and there should only ever be one. 
A Declaration looks like: `<?xml version = "1.0" encoding = "UTF-8"?>`

- Run a report which contains an XML declaration
- Run a report which _does not_ contain an XML Declaration