### PR TITLE
Uses catalog numbers in type specimen stats

### DIFF
--- a/specifyweb/frontend/js_src/lib/components/Statistics/StatsSpec.tsx
+++ b/specifyweb/frontend/js_src/lib/components/Statistics/StatsSpec.tsx
@@ -60,18 +60,18 @@ export const statsSpec: StatsSpec = {
             spec: {
               type: 'QueryStat',
               querySpec: {
-                tableName: 'Determination',
+                tableName: 'CollectionObject',
                 fields: [
                   {
-                    path: formattedEntry,
+                    path: 'catalogNumber',
                   },
                   {
-                    path: 'typeStatusName',
-                    operStart: queryFieldFilters.equal.id,
+                    path: 'determinations.typeStatusName',
+                    operStart: queryFieldFilters.empty.id,
                     isNot: true,
                   },
                   {
-                    path: 'isCurrent',
+                    path: 'determinations.isCurrent',
                     operStart: queryFieldFilters.true.id,
                   },
                 ],
@@ -393,24 +393,24 @@ export const statsSpec: StatsSpec = {
             spec: {
               type: 'DynamicStat',
               dynamicQuerySpec: {
-                tableName: 'Determination',
+                tableName: 'CollectionObject',
                 fields: [
                   {
-                    path: 'isCurrent',
+                    path: 'determinations.isCurrent',
                     operStart: queryFieldFilters.true.id,
                     isDisplay: false,
                   },
                   {
                     isNot: true,
-                    path: 'typeStatusName',
+                    path: 'determinations.typeStatusName',
                     operStart: queryFieldFilters.empty.id,
                   },
                 ],
                 isDistinct: true,
               },
               querySpec: {
-                tableName: 'Determination',
-                fields: [{ path: formattedEntry }],
+                tableName: 'CollectionObject',
+                fields: [{ path: 'catalogNumber' }],
               },
             },
           },

--- a/specifyweb/frontend/js_src/lib/components/Statistics/StatsSpec.tsx
+++ b/specifyweb/frontend/js_src/lib/components/Statistics/StatsSpec.tsx
@@ -72,7 +72,7 @@ export const statsSpec: StatsSpec = {
                   },
                   {
                     path: 'determinations.isCurrent',
-                    operStart: queryFieldFilters.true.id,
+                    operStart: queryFieldFilters.trueOrNull.id,
                   },
                 ],
               },
@@ -397,7 +397,7 @@ export const statsSpec: StatsSpec = {
                 fields: [
                   {
                     path: 'determinations.isCurrent',
-                    operStart: queryFieldFilters.true.id,
+                    operStart: queryFieldFilters.trueOrNull.id,
                     isDisplay: false,
                   },
                   {

--- a/specifyweb/frontend/js_src/lib/components/Statistics/hooks.tsx
+++ b/specifyweb/frontend/js_src/lib/components/Statistics/hooks.tsx
@@ -276,7 +276,10 @@ export function resolveStatsSpec(
         tableName: statSpecItem.spec.dynamicQuerySpec.tableName,
         fields: appendDynamicPathToValue(item.pathToValue, [
           ...statSpecItem.spec.querySpec.fields,
-          ...statSpecItem.spec.dynamicQuerySpec.fields,
+          ...statSpecItem.spec.dynamicQuerySpec.fields.map((field) => ({
+            ...field,
+            isDisplay: true,
+          })),
         ]),
         isDistinct: statSpecItem.spec.querySpec.isDistinct,
       },
@@ -727,7 +730,7 @@ export function appendDynamicPathToValue(
     ...groupField,
     operStart: queryFieldFilters.equal.id,
     startValue: pathToValue.toString(),
-    isDisplay: false,
+    isDisplay: true,
     isNot: false,
   };
   return [...fields.slice(0, -1), startField];


### PR DESCRIPTION
To test:
Make sure the type specimen stats in the holdings category is 
![image](https://github.com/specify/specify7/assets/61122018/4324cc62-7352-4caf-9a3f-0a6349759822)

In the type specimen category, the stat query should be (depending on exact stat query)
![image](https://github.com/specify/specify7/assets/61122018/3f63acf1-3133-4e56-a31f-65943c12aab1)


