### PR TITLE
Allow new picklists to be created 

### DIFF
--- a/specifyweb/frontend/js_src/lib/components/FormCells/PickListEditor.tsx
+++ b/specifyweb/frontend/js_src/lib/components/FormCells/PickListEditor.tsx
@@ -30,7 +30,10 @@ export function PickListEditor({
     [resource]
   );
 
-  const table = tableName === null ? undefined : getModel(tableName);
+  const table =
+    tableName === null || tableName === undefined
+      ? undefined
+      : getModel(tableName);
 
   const collection = React.useMemo(
     () =>


### PR DESCRIPTION
Fixes #3692

The issue occurs because of the following code:

https://github.com/specify/specify7/blob/52d0f1c12b294936382ef90cc24ec825ce0a6e9d/specifyweb/frontend/js_src/lib/components/FormCells/PickListEditor.tsx#L21-L33

`resource.get('tableName')` is returning undefined rather than null, and thus setting the constant of the React state `tableName` to undefined. 

The error is occurring because we are passing undefined to `getModel(tableName)` and getModel is expecting a string. 

I believe the get method in resourceApi.js is returning undefined because the picklist resource does not have an attribute of `tablename` (yet. Whichever code sets tableName has not been run when the error is thrown). 

My fix here is most likely not a long-term solution. 
@maxxxxxdlp I was hesitant to modify the get method of ResourceBase in resourceApi.js because it will have wide-reaching consequences, but since nearly every caller of resource.get() expects the value to be either string or null, a potential solution may be to return null if the internal Backbone call returns undefined. 
Of course, it _may_ be helpful to have the distinction between null and undefined: they mean two entirely different things and callers of resource.get() lose potentially helpful information (this information however, is very easily attainable from other means). 
- - - 

## To Test
- Ensure rendering/loading _all_ picklist forms does not result in an error (both new and existing picklists)
- Try changing the Table from the PickListTable combobox on the PickList form (on both new and existing picklists), and ensure it operates (saves!) correctly