### PR TITLE
Fix refresh stopping other items from loading

### DIFF
--- a/specifyweb/frontend/js_src/lib/components/Statistics/index.tsx
+++ b/specifyweb/frontend/js_src/lib/components/Statistics/index.tsx
@@ -485,7 +485,7 @@ function ProtectedStatsPage(): JSX.Element | null {
   );
 
   const refreshPage = () => {
-    cleanThrottledPromises();
+    cleanThrottledPromises(false);
     setCurrentLayout((layout) =>
       layout === undefined
         ? undefined

--- a/specifyweb/frontend/js_src/lib/utils/ajax/throttledPromise.ts
+++ b/specifyweb/frontend/js_src/lib/utils/ajax/throttledPromise.ts
@@ -10,8 +10,8 @@ const currentRequestsGenerator = <T>(): WritableArray<PromiseWithSpec<T>> => [];
 
 let maybeFulfilled: WritableArray<KillablePromise<any>> = [];
 
-export const cleanThrottledPromises = (killPromise = true): void => {
-  if (killPromise) maybeFulfilled.forEach((promise) => promise.killPromise());
+export const cleanThrottledPromises = (killPromises = true): void => {
+  if (killPromises) maybeFulfilled.forEach((promise) => promise.killPromise());
   maybeFulfilled = [];
   /*
    * Since the kill promise is already supplied, the promises will resolve within a work loop.

--- a/specifyweb/frontend/js_src/lib/utils/ajax/throttledPromise.ts
+++ b/specifyweb/frontend/js_src/lib/utils/ajax/throttledPromise.ts
@@ -10,8 +10,8 @@ const currentRequestsGenerator = <T>(): WritableArray<PromiseWithSpec<T>> => [];
 
 let maybeFulfilled: WritableArray<KillablePromise<any>> = [];
 
-export const cleanThrottledPromises = (): void => {
-  maybeFulfilled.forEach((promise) => promise.killPromise());
+export const cleanThrottledPromises = (killPromise = true): void => {
+  if (killPromise) maybeFulfilled.forEach((promise) => promise.killPromise());
   maybeFulfilled = [];
   /*
    * Since the kill promise is already supplied, the promises will resolve within a work loop.


### PR DESCRIPTION
As part of performance improvements, the requests were stopped when user navigates away from stats page. The same logic was incorrectly used for refresh. So, clicking refresh multiple times, cleans up all the requests from the previous click - which caused the items still waiting in queue to never get loaded. 