### PR TITLE
Restore slider to fictitious record set when adding new records

### DIFF
--- a/specifyweb/frontend/js_src/lib/components/FormSliders/RecordSelectorFromIds.tsx
+++ b/specifyweb/frontend/js_src/lib/components/FormSliders/RecordSelectorFromIds.tsx
@@ -38,7 +38,7 @@ export function RecordSelectorFromIds<SCHEMA extends AnySchema>({
   isDependent,
   mode,
   canRemove = true,
-  totalCount = ids.length,
+  totalCount = ids.length + (typeof newResource === 'object' ? 1 : 0),
   isLoading: isExternalLoading = false,
   isInRecordSet = false,
   onClose: handleClose,
@@ -98,7 +98,7 @@ export function RecordSelectorFromIds<SCHEMA extends AnySchema>({
   );
   const index =
     typeof newResource === 'object'
-      ? totalCount
+      ? totalCount - 1
       : Math.min(rawIndex, totalCount - 1);
 
   const currentResource = newResource ?? records[index];


### PR DESCRIPTION
Fixes #3903 
Fixes #3706 

- - - 

Alongside testing the issue, please do general testing of record sets! 
This includes things like:
- Fictitious Recordsets in DataEntry
- Fictitious Recordsets via Browse in Forms from the Query Builder
- Actual Recordsets

Particularly test cases involving adding/removing records. 