### PR TITLE
Issue-4172 query builder preference warning text

### DIFF
--- a/specifyweb/frontend/js_src/lib/components/Preferences/UserDefinitions.tsx
+++ b/specifyweb/frontend/js_src/lib/components/Preferences/UserDefinitions.tsx
@@ -1427,10 +1427,6 @@ export const userPreferenceDefinitions = {
             description: (
               <span>
                 {preferencesText.noRestrictionsModeQueryDescription()}
-                <br />
-                <span className="text-red-500">
-                  {preferencesText.noRestrictionsModeWarning()}
-                </span>
               </span>
             ),
             requiresReload: false,


### PR DESCRIPTION
Fixes Issue #4172. In this PR, I deleted the red text that was below the Query Builder's No Resreicitions Mode preference. To UX Test, make sure that "`no restctions mode`" does in fact still work and that there is no red text underneath the option in User Prefrences. 