### PR TITLE
Removes geo stats

### DIFF
--- a/specifyweb/frontend/js_src/lib/components/Preferences/CollectionDefinitions.tsx
+++ b/specifyweb/frontend/js_src/lib/components/Preferences/CollectionDefinitions.tsx
@@ -25,7 +25,7 @@ export const collectionPreferenceDefinitions = {
             renderer: f.never,
             container: 'label',
           }),
-          showTotal: defineItem<boolean>({
+          showPreparationsTotal: defineItem<boolean>({
             title: 'Defines if preparation stats include total',
             requiresReload: false,
             visible: false,

--- a/specifyweb/frontend/js_src/lib/components/Preferences/CollectionDefinitions.tsx
+++ b/specifyweb/frontend/js_src/lib/components/Preferences/CollectionDefinitions.tsx
@@ -29,7 +29,7 @@ export const collectionPreferenceDefinitions = {
             title: 'Defines if preparation stats include total',
             requiresReload: false,
             visible: false,
-            defaultValue: false,
+            defaultValue: true,
             renderer: f.never,
             container: 'label',
             type: 'java.lang.Boolean',

--- a/specifyweb/frontend/js_src/lib/components/Statistics/StatsResult.tsx
+++ b/specifyweb/frontend/js_src/lib/components/Statistics/StatsResult.tsx
@@ -70,9 +70,13 @@ export function StatsResult({
       ) : (
         <li className="flex gap-2">
           <Button.LikeLink className="flex-1" onClick={handleClickResolved}>
-            <span className="self-start" style={{ wordBreak: "break-word" }}>{label}</span>
+            <span className="self-start" style={{ wordBreak: 'break-word' }}>
+              {label}
+            </span>
             <span className="-ml-2 flex-1" />
-            <span className="self-start">{value ?? commonText.loading()}</span>
+            <span className="min-w-fit self-start">
+              {value ?? commonText.loading()}
+            </span>
           </Button.LikeLink>
         </li>
       )}

--- a/specifyweb/frontend/js_src/lib/components/Statistics/StatsSpec.tsx
+++ b/specifyweb/frontend/js_src/lib/components/Statistics/StatsSpec.tsx
@@ -5,12 +5,7 @@ import { ensure, filterArray } from '../../utils/types';
 import { formatNumber } from '../Atoms/Internationalization';
 import { userInformation } from '../InitialContext/userInformation';
 import { queryFieldFilters } from '../QueryBuilder/FieldFilter';
-import { flippedSortTypes } from '../QueryBuilder/helpers';
-import {
-  anyTreeRank,
-  formattedEntry,
-  formatTreeRank,
-} from '../WbPlanView/mappingHelpers';
+import { formattedEntry } from '../WbPlanView/mappingHelpers';
 import { generateStatUrl } from './hooks';
 import type {
   BackEndStat,
@@ -124,7 +119,6 @@ export const statsSpec: StatsSpec = {
                   },
                   { path: 'preptype.name', isDisplay: true },
                 ],
-                isDistinct: false,
               },
             },
           },
@@ -284,7 +278,6 @@ export const statsSpec: StatsSpec = {
                     operStart: queryFieldFilters.any.id,
                   },
                 ],
-                isDistinct: true,
               },
             },
           },
@@ -336,7 +329,7 @@ export const statsSpec: StatsSpec = {
           },
         },
       },
