### PR TITLE
Hot fix for prevent deletion of asset server files

### DIFF
--- a/specifyweb/businessrules/attachment_rules.py
+++ b/specifyweb/businessrules/attachment_rules.py
@@ -42,7 +42,8 @@ def attachment_save(attachment):
 @orm_signal_handler('post_delete', 'Attachment')
 def attachment_deletion(attachment):
     from specifyweb.attachment_gw.views import delete_attachment_file
-    delete_attachment_file(attachment.attachmentlocation)
+    if attachment.attachmentlocation is not None:
+        delete_attachment_file(attachment.attachmentlocation)
 
 def get_attachee(jointable_inst):
     main_table_name = JOINTABLE_NAME_RE.match(jointable_inst.__class__.__name__).group(1)


### PR DESCRIPTION
There is a business rule that deletes files from the asset server. In case of agent merging, it deletes the files, but doesn't add it back - leading to loss of asset server files. 

The solution is to just set attachment location of the object to delete to null. This would prevent deletion from the asset server. If an error occurs, everything is rollbacked, so we don't care what we put in. 