### PR TITLE
Remove taxa stats, and kill requests for add stat dialog

### DIFF
--- a/specifyweb/frontend/js_src/lib/components/Statistics/AddStatDialog.tsx
+++ b/specifyweb/frontend/js_src/lib/components/Statistics/AddStatDialog.tsx
@@ -23,6 +23,7 @@ import type {
   StatFormatterSpec,
   StatLayout,
 } from './types';
+import { cleanThrottledPromises } from '../../utils/ajax/throttledPromise';
 
 export function AddStatDialog({
   defaultStatsAddLeft,
@@ -54,6 +55,7 @@ export function AddStatDialog({
   const [isCreating, setIsCreating, unsetIsCreating] = useBooleanState(false);
   React.useLayoutEffect(() => {
     handleLoadInitial();
+    return cleanThrottledPromises;
   }, []);
   return isCreating ? (
     <QueryTablesWrapper

--- a/specifyweb/frontend/js_src/lib/components/Statistics/StatsSpec.tsx
+++ b/specifyweb/frontend/js_src/lib/components/Statistics/StatsSpec.tsx
@@ -196,7 +196,8 @@ export const statsSpec: StatsSpec = {
             },
           },
         },
-      },
+      } /*
+      FIXME: Renable this when optimized query plan has been merged. Also climb the tree before renabling.
       taxonsRepresented: {
         label: statsText.taxonRepresented(),
         items: {
@@ -253,7 +254,7 @@ export const statsSpec: StatsSpec = {
             },
           },
         },
-      },
+      },*/,
 
       // eslint-disable-next-line @typescript-eslint/naming-convention
       locality_geography: {


### PR DESCRIPTION
Removes the taxa stats - so any future stats page won't have "Taxa represented" category.

Also kills the not needed network requests when user closes add stats dialog, but some requests were queued.

TEST 1:
1. The current stat pages (created before this) should work fine - they should just have no items in the category

TEST 2
1. Open networks tab for testing second change. 
2. Use a big database (herb will do). Remove all stats (by deleting categories).
3. Click on 'Add' in Edit Mode. 
4. You should see network requests being made in networks tab. Close the add stats dialog. In v7.9-dev, some requests would still be made (it would say ephemeral). In this branch, they won't.