-
+      /*
       geographiesRepresented: {
         label: statsText.geographiesRepresented(),
         items: {
@@ -389,7 +382,7 @@ export const statsSpec: StatsSpec = {
           },
         },
       },
-
+*/
       // eslint-disable-next-line @typescript-eslint/naming-convention
       type_specimens: {
         label: statsText.typeSpecimens(),

--- a/specifyweb/frontend/js_src/lib/components/Statistics/StatsSpec.tsx
+++ b/specifyweb/frontend/js_src/lib/components/Statistics/StatsSpec.tsx
@@ -89,7 +89,7 @@ export const statsSpec: StatsSpec = {
               type: 'BackEndStat',
               pathToValue: undefined,
               formatterGenerator:
-                ({ showTotal }) =>
+                ({ showPreparationsTotal }) =>
                 (
                   prep:
                     | {
@@ -100,7 +100,7 @@ export const statsSpec: StatsSpec = {
                 ) =>
                   prep === undefined
                     ? undefined
-                    : showTotal
+                    : showPreparationsTotal
                     ? `${formatNumber(prep.lots)} / ${formatNumber(prep.total)}`
                     : formatNumber(prep.lots),
 

--- a/specifyweb/frontend/js_src/lib/components/Statistics/StatsSpec.tsx
+++ b/specifyweb/frontend/js_src/lib/components/Statistics/StatsSpec.tsx
@@ -330,6 +330,7 @@ export const statsSpec: StatsSpec = {
         },
       },
       /*
+      FIXME: Renable this when optimized query plan has been merged. Also climb the tree before renabling.
       geographiesRepresented: {
         label: statsText.geographiesRepresented(),
         items: {

--- a/specifyweb/frontend/js_src/lib/components/Statistics/__tests__/layout.tests.ts
+++ b/specifyweb/frontend/js_src/lib/components/Statistics/__tests__/layout.tests.ts
@@ -43,7 +43,7 @@ export const statsSpecTest: StatsSpec = {
               type: 'BackEndStat',
               pathToValue: undefined,
               formatterGenerator:
-                ({ showTotal }) =>
+                ({ showPreparationsTotal }) =>
                 (
                   prep:
                     | {
@@ -54,7 +54,7 @@ export const statsSpecTest: StatsSpec = {
                 ) =>
                   prep === undefined
                     ? undefined
-                    : showTotal
+                    : showPreparationsTotal
                     ? `${formatNumber(prep.lots)} / ${formatNumber(prep.total)}`
                     : formatNumber(prep.lots),
             },

--- a/specifyweb/frontend/js_src/lib/components/Statistics/index.tsx
+++ b/specifyweb/frontend/js_src/lib/components/Statistics/index.tsx
@@ -52,6 +52,7 @@ import type {
   CustomStat,
   DefaultStat,
   DynamicQuerySpec,
+  StatFormatterSpec,
   StatLayout,
 } from './types';
 
@@ -123,13 +124,16 @@ function ProtectedStatsPage(): JSX.Element | null {
     [setLocalPersonalLayout, setPersonalLayout]
   );
 
-  const [showTotal] = collectionPreferences.use(
+  const [showPreparationsTotal] = collectionPreferences.use(
     'statistics',
     'appearance',
-    'showTotal'
+    'showPreparationsTotal'
   );
 
-  const formatterSpec = React.useMemo(() => ({ showTotal }), [showTotal]);
+  const formatterSpec = React.useMemo<StatFormatterSpec>(
+    () => ({ showPreparationsTotal }),
+    [showPreparationsTotal]
+  );
   const [defaultLayout, setDefaultLayout] = React.useState<
     RA<StatLayout> | undefined
   >(undefined);

--- a/specifyweb/frontend/js_src/lib/components/Statistics/types.ts
+++ b/specifyweb/frontend/js_src/lib/components/Statistics/types.ts
@@ -71,7 +71,7 @@ export type QueryBuilderStat = State<
 export type BackendStatsResult = IR<any>;
 
 export type StatFormatterSpec = {
-  readonly showTotal: boolean;
+  readonly showPreparationsTotal: boolean;
 };
 
 export type StatFormatterGenerator = (


### PR DESCRIPTION
https://github.com/specify/specify7/pull/3948#issue-1867589353

Removes geography represented stats (like https://github.com/specify/specify7/pull/3926)

To test:

Nothing should crash because of this. Geo represented stats should just be absent from their category