### PR TITLE
Do not automatically set ordernumber

### DIFF
--- a/specifyweb/frontend/js_src/lib/components/DataModel/businessRules.ts
+++ b/specifyweb/frontend/js_src/lib/components/DataModel/businessRules.ts
@@ -19,7 +19,7 @@ import { SaveBlockers } from './saveBlockers';
 import type { LiteralField, Relationship } from './specifyField';
 import type { Collection } from './specifyModel';
 import { initializeTreeRecord, treeBusinessRules } from './treeBusinessRules';
-import type { CollectionObjectAttachment, Collector } from './types';
+import type { CollectionObjectAttachment } from './types';
 
 export class BusinessRuleManager<SCHEMA extends AnySchema> {
   private readonly resource: SpecifyResource<SCHEMA>;

--- a/specifyweb/frontend/js_src/lib/components/DataModel/businessRules.ts
+++ b/specifyweb/frontend/js_src/lib/components/DataModel/businessRules.ts
@@ -72,13 +72,6 @@ export class BusinessRuleManager<SCHEMA extends AnySchema> {
         collection.indexOf(resource),
         { silent: true }
       );
-
-    if (resource.specifyModel.getField('orderNumber') !== undefined)
-      (resource as SpecifyResource<Collector>).set(
-        'orderNumber',
-        collection.indexOf(resource),
-        { silent: true }
-      );
     this.addPromise(
       this.invokeRule('onAdded', undefined, [resource, collection])
     );


### PR DESCRIPTION
From commit 8fbae55 first pushed to #3806, the frontend was modified to always set `orderNumber` and `ordinal` for fields which were added to BackBone collections. 

This differs from how the behavior is currently in `production` (which only sets the `ordinal` field automatically) 
https://github.com/specify/specify7/blob/922a61d22a30240cbb8578cb057ae14d6b72e6e6/specifyweb/frontend/js_src/lib/components/DataModel/businessRules.js#L75-L78

This difference causes a potential bug for AgentSpecialties and GroupPersons when they are being added to Agents and Groups (respectively) 
AgentSpecialty and GroupPerson have a database uniqueness constraint which state that `orderNumber` must be unique to their “parent” resource (see https://github.com/specify/specify7/issues/2924#issuecomment-1440638103)

For an example, here is the bug exhibited in `v7.9-dev` (does not throw an error on `production`):

[Screencast from 09-21-2023 10:04:42 AM.webm](https://github.com/specify/specify7/assets/64045831/63bad993-53ae-438f-b67b-4675511f2c2f)

This fix makes v7.9 follow the same behavior as production. 