### PR TITLE
let the exception pass through if not duplicate error

### DIFF
--- a/specifyweb/specify/views.py
+++ b/specifyweb/specify/views.py
@@ -504,6 +504,8 @@ def record_merge_fx(model_name: str, old_model_ids: List[int], new_model_id: int
                         if e.args[0] == 1062 and "Duplicate" in str(e) or \
                             'must have unique' in str(e):
                             return record_merge_recur()
+                        else:
+                            raise
                 
                 response: http.HttpResponse = update_record(obj)
                 if response is not None and response.status_code != 204:


### PR DESCRIPTION
This small change to agent merging will allow the exception pass through to be handled by the atomic.transaction if the error is not a duplicate error.