### PR TITLE
Properly filter uniqueness rules which can be cloned

### DIFF
--- a/specifyweb/frontend/js_src/lib/components/DataModel/__tests__/resource.test.ts
+++ b/specifyweb/frontend/js_src/lib/components/DataModel/__tests__/resource.test.ts
@@ -276,8 +276,6 @@ describe('getUniqueFields', () => {
     ]));
   test('AccessionAgent', () =>
     expect(getUniqueFields(schema.models.AccessionAgent)).toEqual([
-      'role',
-      'agent',
       'timestampCreated',
       'version',
       'timestampModified',

--- a/specifyweb/frontend/js_src/lib/components/DataModel/resource.ts
+++ b/specifyweb/frontend/js_src/lib/components/DataModel/resource.ts
@@ -267,9 +267,19 @@ const uniqueFields = [
 
 export const getUniqueFields = (model: SpecifyModel): RA<string> =>
   f.unique([
-    ...Object.entries(businessRuleDefs[model.name]?.uniqueIn ?? {}).map(
-      ([fieldName]) => model.strictGetField(fieldName).name
-    ),
+    ...Object.entries(businessRuleDefs[model.name]?.uniqueIn ?? {})
+      .filter(
+        /*
+         * When cloning a resource, do not carry over the field which have
+         * uniqueness rules which are scoped to one of the institutional
+         * hierarchy tables or should be globally unique.
+         * All other uniqueness rules can be cloned
+         */
+        ([_field, uniquenessScope]) =>
+          uniquenessScope in schema.domainLevelIds ||
+          uniquenessScope === undefined
+      )
+      .map(([fieldName]) => model.strictGetField(fieldName).name),
     /*
      * Each attachment is assumed to refer to a unique attachment file
      * See https://github.com/specify/specify7/issues/1754#issuecomment-1157796585

--- a/specifyweb/frontend/js_src/lib/components/DataModel/resource.ts
+++ b/specifyweb/frontend/js_src/lib/components/DataModel/resource.ts
@@ -275,9 +275,13 @@ export const getUniqueFields = (model: SpecifyModel): RA<string> =>
          * hierarchy tables or should be globally unique.
          * All other uniqueness rules can be cloned
          */
-        ([_field, uniquenessScope]) =>
-          uniquenessScope in schema.domainLevelIds ||
-          uniquenessScope === undefined
+        ([_field, [uniquenessScope]]: [
+          string,
+          RA<string | undefined | { [field: string]: string | RA<string> }>
+        ]) =>
+          typeof uniquenessScope === 'string'
+            ? uniquenessScope in schema.domainLevelIds
+            : uniquenessScope === undefined
       )
       .map(([fieldName]) => model.strictGetField(fieldName).name),
     /*

--- a/specifyweb/frontend/js_src/lib/components/DataModel/resource.ts
+++ b/specifyweb/frontend/js_src/lib/components/DataModel/resource.ts
@@ -275,9 +275,9 @@ export const getUniqueFields = (model: SpecifyModel): RA<string> =>
          * hierarchy tables or should be globally unique.
          * All other uniqueness rules can be cloned
          */
-        ([_field, [uniquenessScope]]: [
+        ([_field, [uniquenessScope]]: readonly [
           string,
-          RA<string | undefined | { [field: string]: string | RA<string> }>
+          RA<Record<string, RA<string> | string> | string | undefined>
         ]) =>
           typeof uniquenessScope === 'string'
             ? uniquenessScope in schema.domainLevelIds


### PR DESCRIPTION
Fixes #3982 

#3982 was caused as a result of https://github.com/specify/specify7/pull/3963/commits/9a67d19fa2f4074e6c7b2f3a477445d9f428f8b8

From that commit, I made it so that Specify would not carry forward/clone _all_ fields which had a uniqueness rule. 
This is unintentional behavior. 

The fields with uniqueness rules scoped to one of the institutional hierarchies or globally should be the only fields whose values should _not_ be cloned/ carry forwarded. 

Here are all of the fields with uniqueness rules which **_WILL_** be included in a clone or carry forward:
| Table            | Field(s)        | Scope           |
|------------------|-----------------|-----------------|
| AccessionAgent   | role, agent     | accession       |
| AccessionAgent | role, agent | repositoryAgreement |
| Appraisal        | appraisalNumber | accession       |
| Author           | agent           | referenceWork   |
| Author           | orderNumber     | referenceWork   |
| BorrowAgent      | role, agent     | borrow          |
| Collector        | agent           | collectingEvent |
| Determiner       | agent           | determination   |
| DisposalAgent    | role, agent     | disposal        |
| Extractor        | agent           | dnaSequence     |
| FundingAgent     | agent           | collectingTrip  |
| GiftAgent        | role, agent     | gift            |
| GroupPerson      | member          | group           |
| LoanAgent        | role, agent     | loan            |
| LocalityCitation | referenceWork   | locality        |
| PcrPerson        | agent           | dnaSequence     |
| TaxonTreeDefItem | name            | treeDef         |
| TaxonTreeDefItem | title           | treeDef         |

Here are all the fields which **_WILL NOT_** be included in a clone or carry forward:
| Table               | Field(s)                  | Scope       |
|---------------------|---------------------------|-------------|
| Accession           | accessionNumber           | division    |
| Collection          | collectionName            | discipline  |
| Collection          | code                      | discipline  |
| CollectingEvent     | uniqueIdentifier          | [global]    |
| CollectionObject    | catalogNumber             | collection  |
| CollectionObject    | uniqueIdentifier          | [global]    |
| CollectionObject    | guid                      | [global]    |
| Discipline          | name                      | division    |
| Division            | name                      | institution |
| Gift                | giftNumber                | discipline  |
| Institution         | name                      | [global]    |
| Loan                | loanNumber                | discipline  |
| Locality            | uniqueIdentifier          | [global]    |
| Permit              | permitNumber              | [global]    |
| PickList            | name                      | collection  |
| PrepType            | name                      | collection  |
| RepositoryAgreement | repositoryAgreementNumber | division    |
| SpAppResourceData   | spAppResource             | [global]    |
| SpecifyUser         | name                      | [global]    |
| TaxonTreeDef        | name                      | discipline  |