### PR TITLE
Fix specifyuser not being taken as main agent

### DIFF
--- a/specifyweb/frontend/js_src/lib/components/Merging/index.tsx
+++ b/specifyweb/frontend/js_src/lib/components/Merging/index.tsx
@@ -206,7 +206,7 @@ function Merging({
        */
       Array.from(rawSpecifyResources).sort(
         multiSortFunction(
-          (resource) => resource.get('specifyUser'),
+          (resource) => resource.get('specifyUser') ?? '',
           true,
           (resource) => resource.get('timestampCreated')
         )


### PR DESCRIPTION
>       Array.from(rawSpecifyResources).sort(
>         multiSortFunction(
>           (resource) => resource.get('specifyUser'),
>           true,
>           (resource) => resource.get('timestampCreated')
>         )
>       )

The problem in above code is that `null < 'aaa'`  returns false. 