### PR TITLE
Handle case in Date Range when all referencing records have NULL dates

### DIFF
--- a/specifyweb/frontend/js_src/lib/components/Forms/DateRange.tsx
+++ b/specifyweb/frontend/js_src/lib/components/Forms/DateRange.tsx
@@ -82,7 +82,7 @@ function useRange(
                   {
                     limit: 1,
                   }
-                ).then((rows) => rows[0]?.[1])
+                ).then((rows) => (rows.length === 0 ? null : rows[0][1]))
             )
           )
         ).then((rawDates) => {


### PR DESCRIPTION
Fixes #4239 

### Overview
The issue was concerning the Date Range component. 
More specifically, when the query to fetch the dates returned no results. 
 
As a refresher, date ranges in Specify can show whenever the delete blockers are displayed or needed for a -to-many relationship. 
This can appear:
- Within a dialog after the delete button is pressed on a resource with referencing records
- After pressing the `Linked Records` button on a specific "duplicate record" in the Record Merging interface. 

A simple example of the component when attempting to delete a Storage resource with referencing Preparation records:

![Screenshot from 2023-11-29 22-45-10](https://github.com/specify/specify7/assets/64045831/18ae163a-ee27-4eec-9019-57a0f5795759)
> :spiral_notepad:  Preparations use the _preparedDate_ field in the query to fetch the date ranges in the Query

In the case of https://github.com/specify/specify7/issues/4239#issue-2017796430, every referencing Preparation had a `NULL` preparedDate. 
If there a single referencing Preparation which had a non-null preparedDate, the error would not be thrown. 
This case is handled in production, but not on `xml-editor`

### Developer Notes
At a code level, the problem was occurring as a result of the following line: 
https://github.com/specify/specify7/blob/2624e73f6b37c8eec9ab079b310611a760378bbd/specifyweb/frontend/js_src/lib/components/Forms/DateRange.tsx#L81 

`rows` is the result of the query which is constructed to determine the date range. In both `production` and `xml-editor`, if the query returned no results (that is, if all referencing records have a NULL date value for the table's given dateFields), rows would equal an empty array. 
Because of the optional chaining operator, this would result in the promise returning `undefined`, as rows[0] would be undefined. 

This case was handled on production (filtering out undefined values): 
https://github.com/specify/specify7/blob/2624e73f6b37c8eec9ab079b310611a760378bbd/specifyweb/frontend/js_src/lib/components/Forms/DateRange.tsx#L85-L88

But not on `xml-editor`, and passing the undefined value directly to `parseAnyDate` (resulting in the error):
https://github.com/specify/specify7/blob/90a9a400cc4a8719ab6c47eaaf8e55293d387325/specifyweb/frontend/js_src/lib/components/Forms/DateRange.tsx#L89-L95

## Testing Instructions
Test the Date Range component in the following three cases for a -to-many relationship:

- All referencing records have a NULL date
- One referencing record has a non-null date
- At least two referencing records have different date values

An example of such a relationship is that many Preparations can reference a Storage. Thus, a Storage can be assigned to multiple Preparations in the application. If there is at least one referencing Preparation for a Storage record, a Delete Blocker-and thus Date Range Component- should be shown. 
As aforementioned, Preparations use `preparedDate` to calculate the Date Range. 