### PR TITLE
Don't pass empty string to uniqueIn when scope undefined

### DIFF
--- a/specifyweb/frontend/js_src/lib/components/DataModel/businessRules.ts
+++ b/specifyweb/frontend/js_src/lib/components/DataModel/businessRules.ts
@@ -167,7 +167,9 @@ export class BusinessRuleManager<SCHEMA extends AnySchema> {
           scope = uniqueRule.field;
         }
         return this.uniqueIn(
-          ((scope ?? '') as string).toLowerCase(),
+          typeof scope === 'string'
+            ? scope.toLowerCase()
+            : (scope as undefined),
           fieldNames
         );
       }


### PR DESCRIPTION
Fixes #3953 
As discovered by @CarolineDenis, the issue was that I was incorrectly casting an undefined `scope` value to an empty string when it is undefined and did not implement any logic to handle that case. 
Thus, when Specify tried to get the field with value ` `, it caused the console warning  and returned undefined. 

#3953 should have only occurred in cases where a field should be unique at a database level:
  - Collectingevent uniqueIdentifier
  - CollectionObject uniqueIdentifier
  - Institution name
  - Locality uniqueIdentifier
  - Permit permitNumber
  - SpAppResourceData spAppResource
  - Specifyuser name
 
 TO TEST:
Navigate to a form which has one of the above uniqueness rules and change a value in the mentioned field. There should be no warning in the console 