### PR TITLE
Fix insitituion being scoped to global

### DIFF
--- a/specifyweb/businessrules/tests/division.py
+++ b/specifyweb/businessrules/tests/division.py
@@ -8,7 +8,12 @@ class DivisionTests(ApiTests):
             institution=self.institution,
             name='foobar')
 
-        with self.assertRaises(BusinessRuleException):
+        with self.assertRaises(BusinessRuleException) as business_rule_exception:
             models.Division.objects.create(
                 institution=self.institution,
                 name='foobar')
+
+        naive_insitution = business_rule_exception.exception.args[1].get('parentField', None)
+        self.assertEquals(naive_insitution is not None and naive_insitution.lower() == 'institution', True)
+
+    

--- a/specifyweb/businessrules/uniqueness_rules.py
+++ b/specifyweb/businessrules/uniqueness_rules.py
@@ -57,8 +57,7 @@ def make_uniqueness_rule(model_name,
                            }
 
         if len(parent_fields) > 0:
-            error_message += ' in {}'.format(join_with_and(parent_fields)) \
-                if len(parent_fields) > 0 else ''
+            error_message += ' in {}'.format(join_with_and(parent_fields))
             response.update({
                 "parentField": ','.join(parent_fields),
                 "parentData": serialize_multiple_django(matchable, field_map, parent_fields)
@@ -162,7 +161,7 @@ def resolve_child_parent(field, rule_instance):
         parent.append(rule_instance['field'])
         child.extend(rule_instance['otherFields'])
     else:
-        if rule_instance is not None and rule_instance != 'institution':
+        if rule_instance is not None:
             parent.append(rule_instance)
     child.sort()
     return tuple(child), tuple(parent)

--- a/specifyweb/frontend/js_src/lib/components/DataModel/__tests__/businessRules.test.ts
+++ b/specifyweb/frontend/js_src/lib/components/DataModel/__tests__/businessRules.test.ts
@@ -50,7 +50,7 @@ describe('uniqueness rules assigned correctly', () => {
           "collection",
         ],
         "guid": [
-          "institution",
+          undefined,
         ],
         "uniqueIdentifier": [
           undefined,

--- a/specifyweb/frontend/js_src/lib/components/DataModel/uniquness_rules.json
+++ b/specifyweb/frontend/js_src/lib/components/DataModel/uniquness_rules.json
@@ -55,7 +55,7 @@
   "CollectionObject": {
     "catalogNumber": ["collection"],
     "uniqueIdentifier": [null],
-    "guid": ["institution"]
+    "guid": [null]
   },
   "Collector": {
     "agent": ["collectingevent"]


### PR DESCRIPTION
The uniqueness file in v7.9 originally defined guid as unique to institution, incorrectly. 

I made an incorrect change (scoping institution to global scope) when refactoring uniqueness rules to adjust that.

However, I'm unsure of a way to UI test this, but the related backend tests pass (which used to pass before due to my adjustment). I added a more strict unit test for this. 

Ideally, we could have tested this by creating a division in one institution, and then another division with the same name in another institution. The v7.9-dev wouldn't have allowed that, but this branch should.