### PR TITLE
Fix business rule tests

### DIFF
--- a/specifyweb/frontend/js_src/lib/components/DataModel/__tests__/businessRules.test.ts
+++ b/specifyweb/frontend/js_src/lib/components/DataModel/__tests__/businessRules.test.ts
@@ -1,4 +1,3 @@
-import { overrideAjax } from '../../../tests/ajax';
 import { mockTime, requireContext } from '../../../tests/helpers';
 import { overwriteReadOnly } from '../../../utils/types';
 import { businessRuleDefs } from '../businessRuleDefs';

--- a/specifyweb/frontend/js_src/lib/components/DataModel/__tests__/businessRules.test.ts
+++ b/specifyweb/frontend/js_src/lib/components/DataModel/__tests__/businessRules.test.ts
@@ -1,3 +1,4 @@
+import { overrideAjax } from '../../../tests/ajax';
 import { mockTime, requireContext } from '../../../tests/helpers';
 import { overwriteReadOnly } from '../../../utils/types';
 import { businessRuleDefs } from '../businessRuleDefs';
@@ -144,6 +145,8 @@ describe('DNASequence business rules', () => {
       id: 1,
     });
     dNASequence.set('geneSequence', 'aaa  ttttt  gg  c zzzz');
+
+    await dNASequence.businessRuleManager?.checkField('geneSequence');
 
     expect(dNASequence.get('compA')).toEqual(3);
     expect(dNASequence.get('compT')).toEqual(5);

--- a/specifyweb/frontend/js_src/lib/components/DataModel/__tests__/businessRules.test.ts
+++ b/specifyweb/frontend/js_src/lib/components/DataModel/__tests__/businessRules.test.ts
@@ -117,12 +117,18 @@ describe('Collection Object business rules', () => {
       resource_uri: collectionObjectUrl,
     });
 
