### PR TITLE
Don't clone fields unique to database

### DIFF
--- a/specifyweb/frontend/js_src/lib/components/DataModel/__tests__/resource.test.ts
+++ b/specifyweb/frontend/js_src/lib/components/DataModel/__tests__/resource.test.ts
@@ -276,6 +276,8 @@ describe('getUniqueFields', () => {
     ]));
   test('AccessionAgent', () =>
     expect(getUniqueFields(schema.models.AccessionAgent)).toEqual([
+      'role',
+      'agent',
       'timestampCreated',
       'version',
       'timestampModified',

--- a/specifyweb/frontend/js_src/lib/components/DataModel/businessRules.ts
+++ b/specifyweb/frontend/js_src/lib/components/DataModel/businessRules.ts
@@ -29,9 +29,13 @@ export class BusinessRuleManager<SCHEMA extends AnySchema> {
   // eslint-disable-next-line functional/prefer-readonly-type
   public pendingPromise: Promise<BusinessRuleResult | undefined> =
     Promise.resolve(undefined);
+
+  // eslint-disable-next-line functional/prefer-readonly-type
   private fieldChangePromises: {
     [key: string]: ResolvablePromise<string>;
   } = {};
+
+  // eslint-disable-next-line functional/prefer-readonly-type
   private watchers: { [key: string]: () => void } = {};
 
   public constructor(resource: SpecifyResource<SCHEMA>) {

--- a/specifyweb/frontend/js_src/lib/components/DataModel/resource.ts
+++ b/specifyweb/frontend/js_src/lib/components/DataModel/resource.ts
@@ -270,7 +270,8 @@ export const getUniqueFields = (model: SpecifyModel): RA<string> =>
     ...Object.entries(businessRuleDefs[model.name]?.uniqueIn ?? {})
       .filter(
         ([_fieldName, uniquenessRules]) =>
-          uniquenessRules in schema.domainLevelIds
+          uniquenessRules in schema.domainLevelIds ||
+          uniquenessRules === undefined
       )
       .map(([fieldName]) => model.strictGetField(fieldName).name),
     /*

--- a/specifyweb/frontend/js_src/lib/components/DataModel/resource.ts
+++ b/specifyweb/frontend/js_src/lib/components/DataModel/resource.ts
@@ -268,11 +268,6 @@ const uniqueFields = [
 export const getUniqueFields = (model: SpecifyModel): RA<string> =>
   f.unique([
     ...Object.entries(businessRuleDefs[model.name]?.uniqueIn ?? {})
-      .filter(
-        ([_fieldName, uniquenessRules]) =>
-          uniquenessRules in schema.domainLevelIds ||
-          uniquenessRules === undefined
-      )
       .map(([fieldName]) => model.strictGetField(fieldName).name),
     /*
      * Each attachment is assumed to refer to a unique attachment file

--- a/specifyweb/frontend/js_src/lib/components/Merging/Header.tsx
+++ b/specifyweb/frontend/js_src/lib/components/Merging/Header.tsx
@@ -213,6 +213,11 @@ function RecordPreview({
             void resourceEvents.trigger('deleted', resource)
           }
           onSaved={undefined}
+          onSaving={(unsetUnloadProtect): false => {
+            unsetUnloadProtect();
+            handleClose();
+            return false;
+          }}
         />
       )}
     </td>

--- a/specifyweb/frontend/js_src/lib/components/Merging/Status.tsx
+++ b/specifyweb/frontend/js_src/lib/components/Merging/Status.tsx
@@ -10,9 +10,11 @@ import { ping } from '../../utils/ajax/ping';
 import { mergingText } from '../../localization/merging';
 import { Label } from '../Atoms/Form';
 import { Progress } from '../Atoms';
-import { RemainingLoadingTime } from '../WorkBench/RemainingLoadingTime';
 import { commonText } from '../../localization/common';
 import { LocalizedString } from 'typesafe-i18n';
+import { dialogIcons } from '../Atoms/Icons';
+import { downloadFile } from '../Molecules/FilePicker';
+import { produceStackTrace } from '../Errors/stackTrace';
 
 const statusLocalization: { [STATE in MergeStatus]: LocalizedString } = {
   MERGING: mergingText.merging(),
@@ -30,6 +32,8 @@ export function Status({
 }): JSX.Element {
   const [state, setState] = React.useState<StatusState>(initialStatusState);
 
+  const [errorMessage, setErrorMessage] = React.useState<string>('');
+
   React.useEffect(() => {
     let destructorCalled = false;
     const fetchStatus = () =>
@@ -40,13 +44,18 @@ export function Status({
           readonly current: number;
         };
         readonly taskid: string;
+        readonly response: string;
       }>(`/api/specify/merge/status/${mergingId}/`, {
         // eslint-disable-next-line @typescript-eslint/naming-convention
         headers: { Accept: 'application/json' },
       })
         .then(
           ({
-            data: { taskstatus: taskStatus, taskprogress: taskProgress },
+            data: {
+              taskstatus: taskStatus,
+              taskprogress: taskProgress,
+              response: errorMessage,
+            },
           }) => {
             setState({
               status: taskStatus,
@@ -55,6 +64,9 @@ export function Status({
             });
             if (!destructorCalled)
               globalThis.setTimeout(fetchStatus, 2 * MILLISECONDS);
+            if (taskStatus === 'FAILED') {
+              setErrorMessage(errorMessage);
+            }
             return undefined;
           }
         )
@@ -67,10 +79,29 @@ export function Status({
 
   const loading = React.useContext(LoadingContext);
 
+  const percentage = Math.round((state.current / state.total) * 100);
+
   return (
     <Dialog
       buttons={
-        state.status === 'MERGING' ? (
+        state.status === 'FAILED' ? (
+          <>
+            <Button.Info
+              onClick={(): void =>
+                void downloadFile(
+                  `Merging ${mergingId} Crash Report - ${new Date().toJSON()}.txt`,
+                  produceStackTrace(errorMessage)
+                )
+              }
+            >
+              {commonText.downloadErrorMessage()}
+            </Button.Info>
+            <span className="-ml-4 flex-1" />
+            <Button.Danger onClick={handleClose}>
+              {commonText.close()}
+            </Button.Danger>
+          </>
+        ) : state.status === 'MERGING' ? (
           <Button.Danger
             onClick={(): void =>
               loading(
@@ -85,29 +116,30 @@ export function Status({
             {commonText.cancel()}
           </Button.Danger>
         ) : (
-          <Button.Danger onClick={handleClose}>
-            {commonText.close()}
-          </Button.Danger>
+          <Button.Info onClick={handleClose}>{commonText.close()}</Button.Info>
         )
       }
       className={{ container: dialogClassNames.narrowContainer }}
       dimensionsKey="merging-progress"
       header={statusLocalization[state.status]}
       onClose={undefined}
+      icon={
+        state.status === 'SUCCEEDED' ? dialogIcons.success : dialogIcons.error
+      }
     >
       <Label.Block aria-atomic aria-live="polite" className="gap-2">
         <div className="flex flex-col gap-2">
           {state.status === 'MERGING' && (
             <>
               <Progress max={state.total} value={state.current} />
-              <RemainingLoadingTime
-                current={state.current}
-                total={state.total}
-              />
+              {percentage < 100 && <p>{percentage}%</p>}
             </>
           )}
         </div>
       </Label.Block>
+      {state.status === 'FAILED' ? (
+        <p>{mergingText.mergingWentWrong()}</p>
+      ) : null}
     </Dialog>
   );
 }

--- a/specifyweb/frontend/js_src/lib/components/Merging/index.tsx
+++ b/specifyweb/frontend/js_src/lib/components/Merging/index.tsx
@@ -40,6 +40,7 @@ import { CompareRecords } from './Compare';
 import { Status } from './Status';
 import { InvalidMergeRecordsDialog } from './InvalidMergeRecords';
 import { recordMergingTableSpec } from './definitions';
+import { icons } from '../Atoms/Icons';
 
 export const mergingQueryParameter = 'records';
 
@@ -430,6 +431,7 @@ export function MergeDialogContainer({
       // Disable gradient because table headers have solid backgrounds
       specialMode="noGradient"
       onClose={handleClose}
+      icon={icons.cog}
     >
       {children}
     </Dialog>

--- a/specifyweb/frontend/js_src/lib/localization/merging.ts
+++ b/specifyweb/frontend/js_src/lib/localization/merging.ts
@@ -107,7 +107,7 @@ export const mergingText = createDictionary({
   retryMerge: {
     'en-us': 'Retry merge.',
   },
-  references: {
-    'en-us': 'references',
+  mergingWentWrong: {
+    'en-us': 'Something went wrong during the merging process.',
   },
 } as const);

--- a/specifyweb/notifications/migrations/0003_spmerging.py
+++ b/specifyweb/notifications/migrations/0003_spmerging.py
@@ -19,6 +19,7 @@ class Migration(migrations.Migration):
                 ('name', models.CharField(max_length=256)),
                 ('taskid', models.CharField(max_length=256)),
                 ('mergingstatus', models.CharField(max_length=256)),
+                ('response', models.TextField()),
                 ('table', models.CharField(max_length=256)),
                 ('newrecordid', models.IntegerField(null=True)),
                 ('newrecordata', models.JSONField(null=True)),

--- a/specifyweb/notifications/models.py
+++ b/specifyweb/notifications/models.py
@@ -17,6 +17,7 @@ class Spmerging(models.Model):
     name = models.CharField(max_length=256) 
     taskid = models.CharField(max_length=256) 
     mergingstatus = models.CharField(max_length=256)
+    response = models.TextField()
     table = models.CharField(max_length=256)
     newrecordid = models.IntegerField(null=True)
     newrecordata = models.JSONField(null=True)

--- a/specifyweb/specify/schema.py
+++ b/specifyweb/specify/schema.py
@@ -55,7 +55,7 @@ def base_schema(title="Specify 7 API", description="") -> Dict:
         },
         "externalDocs": {
             "description": "How to use specifyweb API as a generic webservice",
-            "url": "https://github.com/specify/specify7/wiki/Api-Demo",
+            "url": "https://github.com/specify/specify7/wiki/API-Documentation-Demo",
         },
         "servers": [
             {

--- a/specifyweb/specify/views.py
+++ b/specifyweb/specify/views.py
@@ -18,6 +18,7 @@ from django.db.models import Q
 from django.db.models.deletion import Collector
 from django.views.decorators.cache import cache_control
 from django.views.decorators.http import require_http_methods, require_POST, require_GET
+from django.db.models.deletion import ProtectedError
 
 from specifyweb.businessrules.exceptions import BusinessRuleException
 from specifyweb.permissions.permissions import PermissionTarget, \
@@ -513,13 +514,11 @@ def record_merge_fx(model_name: str, old_model_ids: List[int], new_model_id: int
         if model_name.lower() in MERGING_OPTIMIZATION_TABLES.keys() and \
             table_name.lower() in MERGING_OPTIMIZATION_TABLES[model_name.lower()]:
             for field_name in MERGING_OPTIMIZATION_FIELDS[(model_name.lower(), table_name.lower())]:
-                query = Q(**{field_name_id: old_model_ids[0]})
-                progress_count = 1
+                query = Q(**{field_name: old_model_ids[0]})
                 for old_model_id in old_model_ids[1:]:
-                    query.add(Q(**{field_name_id: old_model_id}), Q.OR)
-                    progress_count += 1
-                foreign_model.objects.filter(query).update(**{field_name_id: new_model_id})
-                progress(progress_count, 0) if progress is not None else None
+                    query.add(Q(**{field_name: old_model_id}), Q.OR)
+                foreign_model.objects.filter(query).update(**{field_name: new_model_id})
+                progress(1, 0) if progress is not None else None
             continue
 
         apply_order = add_ordering_to_key(table_name.lower().title())
@@ -531,6 +530,8 @@ def record_merge_fx(model_name: str, old_model_ids: List[int], new_model_id: int
         key_function = lambda x: apply_order(x, new_key_fields)
 
         for col in [c[1] for c in column_names]:
+            progress(1, 0) if progress is not None else None
+            
             # Determine the field name to filter on
             field_name = col.lower()
             field_name_id = f'{field_name}_id'
@@ -547,7 +548,15 @@ def record_merge_fx(model_name: str, old_model_ids: List[int], new_model_id: int
                 # If it is a dependent field, delete the object instead of updating it.
                 # This is done in order to avoid duplicates
                 if table_name in dependant_table_names:
-                    obj.delete()
+                    # Note: need to handle case where deletion throws error because it is referenced my other records
+                    try:
+                        obj.delete()
+                    except ProtectedError as e:
+                        # NOTE: Handle ProtectedError in the future.
+                        # EXAMPLE: ProtectedError: ("Cannot delete some instances of model 'Address' because they are 
+                        # referenced through protected foreign keys:
+                        # 'Division.address'.", {<Division: Division object (2)>})
+                        raise
                     continue
 
                 # Set new value for the field
@@ -586,7 +595,7 @@ def record_merge_fx(model_name: str, old_model_ids: List[int], new_model_id: int
                     old_record, new_record = sorted([old_record, new_record], key=key_function)
 
                     # Make a recursive call to record_merge to resolve duplication error
-                    response = record_merge_fx(table_name, [old_record.pk], new_record.pk)
+                    response = record_merge_fx(table_name, [old_record.pk], new_record.pk, progress)
                     if old_record.pk != obj.pk:
                         update_record(new_record)
                     return response
@@ -596,7 +605,6 @@ def record_merge_fx(model_name: str, old_model_ids: List[int], new_model_id: int
                         # TODO: Handle case where this obj has been deleted from recursive merge
                         with transaction.atomic():
                             record.save()
-                            progress(1, 0) if progress is not None else None
                     except (IntegrityError, BusinessRuleException) as e:
                         # Catch duplicate error and recursively run record merge
                         rows_to_lock = None
@@ -625,12 +633,17 @@ def record_merge_fx(model_name: str, old_model_ids: List[int], new_model_id: int
     has_new_record_info = new_record_info is not None
     if has_new_record_info and 'new_record_data' in new_record_info and \
             new_record_info['new_record_data'] is not None:
-        obj = api.put_resource(new_record_info['collection'],
-                               new_record_info['specify_user'],
-                               model_name,
-                               new_model_id,
-                               new_record_info['version'],
-                               new_record_info['new_record_data'])
+        try:
+            obj = api.put_resource(new_record_info['collection'],
+                                   new_record_info['specify_user'],
+                                   model_name,
+                                   new_model_id,
+                                   new_record_info['version'],
+                                   new_record_info['new_record_data'])
+        except IntegrityError as e:
+            # NOTE: Handle IntegrityError Duplicate entry in the future.
+            # EXAMPLE: IntegrityError: (1062, "Duplicate entry '1-0' for key 'AgentID'")
+            raise
 
     # Return http response
     return http.HttpResponse('', status=204)
@@ -663,13 +676,16 @@ def record_merge_task(self, model_name: str, old_model_ids: List[int], new_model
         nonlocal current, total
         current += cur
         total += additional_total
+        if current > total:
+            current = total
         if not self.request.called_directly:
             self.update_state(state='MERGING', meta={'current': current, 'total': total})
 
     # Run the record merging function
     logger.info('Starting record merge')
 
-    response = resolve_record_merge_response(lambda: record_merge_fx(model_name, old_model_ids, int(new_model_id), progress, new_record_info))
+    response = resolve_record_merge_response(
+        lambda: record_merge_fx(model_name, old_model_ids, int(new_model_id), progress, new_record_info))
 
     logger.info('Finishing record merge')
 
@@ -682,6 +698,7 @@ def record_merge_task(self, model_name: str, old_model_ids: List[int], new_model
         self.update_state(state='SUCCEEDED', meta={'current': total, 'total': total})
         merge_record.mergingstatus = 'SUCCEEDED'
     
+    merge_record.response = response.content.decode()
     merge_record.save()
 
     # Create a message record to indicate the finishing status of the record merge
@@ -857,6 +874,17 @@ def record_merge(
         )
     return response
 
+
+CELERY_MERGE_STATUS_MAP = {
+    'PENDING': 'PENDING',
+    'STARTED': 'MERGING',
+    'SUCCESS': 'SUCCEEDED',
+    'FAILURE': 'FAILED',
+    'RETRY': 'MERGING',
+    'REVOKED': 'FAILED',
+    'REJECTED': 'FAILED'
+}
+
 @openapi(schema={
     'get': {
         "responses": {
@@ -914,17 +942,30 @@ def record_merge(
 })
 @require_GET
 def merging_status(request, merge_id: int) -> http.HttpResponse:
-    "Returns the merging status for the record merging celery tasks"
-    merge = Spmerging.objects.get(taskid=merge_id)
-    if merge is None:
+    """Returns the merging status for the record merging celery tasks"""
+    
+    # Try to get the merge object directly
+    try:
+        merge = Spmerging.objects.get(taskid=merge_id)
+    except Spmerging.DoesNotExist:
         return http.HttpResponseNotFound(f'The merge task id is not found: {merge_id}')
 
-    if merge.taskid is None:
-        return http.JsonResponse(None, safe=False)
+    task_status = merge.mergingstatus
+    task_progress = None
 
-    result = record_merge_task.AsyncResult(merge.taskid)
+    try:
+        result = record_merge_task.AsyncResult(merge.taskid)
+        task_progress = result.info if isinstance(result.info, dict) else repr(result.info)
+        
+        # Update task status if necessary
+        if result.state not in ['PENDING', 'STARTED', 'SUCCESS', 'RETRY']:
+            task_status = CELERY_MERGE_STATUS_MAP.get(result.state, task_status)
+    except Exception:
+        pass
+
     status = {
         'taskstatus': merge.mergingstatus,
+        'response': merge.response,
         'taskprogress': result.info if isinstance(result.info, dict) else repr(result.info),
         'taskid': merge.taskid
     }


### PR DESCRIPTION
Fixes #3960 

The following fields should not be carried over/cloned: 
> * Collectingevent uniqueIdentifier
> * CollectionObject uniqueIdentifier
> * Institution name
> * Locality uniqueIdentifier
> * Permit permitNumber
> * SpAppResourceData spAppResource
> * Specifyuser name

(Also, there was another issue in which global uniqueness rules were not working on the frontend. That fix should be included in #3962)