### PR TITLE
Make docker build for arm64 in GitHub Actions workflow

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -49,6 +49,9 @@ jobs:
           echo "tags=${TAGS}" >> $GITHUB_OUTPUT
           echo "created=$(date -u +'%Y-%m-%dT%H:%M:%SZ')" >> $GITHUB_OUTPUT
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
 
@@ -87,3 +90,4 @@ jobs:
             org.opencontainers.image.created=${{ steps.prep.outputs.created }}
             org.opencontainers.image.revision=${{ github.sha }}
             org.opencontainers.image.licenses=${{ github.event.repository.license.spdx_id }}
+          platforms: linux/amd64,linux/arm64

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+kombu==5.2.4
 celery[redis]==5.2.7
 Django==3.2.15
 mysqlclient==2.1.1


### PR DESCRIPTION
For running efficiently on the AWS graviton processors, we need a docker image built for arm64 when pushing to DockerHub.  We already have docker buildx in the GitHub Actions workflow, we just need to specify the platforms.