### PR TITLE
Automatically add ordinal to attachments

### DIFF
--- a/specifyweb/businessrules/attachment_rules.py
+++ b/specifyweb/businessrules/attachment_rules.py
@@ -27,11 +27,6 @@ def attachment_jointable_save(sender, obj):
     obj.attachment.scopetype, obj.attachment.scopeid = Scoping(attachee)()
     obj.attachment.save()
 
-    if obj.id is None and obj.ordinal is None:
-        others = sender.objects.filter(**{attachee.specify_model.name.lower(): attachee})
-        top = others.aggregate(Max('ordinal'))['ordinal__max']
-        obj.ordinal = 0 if top is None else top + 1
-
 @orm_signal_handler('post_delete')
 def attachment_jointable_deletion(sender, obj):
     if sender in attachment_tables:

--- a/specifyweb/businessrules/attachment_rules.py
+++ b/specifyweb/businessrules/attachment_rules.py
@@ -27,11 +27,10 @@ def attachment_jointable_save(sender, obj):
     obj.attachment.scopetype, obj.attachment.scopeid = Scoping(attachee)()
     obj.attachment.save()
 
-    if obj.id is None:
-        if obj.ordinal is None:
-            others = sender.objects.filter(**{attachee.specify_model.name.lower(): attachee})
-            top = others.aggregate(Max('ordinal'))['ordinal__max']
-            obj.ordinal = 0 if top is None else top + 1
+    if obj.id is None and obj.ordinal is None:
+        others = sender.objects.filter(**{attachee.specify_model.name.lower(): attachee})
+        top = others.aggregate(Max('ordinal'))['ordinal__max']
+        obj.ordinal = 0 if top is None else top + 1
 
 @orm_signal_handler('post_delete')
 def attachment_jointable_deletion(sender, obj):

--- a/specifyweb/businessrules/collector_rules.py
+++ b/specifyweb/businessrules/collector_rules.py
@@ -1,4 +1,3 @@
-from .exceptions import BusinessRuleException
 from django.db.models import Max
 from .orm_signal_handler import orm_signal_handler
 from specifyweb.specify.models import Collector

--- a/specifyweb/businessrules/determiner_rules.py
+++ b/specifyweb/businessrules/determiner_rules.py
@@ -1,4 +1,3 @@
-from .exceptions import BusinessRuleException
 from django.db.models import Max
 from .orm_signal_handler import orm_signal_handler
 from specifyweb.specify import models

--- a/specifyweb/businessrules/extractor_rules.py
+++ b/specifyweb/businessrules/extractor_rules.py
@@ -1,0 +1,12 @@
+from django.db.models import Max
+from .orm_signal_handler import orm_signal_handler
+from specifyweb.specify.models import Extractor
+
+@orm_signal_handler('pre_save', 'Extractor')
+def collector_pre_save(extractor):
+    if extractor.id is None:
+        if extractor.ordernumber is None:
+            # this should be atomic, but whatever
+            others = Extractor.objects.filter(dnasequence=extractor.dnasequence)
+            top = others.aggregate(Max('ordernumber'))['ordernumber__max']
+            extractor.ordernumber = 0 if top is None else top + 1

--- a/specifyweb/businessrules/fieldnotebook_rules.py
+++ b/specifyweb/businessrules/fieldnotebook_rules.py
@@ -1,0 +1,12 @@
+from django.db.models import Max
+from .orm_signal_handler import orm_signal_handler
+from specifyweb.specify.models import Fieldnotebookpageset
+
+@orm_signal_handler('pre_save', 'Fieldnotebookpageset')
+def collector_pre_save(pageset):
+    if pageset.id is None:
+        if pageset.ordernumber is None:
+            # this should be atomic, but whatever
+            others = Fieldnotebookpageset.objects.filter(fieldnotebook=pageset.fieldnotebook)
+            top = others.aggregate(Max('ordernumber'))['ordernumber__max']
+            pageset.ordernumber = 0 if top is None else top + 1

--- a/specifyweb/businessrules/models.py
+++ b/specifyweb/businessrules/models.py
@@ -20,4 +20,5 @@ from . import (
     accessionagent_rules,
     fundingagent_rules,
     determiner_rules,
+    extractor_rules,
 )

