### PR TITLE
Catch case where no old_model_ids were given - [issue-3857]

### DIFF
--- a/specifyweb/specify/views.py
+++ b/specifyweb/specify/views.py
@@ -733,6 +733,9 @@ def record_merge(
     data = json.loads(request.body)
     old_model_ids = data['old_record_ids']
     new_record_data = data['new_record_data'] if 'new_record_data' in data else None
+
+    if old_model_ids is None or len(old_model_ids) < 1:
+        return http.HttpResponseBadRequest('There were no old record IDs given to be replaced by the new ID.')
     
     background = True
     if 'background' in data:


### PR DESCRIPTION
Add a guard clause to handle the case where no old_model_ids are given to the record merging API request.  The back-end should respond with an error explaining the need to include old record IDs.  This PR resolves issue-3857 where `old_model_ids=[]` caused issues when sent in the record merging request.  Further investigation might needed to determine how a situation on the front-end was formed so that a request was made to the back-end without 