### PR TITLE
Stop cloning the `barcode` field 

### DIFF
--- a/specifyweb/frontend/js_src/lib/components/AppResources/Editor.tsx
+++ b/specifyweb/frontend/js_src/lib/components/AppResources/Editor.tsx
@@ -234,6 +234,7 @@ export function AppResourceEditor({
         <AppResourcesTabs
           appResource={appResource}
           data={resourceData.data}
+          footer={footer}
           headerButtons={headerButtons}
           isFullScreen={isFullScreen}
           isReadOnly={isReadOnly}
@@ -241,7 +242,6 @@ export function AppResourceEditor({
           resource={resource}
           showValidationRef={showValidationRef}
           onChange={(data): void => setResourceData({ ...resourceData, data })}
-          footer={footer}
         />
       </Form>
       {isFullScreen ? null : footer}

--- a/specifyweb/frontend/js_src/lib/components/DataModel/legacyTypes.ts
+++ b/specifyweb/frontend/js_src/lib/components/DataModel/legacyTypes.ts
@@ -3,6 +3,7 @@
  */
 
 import type { IR, RA } from '../../utils/types';
+import type { BusinessRuleManager } from './businessRules';
 import type {
   AnySchema,
   CommonFields,
@@ -10,7 +11,6 @@ import type {
   SerializedResource,
   TableFields,
 } from './helperTypes';
-import { BusinessRuleManager } from './businessRules';
 import type { SaveBlockers } from './saveBlockers';
 import type { Collection, SpecifyModel } from './specifyModel';
 
@@ -33,7 +33,7 @@ export type SpecifyResource<SCHEMA extends AnySchema> = {
   readonly parent?: SpecifyResource<SCHEMA>;
   readonly noBusinessRules: boolean;
   readonly changed?: {
-    [FIELD_NAME in TableFields<AnySchema>]?: string | number;
+    readonly [FIELD_NAME in TableFields<AnySchema>]?: number | string;
   };
   readonly collection: Collection<SCHEMA>;
   readonly businessRuleManager?: BusinessRuleManager<SCHEMA>;
@@ -190,7 +190,7 @@ export type SpecifyResource<SCHEMA extends AnySchema> = {
   on(
     eventName: string,
     callback: (...args: RA<never>) => void,
-    thisArg?: any
+    thisArgument?: any
   ): void;
   once(eventName: string, callback: (...args: RA<never>) => void): void;
   off(eventName?: string, callback?: (...args: RA<never>) => void): void;

--- a/specifyweb/frontend/js_src/lib/components/DataModel/resource.ts
+++ b/specifyweb/frontend/js_src/lib/components/DataModel/resource.ts
@@ -264,6 +264,7 @@ const uniqueFields = [
   'isCurrent',
   'timestampModified',
   'barcode',
+  'uniqueIdentifier'
 ];
 
 export const getUniqueFields = (model: SpecifyModel): RA<string> =>

--- a/specifyweb/frontend/js_src/lib/components/DataModel/resource.ts
+++ b/specifyweb/frontend/js_src/lib/components/DataModel/resource.ts
@@ -264,7 +264,6 @@ const uniqueFields = [
   'isCurrent',
   'timestampModified',
   'barcode',
-  'uniqueIdentifier'
 ];
 
 export const getUniqueFields = (model: SpecifyModel): RA<string> =>

--- a/specifyweb/frontend/js_src/lib/components/DataModel/resource.ts
+++ b/specifyweb/frontend/js_src/lib/components/DataModel/resource.ts
@@ -263,6 +263,7 @@ const uniqueFields = [
   'version',
   'isCurrent',
   'timestampModified',
+  'barcode',
 ];
 
 export const getUniqueFields = (model: SpecifyModel): RA<string> =>

--- a/specifyweb/frontend/js_src/lib/components/DataModel/resourceApi.js
+++ b/specifyweb/frontend/js_src/lib/components/DataModel/resourceApi.js
@@ -398,8 +398,10 @@ export const ResourceBase = Backbone.Model.extend({
       }
       case 'many-to-one': {
         if (!value) {
-          // BUG: tighten up this check.
-          // The FK is null, or not a URI or inlined resource at any rate
+          /*
+           * BUG: tighten up this check.
+           * The FK is null, or not a URI or inlined resource at any rate
+           */
           field.isDependent() && this.storeDependent(field, null);
           return value;
         }

--- a/specifyweb/frontend/js_src/lib/components/FormSliders/RecordSelectorFromIds.tsx
+++ b/specifyweb/frontend/js_src/lib/components/FormSliders/RecordSelectorFromIds.tsx
@@ -122,7 +122,7 @@ export function RecordSelectorFromIds<SCHEMA extends AnySchema>({
     model,
     records:
       typeof newResource === 'object' ? [...records, newResource] : records,
-    totalCount: totalCount,
+    totalCount,
     onAdd:
       typeof handleAdd === 'function'
         ? (resources): void => {

--- a/specifyweb/frontend/js_src/lib/components/Header/NotificationRenderers.tsx
+++ b/specifyweb/frontend/js_src/lib/components/Header/NotificationRenderers.tsx
@@ -1,17 +1,17 @@
 import React from 'react';
 import type { LocalizedString } from 'typesafe-i18n';
 
+import { mergingText } from '../../localization/merging';
 import { notificationsText } from '../../localization/notifications';
 import { StringToJsx } from '../../localization/utils';
 import type { IR } from '../../utils/types';
 import { Link } from '../Atoms/Link';
-import { mergingText } from '../../localization/merging';
-import { TableIcon } from '../Molecules/TableIcon';
-import { mergingQueryParameter } from '../Merging';
-import { userInformation } from '../InitialContext/userInformation';
-import { formatUrl } from '../Router/queryString';
-import { FormattedResource } from '../Molecules/FormattedResource';
 import { getModel } from '../DataModel/schema';
+import { userInformation } from '../InitialContext/userInformation';
+import { mergingQueryParameter } from '../Merging';
+import { FormattedResource } from '../Molecules/FormattedResource';
+import { TableIcon } from '../Molecules/TableIcon';
+import { formatUrl } from '../Router/queryString';
 
 export type GenericNotification = {
   readonly messageId: string;
@@ -128,7 +128,7 @@ export const notificationRenderers: IR<
   },
   'record-merge-starting'(notification) {
     const tableName = notification.payload.table;
-    const collectionId = parseInt(notification.payload.collection_id);
+    const collectionId = Number.parseInt(notification.payload.collection_id);
     const mergeName = notification.payload.name;
     const collection = userInformation.availableCollections.find(
       ({ id }) => id === collectionId
@@ -146,7 +146,7 @@ export const notificationRenderers: IR<
   },
   'record-merge-failed'(notification) {
     const tableName = notification.payload.table;
-    const id = parseInt(notification.payload.new_record_id);
+    const id = Number.parseInt(notification.payload.new_record_id);
     const ids = [JSON.parse(notification.payload.old_record_ids), id];
     const url = formatUrl(`/specify/overlay/merge/${tableName}/`, {
       [mergingQueryParameter]: Array.from(ids).join(','),
@@ -163,7 +163,7 @@ export const notificationRenderers: IR<
   },
   'record-merge-aborted'(notification) {
     const tableName = notification.payload.table;
-    const collectionId = parseInt(notification.payload.collection_id);
+    const collectionId = Number.parseInt(notification.payload.collection_id);
     const mergeName = notification.payload.name;
     const collection = userInformation.availableCollections.find(
       ({ id }) => id === collectionId
@@ -194,7 +194,7 @@ export const notificationRenderers: IR<
           {mergingText.mergingHasSucceeded()}
           <div className="flex items-center gap-2">
             <TableIcon label name={tableName} />
-            <FormattedResource asLink={true} resource={resource} />
+            <FormattedResource asLink resource={resource} />
           </div>
         </>
       )

--- a/specifyweb/frontend/js_src/lib/components/Merging/CompareSubView.tsx
+++ b/specifyweb/frontend/js_src/lib/components/Merging/CompareSubView.tsx
@@ -77,10 +77,9 @@ export function MergeSubviewButton({
       'blockersChanged',
       () => {
         const hasSaveBlocker = Array.from(
-          resource.saveBlockers?.blockingResources ?? []
-        )
-          .map((resource) => resource.specifyModel.name)
-          .includes(relationshipName);
+          resource.saveBlockers?.blockingResources ?? [],
+          (resource) => resource.specifyModel.name
+        ).includes(relationshipName);
         setValid(!hasSaveBlocker);
       },
       true

--- a/specifyweb/frontend/js_src/lib/components/Merging/InvalidMergeRecords.tsx
+++ b/specifyweb/frontend/js_src/lib/components/Merging/InvalidMergeRecords.tsx
@@ -1,19 +1,20 @@
-import { RA } from '../../utils/types';
-import { AnySchema, SerializedResource } from '../DataModel/helperTypes';
-import { Ul } from '../Atoms';
-import { FormattedResource } from '../Molecules/FormattedResource';
-import { deserializeResource } from '../DataModel/helpers';
 import React from 'react';
-import { OverlayContext } from '../Router/Router';
-import { Dialog } from '../Molecules/Dialog';
-import { recordMergingTableSpec } from './definitions';
-import { dialogIcons } from '../Atoms/Icons';
-import { Button } from '../Atoms/Button';
+
 import { commonText } from '../../localization/common';
 import { mergingText } from '../../localization/merging';
-import { Tables } from '../DataModel/types';
-import { TableIcon } from '../Molecules/TableIcon';
+import type { RA } from '../../utils/types';
+import { Ul } from '../Atoms';
+import { Button } from '../Atoms/Button';
 import { className } from '../Atoms/className';
+import { dialogIcons } from '../Atoms/Icons';
+import { deserializeResource } from '../DataModel/helpers';
+import type { AnySchema, SerializedResource } from '../DataModel/helperTypes';
+import type { Tables } from '../DataModel/types';
+import { Dialog } from '../Molecules/Dialog';
+import { FormattedResource } from '../Molecules/FormattedResource';
+import { TableIcon } from '../Molecules/TableIcon';
+import { OverlayContext } from '../Router/Router';
+import { recordMergingTableSpec } from './definitions';
 
 function InvalidMergeRecords({
   resources,
@@ -52,10 +53,10 @@ function FormattedMemoizedResource({
   );
   return (
     <li
-      key={resource.id as number}
       className="flex min-h-[theme(spacing.8)] flex-1 items-center gap-2"
+      key={resource.id as number}
     >
-      <TableIcon label={true} name={deserializedResource.specifyModel.name} />
+      <TableIcon label name={deserializedResource.specifyModel.name} />
       <FormattedResource resource={deserializedResource} />
     </li>
   );
@@ -73,8 +74,6 @@ export function InvalidMergeRecordsDialog({
   const handleClose = React.useContext(OverlayContext);
   return (
     <Dialog
-      header={mergingText.someCannotBeMerged()}
-      icon={dialogIcons.warning}
       buttons={
         <>
           <Button.DialogClose>{commonText.close()}</Button.DialogClose>
@@ -91,6 +90,8 @@ export function InvalidMergeRecordsDialog({
           )}
         </>
       }
+      header={mergingText.someCannotBeMerged()}
+      icon={dialogIcons.warning}
       onClose={handleClose}
     >
       <InvalidMergeRecords

--- a/specifyweb/frontend/js_src/lib/components/Merging/Status.tsx
+++ b/specifyweb/frontend/js_src/lib/components/Merging/Status.tsx
@@ -1,27 +1,30 @@
 import React from 'react';
-import { MergeStatus, StatusState, initialStatusState } from './types';
-import { ajax } from '../../utils/ajax';
-import { MILLISECONDS } from '../Atoms/timeUnits';
-import { softFail } from '../Errors/Crash';
-import { LoadingContext } from '../Core/Contexts';
-import { Dialog, dialogClassNames } from '../Molecules/Dialog';
-import { Button } from '../Atoms/Button';
-import { ping } from '../../utils/ajax/ping';
-import { mergingText } from '../../localization/merging';
-import { Label } from '../Atoms/Form';
-import { Progress } from '../Atoms';
-import { commonText } from '../../localization/common';
-import { LocalizedString } from 'typesafe-i18n';
-import { dialogIcons } from '../Atoms/Icons';
-import { downloadFile } from '../Molecules/FilePicker';
-import { produceStackTrace } from '../Errors/stackTrace';
+import type { LocalizedString } from 'typesafe-i18n';
 
-const statusLocalization: { [STATE in MergeStatus]: LocalizedString } = {
-  MERGING: mergingText.merging(),
-  ABORTED: mergingText.mergeFailed(),
-  FAILED: mergingText.mergeFailed(),
-  SUCCEEDED: mergingText.mergeSucceeded(),
-};
+import { commonText } from '../../localization/common';
+import { mergingText } from '../../localization/merging';
+import { ajax } from '../../utils/ajax';
+import { ping } from '../../utils/ajax/ping';
+import { Progress } from '../Atoms';
+import { Button } from '../Atoms/Button';
+import { Label } from '../Atoms/Form';
+import { dialogIcons } from '../Atoms/Icons';
+import { MILLISECONDS } from '../Atoms/timeUnits';
+import { LoadingContext } from '../Core/Contexts';
+import { softFail } from '../Errors/Crash';
+import { produceStackTrace } from '../Errors/stackTrace';
+import { Dialog, dialogClassNames } from '../Molecules/Dialog';
+import { downloadFile } from '../Molecules/FilePicker';
+import type { MergeStatus, StatusState } from './types';
+import { initialStatusState } from './types';
+
+const statusLocalization: { readonly [STATE in MergeStatus]: LocalizedString } =
+  {
+    MERGING: mergingText.merging(),
+    ABORTED: mergingText.mergeFailed(),
+    FAILED: mergingText.mergeFailed(),
+    SUCCEEDED: mergingText.mergeSucceeded(),
+  };
 
 export function Status({
   mergingId,
@@ -122,10 +125,10 @@ export function Status({
       className={{ container: dialogClassNames.narrowContainer }}
       dimensionsKey="merging-progress"
       header={statusLocalization[state.status]}
-      onClose={undefined}
       icon={
         state.status === 'SUCCEEDED' ? dialogIcons.success : dialogIcons.error
       }
+      onClose={undefined}
     >
       <Label.Block aria-atomic aria-live="polite" className="gap-2">
         <div className="flex flex-col gap-2">

--- a/specifyweb/frontend/js_src/lib/components/Merging/definitions.ts
+++ b/specifyweb/frontend/js_src/lib/components/Merging/definitions.ts
@@ -1,19 +1,19 @@
-import { Tables } from '../DataModel/types';
-import { SerializedResource } from '../DataModel/helperTypes';
 import { mergingText } from '../../localization/merging';
+import type { SerializedResource } from '../DataModel/helperTypes';
+import type { Tables } from '../DataModel/types';
 
 export const recordMergingTableSpec: Partial<{
-  [TABLE_NAME in keyof Tables]: {
-    filterIgnore?: (
+  readonly [TABLE_NAME in keyof Tables]: {
+    readonly filterIgnore?: (
       resource: SerializedResource<Tables[TABLE_NAME]>
     ) => SerializedResource<Tables[TABLE_NAME]> | undefined;
-    dialogSpecificText: string;
+    readonly dialogSpecificText: string;
   };
 }> = {
   Agent: {
     filterIgnore(resource) {
       const groups = resource.groups;
-      const hasGroup = Array.isArray(groups) && groups.length !== 0;
+      const hasGroup = Array.isArray(groups) && groups.length > 0;
       return hasGroup ? resource : undefined;
     },
     dialogSpecificText: mergingText.agentContainsGroupDescription(),

--- a/specifyweb/frontend/js_src/lib/components/Merging/index.tsx
+++ b/specifyweb/frontend/js_src/lib/components/Merging/index.tsx
@@ -17,6 +17,7 @@ import { filterArray } from '../../utils/types';
 import { multiSortFunction, removeKey } from '../../utils/utils';
 import { Button } from '../Atoms/Button';
 import { Input, Label } from '../Atoms/Form';
+import { icons } from '../Atoms/Icons';
 import { Link } from '../Atoms/Link';
 import { Submit } from '../Atoms/Submit';
 import { LoadingContext } from '../Core/Contexts';
@@ -37,10 +38,9 @@ import { formatUrl } from '../Router/queryString';
 import { OverlayContext, OverlayLocation } from '../Router/Router';
 import { autoMerge, postMergeResource } from './autoMerge';
 import { CompareRecords } from './Compare';
-import { Status } from './Status';
-import { InvalidMergeRecordsDialog } from './InvalidMergeRecords';
 import { recordMergingTableSpec } from './definitions';
-import { icons } from '../Atoms/Icons';
+import { InvalidMergeRecordsDialog } from './InvalidMergeRecords';
+import { Status } from './Status';
 
 export const mergingQueryParameter = 'records';
 
@@ -121,7 +121,7 @@ export function MergingDialog(): JSX.Element | null {
     setIds(ids.filter((id) => !dismissedIds.includes(id)).join(','));
 
   return model === undefined ? null : (
-    <RestrictMerge model={model} ids={ids} onDismiss={handleDismiss} />
+    <RestrictMerge ids={ids} model={model} onDismiss={handleDismiss} />
   );
 }
 
@@ -166,7 +166,7 @@ function RestrictMerge({
       }
     />
   ) : (
-    <Merging records={records} model={model} onDismiss={handleDismiss} />
+    <Merging model={model} records={records} onDismiss={handleDismiss} />
   );
 }
 
@@ -427,11 +427,11 @@ export function MergeDialogContainer({
   return (
     <Dialog
       buttons={buttons}
+      icon={icons.cog}
+      onClose={handleClose}
       header={header}
       // Disable gradient because table headers have solid backgrounds
       specialMode="noGradient"
-      onClose={handleClose}
-      icon={icons.cog}
     >
       {children}
     </Dialog>

--- a/specifyweb/frontend/js_src/lib/components/Merging/types.ts
+++ b/specifyweb/frontend/js_src/lib/components/Merging/types.ts
@@ -1,4 +1,4 @@
-export type MergeStatus = 'FAILED' | 'MERGING' | 'ABORTED' | 'SUCCEEDED';
+export type MergeStatus = 'ABORTED' | 'FAILED' | 'MERGING' | 'SUCCEEDED';
 export type StatusState = {
   readonly status: MergeStatus;
   readonly total: number;

--- a/specifyweb/frontend/js_src/lib/components/QueryBuilder/FieldFilter.tsx
+++ b/specifyweb/frontend/js_src/lib/components/QueryBuilder/FieldFilter.tsx
@@ -583,7 +583,7 @@ export function QueryLineFilter({
 
   const [pickListItems] = useAsyncState(
     React.useCallback(
-      () =>
+      async () =>
         typeof parser.pickListName === 'string'
           ? fetchPickList(parser.pickListName).then((pickList) =>
               typeof pickList === 'object' ? getPickListItems(pickList) : false

--- a/specifyweb/frontend/js_src/lib/components/QueryBuilder/Header.tsx
+++ b/specifyweb/frontend/js_src/lib/components/QueryBuilder/Header.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { useNavigate } from 'react-router-dom';
 
+import { useCachedState } from '../../hooks/useCachedState';
 import { commonText } from '../../localization/common';
 import { preferencesText } from '../../localization/preferences';
 import { queryText } from '../../localization/query';
@@ -26,7 +27,6 @@ import { QueryEditButton } from './Edit';
 import { smoothScroll } from './helpers';
 import { QueryLoanReturn } from './LoanReturn';
 import type { MainState } from './reducer';
-import { useCachedState } from '../../hooks/useCachedState';
 
 export type QueryView = {
   readonly basicView: RA<number>;

--- a/specifyweb/frontend/js_src/lib/components/QueryBuilder/Results.tsx
+++ b/specifyweb/frontend/js_src/lib/components/QueryBuilder/Results.tsx
@@ -9,7 +9,14 @@ import { commonText } from '../../localization/common';
 import { interactionsText } from '../../localization/interactions';
 import { queryText } from '../../localization/query';
 import { f } from '../../utils/functools';
-import { filterArray, type GetOrSet, type GetSet, type IR, type R, type RA } from '../../utils/types';
+import {
+  type GetOrSet,
+  type GetSet,
+  type IR,
+  type R,
+  type RA,
+  filterArray,
+} from '../../utils/types';
 import { removeKey } from '../../utils/utils';
 import { Container, H3 } from '../Atoms';
 import { Button } from '../Atoms/Button';
@@ -202,7 +209,7 @@ export function QueryResults(props: Props): JSX.Element {
         Array.isArray(results) &&
         Array.isArray(loadedResults) &&
         results.length > 0 &&
-        typeof fetchResults === 'function'? (
+        typeof fetchResults === 'function' ? (
           <>
             {hasPermission('/record/replace', 'update') &&
               hasTablePermission(model.name, 'update') && (
@@ -393,7 +400,8 @@ export function useFetchQueryResults({
   const resultsRef = React.useRef(results);
   const handleSetResults = React.useCallback(
     (results: RA<QueryResultRow | undefined> | undefined) => {
-      const filteredResults = results !== undefined ? filterArray(results) : undefined
+      const filteredResults =
+        results === undefined ? undefined : filterArray(results);
       setResults(filteredResults);
       resultsRef.current = results;
     },

--- a/specifyweb/frontend/js_src/lib/components/QueryBuilder/ToForms.tsx
+++ b/specifyweb/frontend/js_src/lib/components/QueryBuilder/ToForms.tsx
@@ -57,8 +57,8 @@ export function QueryToForms({
             label: queryText.queryResults(),
             value: model.label,
           })}
-          onAdd={undefined}
           totalCount={selectedRows.size === 0 ? totalCount : selectedRows.size}
+          onAdd={undefined}
           onClone={undefined}
           onClose={handleClose}
           onDelete={(index): void => handleDelete(unParseIndex(index))}

--- a/specifyweb/frontend/js_src/lib/components/Statistics/AddStatDialog.tsx
+++ b/specifyweb/frontend/js_src/lib/components/Statistics/AddStatDialog.tsx
@@ -4,6 +4,7 @@ import { useBooleanState } from '../../hooks/useBooleanState';
 import { commonText } from '../../localization/common';
 import { queryText } from '../../localization/query';
 import { statsText } from '../../localization/stats';
+import { cleanThrottledPromises } from '../../utils/ajax/throttledPromise';
 import type { RA } from '../../utils/types';
 import { H3, Ul } from '../Atoms';
 import { Button } from '../Atoms/Button';
@@ -23,7 +24,6 @@ import type {
   StatFormatterSpec,
   StatLayout,
 } from './types';
-import { cleanThrottledPromises } from '../../utils/ajax/throttledPromise';
 
 export function AddStatDialog({
   defaultStatsAddLeft,

--- a/specifyweb/frontend/js_src/lib/localization/preferences.ts
+++ b/specifyweb/frontend/js_src/lib/localization/preferences.ts
@@ -1819,7 +1819,7 @@ export const preferencesText = createDictionary({
   },
   detailedView: {
     'en-us': 'Detailed view',
-  },  
+  },
   attachmentPreviewMode: {
     'en-us': 'Attachment preview mode',
     'de-ch': 'Anhang-Vorschaumodus',


### PR DESCRIPTION
Fixes #3787

**Steps to test:**
1. Go to a record that has a barcode value on the preparation form
2. Clone the record
3. Verify that the barcode is not being cloned

Tested locally and it seems to do the job.