### PR TITLE
Properly display error message in Merging Dialog

### DIFF
--- a/specifyweb/specify/views.py
+++ b/specifyweb/specify/views.py
@@ -478,7 +478,7 @@ def record_merge_fx(model_name: str, old_model_ids: List[int], new_model_id: int
                     if foreign_record_lst.count() > 1:
                         # NOTE: Maybe try handling multiple possible row that are potentially causes the conflict.
                         # Would have to go through all constraints and check records based on columns in each constraint. 
-                        return http.HttpResponseNotAllowed('Error! Multiple records violating uniqueness constraints in ' + table_name)
+                        return http.HttpResponse('Error! Multiple records violating uniqueness constraints in ' + table_name, status=405)
 
                     old_record = obj
                     new_record = foreign_record_lst.first()


### PR DESCRIPTION
Addresses the frontend component of #3801 

The issue was that `http.HttpResponseNotAllowed` expected the first argument to be a list of permitted methods for the endpoint. 
The frontend was expecting a response with code 405, and was not going to construct the usual error message because we had said we would handle the error:  https://github.com/specify/specify7/blob/76878df9e9fa53a3e94b753ec7d11f19f9a9d6b6/specifyweb/frontend/js_src/lib/components/Merging/index.tsx#L233

The data for `http.HttpResponseNotAllowed` would have to be included as another argument, once the list of permitted methods was included. Thus the backend was not passing any data to the frontend. The proper way of using the response would be something like: 
```python
http.HttpResponseNotAllowed(["POST"], 'Error! Multiple records violating uniqueness constraints in ' + table_name)
```

https://docs.djangoproject.com/en/4.2/ref/request-response/#django.http.HttpResponseNotAllowed

TO TEST: 
- Follow the steps in https://github.com/specify/specify7/issues/3801#issuecomment-1640975722