### PR TITLE
fix(useAsyncState): Properly handle function returns

### DIFF
--- a/specifyweb/frontend/js_src/lib/hooks/useAsyncState.tsx
+++ b/specifyweb/frontend/js_src/lib/hooks/useAsyncState.tsx
@@ -46,7 +46,9 @@ export function useAsyncState<T>(
     setState(undefined);
 
     const promise = Promise.resolve(callback()).then((newState) =>
-      destructorCalled ? undefined : setState(newState)
+      destructorCalled
+        ? undefined
+        : setState(typeof newState === 'function' ? () => newState : newState)
     );
 
     if (loadingScreen) loading(promise);


### PR DESCRIPTION
We have been using useAsyncState hook a lot on the front-end for several years with little to no issues.
You can imagine my surprise today when I discovered bug in it - if your promise resolves to a function (or a React component, because react component is a function), rather than setting that function as the state value, it calls that function and sets the result of the function as state value (because that is how setState behaves in react when given a function)
Funny that we never encountered it before.

Typing is wrong in that case too so the typescript doesn't detect the bug