### PR TITLE
Remove saveblockers when -to-many relationship is removed when merging

### DIFF
--- a/specifyweb/frontend/js_src/lib/components/Merging/CompareSubView.tsx
+++ b/specifyweb/frontend/js_src/lib/components/Merging/CompareSubView.tsx
@@ -218,9 +218,10 @@ function MergeDialog({
                   : undefined
               }
               resources={children.map((record) => record[index])}
-              onRemove={(): void =>
-                setMergedRecords(removeItem(mergedRecords, index))
-              }
+              onRemove={(): void => {
+                mergedRecords[index].destroy();
+                setMergedRecords(removeItem(mergedRecords, index));
+              }}
               onSlide={(columnIndex, direction): void => {
                 if (columnIndex === 0)
                   setMergedRecords(moveItem(mergedRecords, index, direction));


### PR DESCRIPTION
Fixes #3872 

> This issue occurred whenever a saveblocker was added to the dependent resource (in this case, ordinal and agent are required for an AgentAttachment).
> As soon as the AgentAttachment resource is created, it adds the saveblockers for all of the required fields.
> To handle -to-many resources, we create a list (array) based off of the resources in Backbone's internal array for that collection.
> 
> The trash icon just removed the resource from the array we created.
> We have to tell Backbone that we are deleting the Resource we created as well, which will remove the saveBlockers.

https://github.com/specify/specify7/issues/3872#issuecomment-1659355496

TO TEST: 
- Open up a -to-many relationship Subview in the Merging Dialog
- Get the record in a state where it has saveBlockers
  - An easy method, and the one showcased in https://github.com/specify/specify7/issues/3872#issue-1829828940 is to leave a required field blank
- Press the trash icon in the Subview to remove the record
- The Agent record should be able to be merged, and the subview button shouldn't be red/invalid