### PR TITLE
Use proper function scoping for Collections of resources

### DIFF
--- a/specifyweb/frontend/js_src/lib/components/DataModel/collectionApi.js
+++ b/specifyweb/frontend/js_src/lib/components/DataModel/collectionApi.js
@@ -89,7 +89,7 @@ export const LazyCollection = Base.extend({
     this.filters = options.filters || {};
     this.domainfilter =
       Boolean(options.domainfilter) &&
-      this.model?.specifyModel.getScopingRelationship() !== undefined;
+      this.model?.specifyModel.getDirectScope() !== undefined;
   },
   url() {
     return `/api/specify/${this.model.specifyModel.name.toLowerCase()}/`;


### PR DESCRIPTION
Fixes #3901 

TO TEST:
Make sure the following behavior does not happen

> **To Reproduce**
> Steps to reproduce the behavior:
> 1. Create new pick list 
> 2. For type, select Entire Table or Field From Table
> 3. Try to select a table 
> 4. See error 

Make sure that you can create/view picklists of type Entire Table or Field From Table. 

Also do light testing of "-to-many" relationships (Like Collectors on Collecting Events, AccessionAgents on Accession, etc.)