### PR TITLE
Fix Merging Status in Merging Dialog

### DIFF
--- a/specifyweb/frontend/js_src/lib/components/Merging/Status.tsx
+++ b/specifyweb/frontend/js_src/lib/components/Merging/Status.tsx
@@ -70,11 +70,7 @@ export function Status({
   return (
     <Dialog
       buttons={
-        state.status === 'SUCCEEDED' ? (
-          <Button.Danger onClick={handleClose}>
-            {commonText.close()}
-          </Button.Danger>
-        ) : (
+        state.status === 'MERGING' ? (
           <Button.Danger
             onClick={(): void =>
               loading(
@@ -87,6 +83,10 @@ export function Status({
             }
           >
             {commonText.cancel()}
+          </Button.Danger>
+        ) : (
+          <Button.Danger onClick={handleClose}>
+            {commonText.close()}
           </Button.Danger>
         )
       }

--- a/specifyweb/frontend/js_src/lib/components/Merging/Status.tsx
+++ b/specifyweb/frontend/js_src/lib/components/Merging/Status.tsx
@@ -12,12 +12,13 @@ import { Label } from '../Atoms/Form';
 import { Progress } from '../Atoms';
 import { RemainingLoadingTime } from '../WorkBench/RemainingLoadingTime';
 import { commonText } from '../../localization/common';
+import { LocalizedString } from 'typesafe-i18n';
 
-const statusLocalization = {
-  FAILED: mergingText.mergeFailed(),
-  SUCCESS: mergingText.mergeSucceeded(),
-  PENDING: mergingText.mergePending(),
+const statusLocalization: { [STATE in MergeStatus]: LocalizedString } = {
   MERGING: mergingText.merging(),
+  ABORTED: mergingText.mergeFailed(),
+  FAILED: mergingText.mergeFailed(),
+  SUCCEEDED: mergingText.mergeSucceeded(),
 };
 
 export function Status({
@@ -69,7 +70,7 @@ export function Status({
   return (
     <Dialog
       buttons={
-        state.status === 'SUCCESS' ? (
+        state.status === 'SUCCEEDED' ? (
           <Button.Danger onClick={handleClose}>
             {commonText.close()}
           </Button.Danger>

--- a/specifyweb/frontend/js_src/lib/components/Merging/types.ts
+++ b/specifyweb/frontend/js_src/lib/components/Merging/types.ts
@@ -1,4 +1,4 @@
-export type MergeStatus = 'FAILED' | 'MERGING' | 'PENDING' | 'SUCCESS';
+export type MergeStatus = 'FAILED' | 'MERGING' | 'ABORTED' | 'SUCCEEDED';
 export type StatusState = {
   readonly status: MergeStatus;
   readonly total: number;
@@ -6,7 +6,7 @@ export type StatusState = {
 };
 
 export const initialStatusState: StatusState = {
-  status: 'PENDING',
+  status: 'MERGING',
   total: 0,
   current: 0,
 };

--- a/specifyweb/specify/views.py
+++ b/specifyweb/specify/views.py
@@ -925,7 +925,7 @@ def merging_status(request, merge_id: int) -> http.HttpResponse:
 
     result = record_merge_task.AsyncResult(merge.taskid)
     status = {
-        'taskstatus': result.state,
+        'taskstatus': merge.mergingstatus,
         'taskprogress': result.info if isinstance(result.info, dict) else repr(result.info),
         'taskid': merge.taskid
     }


### PR DESCRIPTION
> > However, it will tell you success but then send a fail notification
> > https://drive.google.com/file/d/1zehhB45CYmOHkdRnEZ_vK3JtxUz90NCz/view?usp=sharing (drive for privacy)
> 
> This is a backend-related problem. The backend endoint for getting the merge status always states the merge is a success. Should be fixed if we fix that endpoint

From https://github.com/specify/specify7/pull/3864#issuecomment-1677420435

The `/merge/status/` endpoint was always returning SUCCESS for the merge status, even when it had failed. 
Since the Celery task status is not getting properly updated, I am using the `mergingstatus` attribute on the SpMerging object instead. 

TO TEST:
- Perform a merge that will fail
- The header of the dialog should show "Merge Failed" instead of "Merge Success"