--- a/specifyweb/businessrules/pcrperson_rules.py
+++ b/specifyweb/businessrules/pcrperson_rules.py
@@ -1,0 +1,12 @@
+from django.db.models import Max
+from .orm_signal_handler import orm_signal_handler
+from specifyweb.specify.models import Pcrperson
+
+@orm_signal_handler('pre_save', 'Pcrperson')
+def collector_pre_save(pcr_person):
+    if pcr_person.id is None:
+        if pcr_person.ordernumber is None:
+            # this should be atomic, but whatever
+            others = Pcrperson.objects.filter(dnasequence=pcr_person.dnasequence)
+            top = others.aggregate(Max('ordernumber'))['ordernumber__max']
+            pcr_person.ordernumber = 0 if top is None else top + 1

--- a/specifyweb/frontend/js_src/lib/components/DataModel/businessRuleDefs.ts
+++ b/specifyweb/frontend/js_src/lib/components/DataModel/businessRuleDefs.ts
@@ -27,6 +27,10 @@ import {
 import uniquenessRules from './uniquness_rules.json';
 
 export type BusinessRuleDefs<SCHEMA extends AnySchema> = {
+  readonly onAdded?: (
+    resource: SpecifyResource<SCHEMA>,
+    collection: Collection<SCHEMA>
+  ) => void;
   readonly onRemoved?: (
     resource: SpecifyResource<SCHEMA>,
     collection: Collection<SCHEMA>

--- a/specifyweb/frontend/js_src/lib/components/DataModel/businessRules.ts
+++ b/specifyweb/frontend/js_src/lib/components/DataModel/businessRules.ts
@@ -49,6 +49,10 @@ export class BusinessRuleManager<SCHEMA extends AnySchema> {
     resource: SpecifyResource<SCHEMA>,
     collection: Collection<SCHEMA>
   ) {
+    /**
+     * REFACTOR: remove the need for this and the orderNumber check by
+     * implementing a general solution on the backend
+     */
     if (resource.specifyModel.getField('ordinal') !== undefined)
       (resource as SpecifyResource<CollectionObjectAttachment>).set(
         'ordinal',
@@ -56,7 +60,7 @@ export class BusinessRuleManager<SCHEMA extends AnySchema> {
         { silent: true }
       );
 
-    if (resource.specifyModel.getField('ordernumber') !== undefined)
+    if (resource.specifyModel.getField('orderNumber') !== undefined)
       (resource as SpecifyResource<Collector>).set(
         'orderNumber',
         collection.indexOf(resource),

--- a/specifyweb/frontend/js_src/lib/components/DataModel/businessRules.ts
+++ b/specifyweb/frontend/js_src/lib/components/DataModel/businessRules.ts
@@ -56,7 +56,7 @@ export class BusinessRuleManager<SCHEMA extends AnySchema> {
         { silent: true }
       );
 
-    if (resource.specifyModel.getField('ordernumber') !== undefined)
+    if (resource.specifyModel.getField('orderNumber') !== undefined)
       (resource as SpecifyResource<Collector>).set(
         'orderNumber',
         collection.indexOf(resource),

--- a/specifyweb/frontend/js_src/lib/components/DataModel/businessRules.ts
+++ b/specifyweb/frontend/js_src/lib/components/DataModel/businessRules.ts
@@ -49,6 +49,19 @@ export class BusinessRuleManager<SCHEMA extends AnySchema> {
     resource: SpecifyResource<SCHEMA>,
     collection: Collection<SCHEMA>
   ) {
+    if (resource.specifyModel.getField('ordinal') !== undefined)
+      (resource as SpecifyResource<CollectionObjectAttachment>).set(
+        'ordinal',
+        collection.indexOf(resource),
+        { silent: true }
+      );
+
+    if (resource.specifyModel.getField('ordernumber') !== undefined)
+      (resource as SpecifyResource<Collector>).set(
+        'orderNumber',
+        collection.indexOf(resource),
+        { silent: true }
+      );
     this.addPromise(
       this.invokeRule('onAdded', undefined, [resource, collection])
     );

--- a/specifyweb/frontend/js_src/lib/components/DataModel/businessRules.ts
+++ b/specifyweb/frontend/js_src/lib/components/DataModel/businessRules.ts
@@ -11,6 +11,7 @@ import { formatConjunction } from '../Atoms/Internationalization';
 import { formsText } from '../../localization/forms';
 import { LiteralField, Relationship } from './specifyField';
 import { idFromUrl } from './resource';
+import { CollectionObjectAttachment, Collector } from './types';
 
 export class BusinessRuleManager<SCHEMA extends AnySchema> {
   private readonly resource: SpecifyResource<SCHEMA>;
@@ -44,6 +45,28 @@ export class BusinessRuleManager<SCHEMA extends AnySchema> {
     }
   }
 
+  private added(
+    resource: SpecifyResource<SCHEMA>,
+    collection: Collection<SCHEMA>
+  ) {
+    if (resource.specifyModel.getField('ordinal') !== undefined)
+      (resource as SpecifyResource<CollectionObjectAttachment>).set(
+        'ordinal',
+        collection.indexOf(resource),
+        { silent: true }
+      );
+
+    if (resource.specifyModel.getField('ordernumber') !== undefined)
+      (resource as SpecifyResource<Collector>).set(
+        'orderNumber',
+        collection.indexOf(resource),
+        { silent: true }
+      );
+    this.addPromise(
+      this.invokeRule('onAdded', undefined, [resource, collection])
+    );
+  }
+
   private removed(
     resource: SpecifyResource<SCHEMA>,
     collection: Collection<SCHEMA>
@@ -59,6 +82,7 @@ export class BusinessRuleManager<SCHEMA extends AnySchema> {
       initializeTreeRecord(this.resource as SpecifyResource<AnyTree>);
 
     this.resource.on('change', this.changed, this);
+    this.resource.on('add', this.added, this);
     this.resource.on('remove', this.removed, this);
   }
 

--- a/specifyweb/frontend/js_src/lib/components/DataModel/businessRules.ts
+++ b/specifyweb/frontend/js_src/lib/components/DataModel/businessRules.ts
@@ -49,19 +49,6 @@ export class BusinessRuleManager<SCHEMA extends AnySchema> {
     resource: SpecifyResource<SCHEMA>,
     collection: Collection<SCHEMA>
   ) {
-    if (resource.specifyModel.getField('ordinal') !== undefined)
-      (resource as SpecifyResource<CollectionObjectAttachment>).set(
-        'ordinal',
-        collection.indexOf(resource),
-        { silent: true }
-      );
-
-    if (resource.specifyModel.getField('orderNumber') !== undefined)
-      (resource as SpecifyResource<Collector>).set(
-        'orderNumber',
-        collection.indexOf(resource),
-        { silent: true }
-      );
     this.addPromise(
       this.invokeRule('onAdded', undefined, [resource, collection])
     );

--- a/specifyweb/frontend/js_src/lib/components/DataModel/specifyModel.ts
+++ b/specifyweb/frontend/js_src/lib/components/DataModel/specifyModel.ts
@@ -98,6 +98,7 @@ export type Collection<SCHEMA extends AnySchema> = {
   /* eslint-disable @typescript-eslint/method-signature-style */
   isComplete(): boolean;
   getTotalCount(): Promise<number>;
+  indexOf(resource: SpecifyResource<SCHEMA>): number;
   // eslint-disable-next-line @typescript-eslint/naming-convention
   toJSON<V extends IR<unknown>>(): RA<V>;
   add(resource: RA<SpecifyResource<SCHEMA>> | SpecifyResource<SCHEMA>): void;


### PR DESCRIPTION
Fixes #3788

This adds a backend business rule which sets the `ordinal` field of Attachment tables if `ordinal` is not provided. 
It does so via the following: 
- Get all of the other Attachments on the related record
- Gets the maximum `ordinal` value among those attachments
- Sets the new Attachment equal to 1 + the maximum, or 0 if there are no other attachments

This also adds a frontend business rule which sets the `ordinal` and `ordernumber` fields equal to the index of wherever they are in the collection when they're added. 
In other words, if I you add the 4th attachment to a CollectionObject, its ordinal field should be 3. 

TO TEST:
Try uploading Attachments to models that support Attachments.

For convenience, here's a list of all attachment tables (extracted from MariaDB):

```sql
MariaDB [specify]> show tables like "%_attachment";
+----------------------------------+
| Tables_in_specify (%_attachment) |
+----------------------------------+
| accessionattachment              |
| agentattachment                  |
| borrowattachment                 |
| collectingeventattachment        |
| collectingtripattachment         |
| collectionobjectattachment       |
| conservdescriptionattachment     |
| conserveventattachment           |
| deaccessionattachment            |
| disposalattachment               |
| dnasequenceattachment            |
| dnasequencerunattachment         |
| exchangeinattachment             |
| exchangeoutattachment            |
| fieldnotebookattachment          |
| fieldnotebookpageattachment      |
| fieldnotebookpagesetattachment   |
| giftattachment                   |
| loanattachment                   |
| localityattachment               |
| permitattachment                 |
| preparationattachment            |
| referenceworkattachment          |
| repositoryagreementattachment    |
| storageattachment                |
| taxonattachment                  |
| treatmenteventattachment         |
+----------------------------------+
``` 