+  const orginalEmbeddedCollectingEvent = schema.embeddedCollectingEvent;
+
   beforeAll(() => {
     overwriteReadOnly(schema, 'embeddedCollectingEvent', true);
   });
 
   afterAll(() => {
-    overwriteReadOnly(schema, 'embeddedCollectingEvent', false);
+    overwriteReadOnly(
+      schema,
+      'embeddedCollectingEvent',
+      orginalEmbeddedCollectingEvent
+    );
   });
 
   test('CollectionObject customInit', async () => {

--- a/specifyweb/frontend/js_src/lib/components/DataModel/__tests__/businessRules.test.ts
+++ b/specifyweb/frontend/js_src/lib/components/DataModel/__tests__/businessRules.test.ts
@@ -1,194 +1,144 @@
-import { overrideAjax } from '../../../tests/ajax';
 import { mockTime, requireContext } from '../../../tests/helpers';
+import { overwriteReadOnly } from '../../../utils/types';
 import { businessRuleDefs } from '../businessRuleDefs';
-import { SerializedModel } from '../helperTypes';
 import { getResourceApiUrl } from '../resource';
 import { schema } from '../schema';
-import { Determination } from '../types';
 
 mockTime();
 requireContext();
 
-test('uniqueness rules assigned correctly', async () => {
-  const accessionAgentUniquenessRules = {
-    role: [
+describe('uniqueness rules assigned correctly', () => {
+  test('otherField uniqueness rule assigned', async () => {
+    expect(businessRuleDefs.AccessionAgent?.uniqueIn).toMatchInlineSnapshot(`
       {
-        field: 'accession',
-        otherFields: ['agent'],
-      },
-      {
-        field: 'repositoryagreement',
-        otherFields: ['agent'],
-      },
-    ],
-    agent: [
-      {
-        field: 'accession',
-        otherFields: ['role'],
-      },
-      {
-        field: 'repositoryagreement',
-        otherFields: ['role'],
-      },
-    ],
-  };
-  expect(businessRuleDefs.AccessionAgent?.uniqueIn).toBe(
-    accessionAgentUniquenessRules
-  );
+        "agent": [
+          {
+            "field": "accession",
+            "otherFields": [
+              "role",
+            ],
+          },
+          {
+            "field": "repositoryagreement",
+            "otherFields": [
+              "role",
+            ],
+          },
+        ],
+        "role": [
+          {
+            "field": "accession",
+            "otherFields": [
+              "agent",
+            ],
+          },
+          {
+            "field": "repositoryagreement",
+            "otherFields": [
+              "agent",
+            ],
+          },
+        ],
+      }
+    `);
+  });
+
+  test('Standard rules assigned correctly', async () => {
+    expect(businessRuleDefs.CollectionObject?.uniqueIn).toMatchInlineSnapshot(`
+          {
+            "catalogNumber": [
+              "collection",
+            ],
+            "guid": [
+              "institution",
+            ],
+            "uniqueIdentifier": [
+              "collection",
+            ],
+          }
+      `);
+  });
+
+  test('JSON nulls are converted to undefined', async () => {
+    expect(businessRuleDefs.Permit?.uniqueIn).toMatchInlineSnapshot(`
+          {
+            "permitNumber": [
+              undefined,
+            ],
+          }
+      `);
+  });
 });
 
-const determinationId = 321;
-const determinationUrl = getResourceApiUrl('Determination', determinationId);
-const determinationResponse: Partial<SerializedModel<Determination>> = {
-  id: determinationId,
-  resource_uri: determinationUrl,
-};
+describe('Borrow Material business rules', () => {
+  const borrowMaterialId = 1;
+  const borrowMaterialUrl = getResourceApiUrl(
+    'BorrowMaterial',
+    borrowMaterialId
+  );
 
-const collectionObjectId = 220;
-const collectionObjectUrl = getResourceApiUrl(
-  'CollectionObject',
-  collectionObjectId
-);
-const collectionObjectResponse = {
-  id: collectionObjectId,
-  resource_uri: collectionObjectUrl,
-  catalognumber: '000022002',
-  collection: getResourceApiUrl('Collection', 4),
-  determinations: determinationUrl,
-};
-
-overrideAjax(collectionObjectUrl, collectionObjectResponse);
-overrideAjax(determinationUrl, determinationResponse);
-
-describe('business rules', () => {
-  test('collectionObject customInit', async () => {
-    const resource = new schema.models.CollectionObject.Resource({
-      id: collectionObjectId,
+  const getBaseBorrowMaterial = () =>
+    new schema.models.BorrowMaterial.Resource({
+      id: borrowMaterialId,
+      resource_uri: borrowMaterialUrl,
+      quantity: 20,
+      quantityreturned: 13,
+      quantityresolved: 15,
     });
-    await resource.fetch();
-    expect(resource.get('collectingEvent')).toBeDefined();
-    resource.save();
+
+  test('fieldCheck quantityReturned', async () => {
+    const borrowMaterial = getBaseBorrowMaterial();
+
+    borrowMaterial.set('quantityReturned', 30);
+    expect(borrowMaterial.get('quantityReturned')).toBe(15);
   });
 
-  describe('determination business rules', () => {
-    test('determination customInit', async () => {
-      const determination = new schema.models.Determination.Resource({
-        id: determinationId,
-      });
-      await determination.fetch();
-      expect(determination.get('isCurrent')).toBe(true);
+  test('fieldCheck quantityResolved', async () => {
+    const borrowMaterial = getBaseBorrowMaterial();
+
+    borrowMaterial.set('quantityResolved', 30);
+    expect(borrowMaterial.get('quantityResolved')).toBe(20);
+
+    borrowMaterial.set('quantityResolved', 5);
+    expect(borrowMaterial.get('quantityResolved')).toBe(13);
+  });
+});
+
+describe('Collection Object business rules', () => {
+  const collectionObjectlId = 2;
+  const collectionObjectUrl = getResourceApiUrl(
+    'CollectionObject',
+    collectionObjectlId
+  );
+
+  const getBaseCollectionObject = () =>
+    new schema.models.CollectionObject.Resource({
+      id: collectionObjectlId,
+      resource_uri: collectionObjectUrl,
     });
-    test('only one determination isCurrent', async () => {
-      const determination = new schema.models.Determination.Resource({
-        id: determinationId,
-      });
-      const resource = new schema.models.CollectionObject.Resource({
-        id: collectionObjectId,
-      });
-      await resource.rgetCollection('determinations').then((collection) => {
-        collection.add(new schema.models.Determination.Resource());
-      });
-      expect(determination.get('isCurrent')).toBe(false);
-    });
-    test('determination taxon field check', async () => {
-      const determination = new schema.models.Determination.Resource({
-        id: determinationId,
-      });
-      const taxonId = 19345;
-      const taxonUrl = getResourceApiUrl('Taxon', taxonId);
-      const taxonResponse = {
-        resource_uri: getResourceApiUrl('Taxon', taxonUrl),
-        id: taxonId,
-        name: 'melas',
-        fullName: 'Ameiurus melas',
-      };
-      overrideAjax(taxonUrl, taxonResponse);
-      determination.set(
-        'taxon',
-        new schema.models.Taxon.Resource({
-          id: taxonId,
-        })
-      );
-      expect(determination.get('preferredTaxon')).toBe(taxonUrl);
-    });
+
+  beforeEach(() => {
+    overwriteReadOnly(schema, 'embeddedCollectingEvent', true);
   });
 
-  test('dnaSequence genesequence fieldCheck', async () => {
-    const dnaSequence = new schema.models.DNASequence.Resource({
+  test('CollectionObject customInit', async () => {
+    const collectionObject = getBaseCollectionObject();
+
+    expect(collectionObject.get('collectingEvent')).toBeDefined();
+  });
+});
+
+describe('DNASequence business rules', () => {
+  test('fieldCheck geneSequence', async () => {
+    const dNASequence = new schema.models.DNASequence.Resource({
       id: 1,
     });
-    dnaSequence.set('geneSequence', 'cat123gaaz');
+    dNASequence.set('geneSequence', 'aaa  ttttt  gg  c zzzz');
 
-    expect(dnaSequence.get('totalResidues')).toBe(10);
-    expect(dnaSequence.get('compA')).toBe(3);
-    expect(dnaSequence.get('ambiguousResidues')).toBe(4);
-  });
-});
-
-describe('uniquenessRules', () => {
-  const permitOneId = 1;
-  const permitOneUrl = '/api/specify/permit/1/';
-  const permitOneResponse = {
-    id: permitOneId,
-    resource_uri: permitOneUrl,
-    permitNumber: '20',
-  };
-  overrideAjax(permitOneUrl, permitOneResponse);
-
-  const permitTwoId = 2;
-  const permitTwoUrl = getResourceApiUrl('Permit', permitTwoId);
-  const permitTwoResponse = {
-    id: permitTwoId,
-    resource_uri: permitTwoUrl,
-    permitNumber: '20',
-  };
-  overrideAjax(permitTwoUrl, permitTwoResponse);
-
-  overrideAjax(getResourceApiUrl('CollectionObject', 221), {
-    id: 221,
-    resource_uri: getResourceApiUrl('CollectionObject', 221),
-    catalogNumber: '000022002',
-  });
-
-  test('global uniquenessRule', async () => {
-    const testPermit = new schema.models.Permit.Resource({
-      id: permitOneId,
-      permitNumber: '20',
-    });
-    await testPermit.save();
-
-    const duplicatePermit = new schema.models.Permit.Resource({
-      id: permitTwoId,
-      permitNumber: '20',
-    });
-    expect(
-      duplicatePermit
-        .fetch()
-        .then((permit) =>
-          permit.businessRuleManager?.checkField('permitNumber')
-        )
-    ).resolves.toBe({
-      key: 'br-uniqueness-permitnumber',
-      valid: false,
-      reason: 'Value must be unique to Database',
-    });
-  });
-
-  test('scoped uniqueness rule', async () => {
-    const resource = new schema.models.CollectionObject.Resource({
-      id: 221,
-      catalogNumber: '000022002',
-    });
-    expect(
-      resource
-        .fetch()
-        .then((collectionObject) =>
-          collectionObject.businessRuleManager?.checkField('catalogNumber')
-        )
-    ).resolves.toBe({
-      key: 'br-uniqueness-catalognumber',
-      valid: false,
-      reason: 'Value must be unique to Collection',
-    });
+    expect(dNASequence.get('compA')).toEqual(3);
+    expect(dNASequence.get('compT')).toEqual(5);
+    expect(dNASequence.get('compG')).toEqual(2);
+    expect(dNASequence.get('compC')).toEqual(1);
+    expect(dNASequence.get('ambiguousResidues')).toEqual(4);
   });
 });

--- a/specifyweb/frontend/js_src/lib/components/DataModel/__tests__/businessRules.test.ts
+++ b/specifyweb/frontend/js_src/lib/components/DataModel/__tests__/businessRules.test.ts
@@ -45,18 +45,18 @@ describe('uniqueness rules assigned correctly', () => {
 
   test('Standard rules assigned correctly', async () => {
     expect(businessRuleDefs.CollectionObject?.uniqueIn).toMatchInlineSnapshot(`
-          {
-            "catalogNumber": [
-              "collection",
-            ],
-            "guid": [
-              "institution",
-            ],
-            "uniqueIdentifier": [
-              "collection",
-            ],
-          }
-      `);
+      {
+        "catalogNumber": [
+          "collection",
+        ],
+        "guid": [
+          "institution",
+        ],
+        "uniqueIdentifier": [
+          undefined,
+        ],
+      }
+    `);
   });
 
   test('JSON nulls are converted to undefined', async () => {

--- a/specifyweb/frontend/js_src/lib/components/DataModel/__tests__/businessRules.test.ts
+++ b/specifyweb/frontend/js_src/lib/components/DataModel/__tests__/businessRules.test.ts
@@ -117,8 +117,12 @@ describe('Collection Object business rules', () => {
       resource_uri: collectionObjectUrl,
     });
 
-  beforeEach(() => {
+  beforeAll(() => {
     overwriteReadOnly(schema, 'embeddedCollectingEvent', true);
+  });
+
+  afterAll(() => {
+    overwriteReadOnly(schema, 'embeddedCollectingEvent', false);
   });
 
   test('CollectionObject customInit', async () => {

--- a/specifyweb/frontend/js_src/lib/components/DataModel/__tests__/resourceApi.test.ts
+++ b/specifyweb/frontend/js_src/lib/components/DataModel/__tests__/resourceApi.test.ts
@@ -43,6 +43,17 @@ const collectionObjectResponse = {
 };
 
 overrideAjax(collectionObjectUrl, collectionObjectResponse);
+overrideAjax(
+  '/api/specify/collectionobject/?domainfilter=false&catalognumber=000029432&collection=4&offset=0',
+  {
+    objects: [collectionObjectResponse],
+    meta: {
+      limit: 20,
+      offset: 0,
+      total_count: 1,
+    },
+  }
+);
 
 const accessionNumber = '2011-IC-116';
 const accessionResponse = {
@@ -227,6 +238,18 @@ overrideAjax(
         number1: 1,
       }),
     }),
+  }
+);
+
+overrideAjax(
+  '/api/specify/collectionobject/?domainfilter=false&catalognumber=abc&collection=4&offset=0',
+  {
+    objects: [collectionObjectResponse],
+    meta: {
+      limit: 20,
+      offset: 0,
+      total_count: 1,
+    },
   }
 );
 

--- a/specifyweb/frontend/js_src/lib/components/DataModel/businessRuleDefs.ts
+++ b/specifyweb/frontend/js_src/lib/components/DataModel/businessRuleDefs.ts
@@ -73,19 +73,20 @@ export const nonUniqueBusinessRuleDefs: MappedBusinessRuleDefs = {
         const returned = borrowMaterial.get('quantityReturned');
         const resolved = borrowMaterial.get('quantityResolved');
         const quantity = borrowMaterial.get('quantity');
-        var newVal: number | undefined = undefined;
-        if (
+
+        const adjustedReturned =
           typeof quantity === 'number' &&
           typeof returned === 'number' &&
-          returned > quantity
-        ) {
-          newVal = quantity;
-        }
-        if (returned && resolved && returned > resolved) {
-          newVal = resolved;
-        }
+          typeof resolved === 'number'
+            ? returned > quantity
+              ? quantity
+              : returned > resolved
+              ? resolved
+              : returned
+            : undefined;
 
-        newVal && borrowMaterial.set('quantityReturned', newVal);
+        if (typeof adjustedReturned === 'number')
+          borrowMaterial.set('quantityReturned', adjustedReturned);
       },
       quantityResolved: (
         borrowMaterial: SpecifyResource<BorrowMaterial>
@@ -93,16 +94,20 @@ export const nonUniqueBusinessRuleDefs: MappedBusinessRuleDefs = {
         const resolved = borrowMaterial.get('quantityResolved');
         const quantity = borrowMaterial.get('quantity');
         const returned = borrowMaterial.get('quantityReturned');
-        let newVal: number | undefined = undefined;
-        if (resolved && quantity && resolved > quantity) {
-          newVal = quantity;
-        }
-        if (resolved && returned && resolved < returned) {
-          newVal = returned;
-        }
 
-        if (typeof newVal === 'number')
-          borrowMaterial.set('quantityResolved', newVal);
+        const adjustedResolved =
+          typeof quantity === 'number' &&
+          typeof returned === 'number' &&
+          typeof resolved === 'number'
+            ? resolved > quantity
+              ? quantity
+              : resolved < returned
+              ? returned
+              : resolved
+            : undefined;
+
+        if (typeof adjustedResolved === 'number')
+          borrowMaterial.set('quantityResolved', adjustedResolved);
       },
     },
   },

--- a/specifyweb/frontend/js_src/lib/components/DataModel/businessRules.ts
+++ b/specifyweb/frontend/js_src/lib/components/DataModel/businessRules.ts
@@ -300,7 +300,7 @@ export class BusinessRuleManager<SCHEMA extends AnySchema> {
       }
 
       const relatedPromise: Promise<SpecifyResource<AnySchema>> =
-        this.resource.rgetPromise(scope);
+        this.resource.getRelated(scope);
 
       return relatedPromise.then((related) => {
         if (!related) return { valid: true };

--- a/specifyweb/frontend/js_src/lib/components/Forms/Save.tsx
+++ b/specifyweb/frontend/js_src/lib/components/Forms/Save.tsx
@@ -145,7 +145,7 @@ export function SaveButton<SCHEMA extends AnySchema = AnySchema>({
     }
 
     loading(
-      (resource.businessRuleManager?.pendingPromises ?? Promise.resolve()).then(
+      (resource.businessRuleManager?.pendingPromise ?? Promise.resolve()).then(
         () => {
           const blockingResources = Array.from(
             resource.saveBlockers?.blockingResources ?? []


### PR DESCRIPTION
Rewrites the business rule tests so they are run correctly. The issue before was with the order of execution for the setup and teardown of Jest tests (https://jestjs.io/docs/setup-teardown).
For example, we would be trying to call  resource.fetch() before the associated `overrideAjax` function was called. 

My changes should have resolved these issues and make sure that the order of operations are correct for Jest tests. 