### PR TITLE
perf: improve TypeScript's typecheck performance

### DIFF
--- a/specifyweb/frontend/js_src/lib/components/Attachments/index.tsx
+++ b/specifyweb/frontend/js_src/lib/components/Attachments/index.tsx
@@ -20,7 +20,7 @@ import { className } from '../Atoms/className';
 import { Input, Label, Select } from '../Atoms/Form';
 import { DEFAULT_FETCH_LIMIT, fetchCollection } from '../DataModel/collection';
 import type { SerializedResource } from '../DataModel/helperTypes';
-import { getTable, tables } from '../DataModel/tables';
+import { genericTables, getTable, tables } from '../DataModel/tables';
 import type { Attachment, Tables } from '../DataModel/types';
 import { useMenuItem } from '../Header/MenuContext';
 import { Dialog } from '../Molecules/Dialog';
@@ -159,7 +159,7 @@ function Attachments({
               { tableId__isNull: 'true' }
             : filter.type === 'byTable'
             ? {
-                tableId: tables[filter.tableName].tableId,
+                tableId: genericTables[filter.tableName].tableId,
               }
             : allTablesWithAttachments().length ===
               tablesWithAttachments().length

--- a/specifyweb/frontend/js_src/lib/components/DataEntryTables/fetchTables.ts
+++ b/specifyweb/frontend/js_src/lib/components/DataEntryTables/fetchTables.ts
@@ -4,7 +4,7 @@ import { useAsyncState } from '../../hooks/useAsyncState';
 import { f } from '../../utils/functools';
 import type { RA } from '../../utils/types';
 import type { SpecifyTable } from '../DataModel/specifyTable';
-import { tables } from '../DataModel/tables';
+import { genericTables } from '../DataModel/tables';
 import {
   defaultInteractionTables,
   fetchLegacyInteractions,
@@ -25,7 +25,7 @@ export function useDataEntryTables(
               // Make list unique
               f
                 .unique(configuredTables.map(({ name }) => name))
-                .map((name) => tables[name])
+                .map((name) => genericTables[name])
             )
           : undefined,
       [isLegacy, type]

--- a/specifyweb/frontend/js_src/lib/components/DataModel/__tests__/specifyTable.test.ts
+++ b/specifyweb/frontend/js_src/lib/components/DataModel/__tests__/specifyTable.test.ts
@@ -3,7 +3,7 @@ import { attachmentView } from '../../FormParse/webOnlyViews';
 import { ResourceBase } from '../resourceApi';
 import { LiteralField } from '../specifyField';
 import { SpecifyTable } from '../specifyTable';
-import { tables } from '../tables';
+import { genericTables, tables } from '../tables';
 
 requireContext();
 
@@ -349,7 +349,7 @@ describe('fromJson', () => {
 test('tableScoping', () =>
   expect(
     Object.fromEntries(
-      Object.entries(tables).map(([name, table]) => [
+      Object.entries(genericTables).map(([name, table]) => [
         name,
         table
           .getScope()

--- a/specifyweb/frontend/js_src/lib/components/DataModel/collection.ts
+++ b/specifyweb/frontend/js_src/lib/components/DataModel/collection.ts
@@ -10,7 +10,7 @@ import type {
 } from './helperTypes';
 import { parseResourceUrl } from './resource';
 import { serializeResource } from './serializers';
-import { tables } from './tables';
+import { genericTables } from './tables';
 import type { Tables } from './types';
 
 export type CollectionFetchFilters<SCHEMA extends AnySchema> = Partial<
@@ -125,7 +125,7 @@ export async function fetchRelated<
     (resource.resource_uri as string) ?? ''
   ) ?? [resource._tableName, resource.id];
   const relationship =
-    tables[tableName].strictGetRelationship(relationshipName);
+    genericTables[tableName].strictGetRelationship(relationshipName);
   const reverseName = defined(
     relationship.getReverse(),
     `Trying to fetch related resource, but no reverse relationship exists for ${relationship.name} in ${tableName}`

--- a/specifyweb/frontend/js_src/lib/components/DataModel/serializers.ts
+++ b/specifyweb/frontend/js_src/lib/components/DataModel/serializers.ts
@@ -8,7 +8,7 @@ import type {
 } from './helperTypes';
 import type { SpecifyResource } from './legacyTypes';
 import { parseResourceUrl, resourceToJson } from './resource';
-import { strictGetTable, tables } from './tables';
+import { genericTables, strictGetTable } from './tables';
 import type { Tables } from './types';
 
 /** Like resource.toJSON(), but keys are converted to camel case */
@@ -108,7 +108,7 @@ function serializeRecord<SCHEMA extends AnySchema>(
 export const deserializeResource = <SCHEMA extends AnySchema>(
   serializedResource: SerializedRecord<SCHEMA> | SerializedResource<SCHEMA>
 ): SpecifyResource<SCHEMA> =>
-  new tables[
+  new genericTables[
     /**
      * This assertion, while not required by TypeScript, is needed to fix
      * a typechecking performance issue (it was taking 5s to typecheck this

--- a/specifyweb/frontend/js_src/lib/components/DataModel/specifyTable.ts
+++ b/specifyweb/frontend/js_src/lib/components/DataModel/specifyTable.ts
@@ -38,7 +38,7 @@ import {
   LiteralField,
 } from './specifyField';
 import type { SchemaLocalization } from './tables';
-import { getSchemaLocalization, getTable, tables } from './tables';
+import { genericTables, getSchemaLocalization, getTable } from './tables';
 
 type FieldAlias = {
   readonly vname: string;
@@ -480,7 +480,7 @@ export class SpecifyTable<SCHEMA extends AnySchema = AnySchema> {
     }
 
     const scopingRelationships = filterArray(
-      tables[this.name].relationships.map((relationship) => {
+      genericTables[this.name].relationships.map((relationship) => {
         if (
           !relationshipIsToMany(relationship) &&
           relationship.isRequired &&

--- a/specifyweb/frontend/js_src/lib/components/FormCells/index.tsx
+++ b/specifyweb/frontend/js_src/lib/components/FormCells/index.tsx
@@ -13,7 +13,7 @@ import { toTable } from '../DataModel/helpers';
 import type { AnySchema } from '../DataModel/helperTypes';
 import type { SpecifyResource } from '../DataModel/legacyTypes';
 import { resourceOn } from '../DataModel/resource';
-import { tables } from '../DataModel/tables';
+import { genericTables } from '../DataModel/tables';
 import { softFail } from '../Errors/Crash';
 import { fetchPathAsString } from '../Formatters/formatters';
 import { UiCommand } from '../FormCommands';
@@ -87,14 +87,14 @@ const cellRenderers: {
         className="border-b border-gray-500"
         title={
           typeof forClass === 'string'
-            ? tables[forClass].localization.desc ?? undefined
+            ? genericTables[forClass].localization.desc ?? undefined
             : undefined
         }
       >
         {typeof forClass === 'string' ? (
           <>
             <TableIcon label={false} name={forClass} />
-            {tables[forClass].label}
+            {genericTables[forClass].label}
           </>
         ) : (
           <>

--- a/specifyweb/frontend/js_src/lib/components/FormEditor/createView.ts
+++ b/specifyweb/frontend/js_src/lib/components/FormEditor/createView.ts
@@ -5,7 +5,7 @@ import type { RA } from '../../utils/types';
 import { filterArray, localized } from '../../utils/types';
 import { getUniqueName } from '../../utils/uniquifyName';
 import type { SpecifyTable } from '../DataModel/specifyTable';
-import { tables } from '../DataModel/tables';
+import { genericTables } from '../DataModel/tables';
 import { getLogContext, setLogContext } from '../Errors/logContext';
 import type { ViewDefinition } from '../FormParse';
 import { fromSimpleXmlNode } from '../Syncer/fromSimpleXmlNode';
@@ -30,7 +30,7 @@ export const createViewDefinition = (
  * "formTable" display option in sp6 out of the box, but it's good enough
  */
 const tablesWithFormTable = f.store<RA<SpecifyTable>>(() =>
-  Object.values(tables).filter(
+  Object.values(genericTables).filter(
     (table) =>
       !table.isHidden &&
       !table.overrides.isHidden &&

--- a/specifyweb/frontend/js_src/lib/components/FormEditor/viewSpec.ts
+++ b/specifyweb/frontend/js_src/lib/components/FormEditor/viewSpec.ts
@@ -4,7 +4,7 @@ import { filterArray, localized } from '../../utils/types';
 import { formatDisjunction } from '../Atoms/Internationalization';
 import type { LiteralField, Relationship } from '../DataModel/specifyField';
 import type { SpecifyTable } from '../DataModel/specifyTable';
-import { tables } from '../DataModel/tables';
+import { genericTables } from '../DataModel/tables';
 import type { Tables } from '../DataModel/types';
 import { paleoPluginTables } from '../FormPlugins/PaleoLocation';
 import { toLargeSortConfig, toSmallSortConfig } from '../Molecules/Sorting';
@@ -111,7 +111,7 @@ const rowsSpec = (table: SpecifyTable | undefined) =>
                       `Can't display ${
                         cell.definition.label ?? name ?? 'plugin'
                       } on the ${table.name} form. Instead, try ` +
-                        `displaying it on the ${tables[allowedTable].label} form`
+                        `displaying it on the ${genericTables[allowedTable].label} form`
                     );
                     return { ...cell.definition, name: undefined };
                   }

--- a/specifyweb/frontend/js_src/lib/components/FormMeta/CarryForward.tsx
+++ b/specifyweb/frontend/js_src/lib/components/FormMeta/CarryForward.tsx
@@ -19,7 +19,7 @@ import { Submit } from '../Atoms/Submit';
 import { getFieldsToClone, getUniqueFields } from '../DataModel/resource';
 import type { LiteralField, Relationship } from '../DataModel/specifyField';
 import type { SpecifyTable } from '../DataModel/specifyTable';
-import { tables } from '../DataModel/tables';
+import { genericTables } from '../DataModel/tables';
 import { NO_CLONE } from '../Forms/ResourceView';
 import { Dialog } from '../Molecules/Dialog';
 import { userPreferences } from '../Preferences/userPreferences';
@@ -48,7 +48,7 @@ const invisibleCarry = new Set([
 /** Search for all dependent fields using a suffix */
 const dependentFieldSeeker = (suffix: string): IR<string> =>
   Object.fromEntries(
-    Object.values(tables)
+    Object.values(genericTables)
       .flatMap(({ literalFields }) =>
         literalFields.filter((v) => v.name.toLowerCase().endsWith(suffix))
       )

--- a/specifyweb/frontend/js_src/lib/components/FormPlugins/PaleoLocation.tsx
+++ b/specifyweb/frontend/js_src/lib/components/FormPlugins/PaleoLocation.tsx
@@ -11,7 +11,7 @@ import { LoadingContext } from '../Core/Contexts';
 import { toTable, toTables } from '../DataModel/helpers';
 import type { AnySchema } from '../DataModel/helperTypes';
 import type { SpecifyResource } from '../DataModel/legacyTypes';
-import { tables } from '../DataModel/tables';
+import { genericTables, tables } from '../DataModel/tables';
 import type { Locality } from '../DataModel/types';
 import { ErrorBoundary } from '../Errors/ErrorBoundary';
 import { Dialog } from '../Molecules/Dialog';
@@ -65,7 +65,7 @@ export function PaleoLocationMapPlugin({
           {formsText.wrongTableForPlugin({
             currentTable: resource.specifyTable.name,
             supportedTables: formatDisjunction(
-              paleoPluginTables.map((name) => tables[name].label)
+              paleoPluginTables.map((name) => genericTables[name].label)
             ),
           })}
         </Dialog>

--- a/specifyweb/frontend/js_src/lib/components/Formatters/formatters.ts
+++ b/specifyweb/frontend/js_src/lib/components/Formatters/formatters.ts
@@ -17,7 +17,10 @@ import type { SpecifyResource } from '../DataModel/legacyTypes';
 import { fetchContext as fetchDomain } from '../DataModel/schema';
 import type { LiteralField, Relationship } from '../DataModel/specifyField';
 import type { SpecifyTable } from '../DataModel/specifyTable';
-import { fetchContext as fetchSchema, tables } from '../DataModel/tables';
+import {
+  fetchContext as fetchSchema,
+  genericTables,
+} from '../DataModel/tables';
 import type { Tables } from '../DataModel/types';
 import {
   cachableUrl,
@@ -272,7 +275,7 @@ const autoGenerateFormatter = (table: SpecifyTable): Formatter => ({
  * are more interesting than fields.
  */
 export const getMainTableFields = (tableName: keyof Tables): RA<LiteralField> =>
-  tables[tableName].literalFields
+  genericTables[tableName].literalFields
     .filter(
       ({ type, isRequired, isHidden, isReadOnly }) =>
         type === 'java.lang.String' && !isReadOnly && (isRequired || isHidden)

--- a/specifyweb/frontend/js_src/lib/components/Forms/DateRange.tsx
+++ b/specifyweb/frontend/js_src/lib/components/Forms/DateRange.tsx
@@ -11,7 +11,7 @@ import { filterArray } from '../../utils/types';
 import { sortFunction } from '../../utils/utils';
 import { serializeResource } from '../DataModel/serializers';
 import type { SpecifyTable } from '../DataModel/specifyTable';
-import { tables } from '../DataModel/tables';
+import { genericTables } from '../DataModel/tables';
 import type { Tables } from '../DataModel/types';
 import { createQuery } from '../QueryBuilder';
 import { queryFieldFilters } from '../QueryBuilder/FieldFilter';
@@ -118,7 +118,7 @@ const rangeDateFields = f.store(() => ({
    * that are applicable for use in date ranges.
    */
   ...Object.fromEntries(
-    Object.values(tables)
+    Object.values(genericTables)
       .map((table) => [
         table.name,
         table.literalFields

--- a/specifyweb/frontend/js_src/lib/components/Forms/dataObjFormatters.ts
+++ b/specifyweb/frontend/js_src/lib/components/Forms/dataObjFormatters.ts
@@ -18,7 +18,7 @@ import type { AnySchema } from '../DataModel/helperTypes';
 import type { SpecifyResource } from '../DataModel/legacyTypes';
 import type { LiteralField } from '../DataModel/specifyField';
 import type { Collection, SpecifyTable } from '../DataModel/specifyTable';
-import { tables } from '../DataModel/tables';
+import { genericTables } from '../DataModel/tables';
 import type { Tables } from '../DataModel/types';
 import { softFail } from '../Errors/Crash';
 import { fieldFormat } from '../Formatters/fieldFormat';
@@ -142,7 +142,7 @@ export const fetchFormatters: Promise<{
 );
 
 export const getMainTableFields = (tableName: keyof Tables): RA<LiteralField> =>
-  tables[tableName].literalFields
+  genericTables[tableName].literalFields
     .filter(
       ({ type, overrides }) =>
         type === 'java.lang.String' &&

--- a/specifyweb/frontend/js_src/lib/components/Forms/parentTables.ts
+++ b/specifyweb/frontend/js_src/lib/components/Forms/parentTables.ts
@@ -2,7 +2,7 @@ import { f } from '../../utils/functools';
 import type { RR } from '../../utils/types';
 import { filterArray } from '../../utils/types';
 import type { Relationship } from '../DataModel/specifyField';
-import { tables } from '../DataModel/tables';
+import { genericTables } from '../DataModel/tables';
 import type { Tables } from '../DataModel/types';
 import { error } from '../Errors/assert';
 import { softFail } from '../Errors/Crash';
@@ -19,7 +19,7 @@ export const parentTableRelationship = f.store<RR<keyof Tables, Relationship>>(
   () =>
     Object.fromEntries(
       filterArray(
-        Object.entries(tables).map(([name, table]) => {
+        Object.entries(genericTables).map(([name, table]) => {
           if (name in overrides) {
             const override = overrides[name];
             return override === undefined

--- a/specifyweb/frontend/js_src/lib/components/InitialContext/treeRanks.ts
+++ b/specifyweb/frontend/js_src/lib/components/InitialContext/treeRanks.ts
@@ -21,7 +21,7 @@ import type { SpecifyResource } from '../DataModel/legacyTypes';
 import { fetchContext as fetchDomain, schema } from '../DataModel/schema';
 import { getDomainResource } from '../DataModel/scoping';
 import { serializeResource } from '../DataModel/serializers';
-import { tables } from '../DataModel/tables';
+import { genericTables } from '../DataModel/tables';
 import type { Tables } from '../DataModel/types';
 
 let treeDefinitions: {
@@ -107,7 +107,7 @@ function getTreeScope(
   treeName: AnyTree['tableName']
 ): keyof typeof schema['domainLevelIds'] | undefined {
   const treeRelationships = new Set(
-    tables[`${treeName}TreeDef`].relationships.map(({ relatedTable }) =>
+    genericTables[`${treeName}TreeDef`].relationships.map(({ relatedTable }) =>
       relatedTable.name.toLowerCase()
     )
   );

--- a/specifyweb/frontend/js_src/lib/components/Interactions/PrepDialogRow.tsx
+++ b/specifyweb/frontend/js_src/lib/components/Interactions/PrepDialogRow.tsx
@@ -13,7 +13,7 @@ import { LoadingContext } from '../Core/Contexts';
 import { getField } from '../DataModel/helpers';
 import type { SpecifyResource } from '../DataModel/legacyTypes';
 import { getResourceViewUrl } from '../DataModel/resource';
-import { tables } from '../DataModel/tables';
+import { genericTables, tables } from '../DataModel/tables';
 import type { ExchangeOut, Gift, Loan } from '../DataModel/types';
 import { syncFieldFormat } from '../Formatters/fieldFormat';
 import { ResourceView } from '../Forms/ResourceView';
@@ -166,12 +166,12 @@ export function PrepDialogRow({
                   onClick={(): void =>
                     setState({
                       type: 'ResourceDialog',
-                      resource: new tables[tableName].Resource({ id }),
+                      resource: new genericTables[tableName].Resource({ id }),
                     })
                   }
                 >
                   {interactionsText.prepReturnFormatter({
-                    tableName: tables[tableName].label,
+                    tableName: genericTables[tableName].label,
                     resource: label,
                   })}
                 </Button.LikeLink>

--- a/specifyweb/frontend/js_src/lib/components/Molecules/AutoComplete.tsx
+++ b/specifyweb/frontend/js_src/lib/components/Molecules/AutoComplete.tsx
@@ -374,7 +374,7 @@ export function AutoComplete<T>({
   }, [currentValue]);
 
   return (
-    <Combobox
+    <Combobox<'div', AutoCompleteItem<T> | string | null | undefined>
       as="div"
       className="relative w-full"
       disabled={disabled}
@@ -389,7 +389,7 @@ export function AutoComplete<T>({
         else handleChanged(value);
       }}
     >
-      <Combobox.Input
+      <Combobox.Input<'input'>
         autoComplete="off"
         onChange={({ target }): void => {
           const value = (target as HTMLInputElement).value;
@@ -424,7 +424,7 @@ export function AutoComplete<T>({
        * of parents with overflow:hidden
        */}
       <Portal>
-        <Combobox.Options
+        <Combobox.Options<'ul'>
           className={`
             fixed z-[10000] max-h-[50vh] w-[inherit] cursor-pointer
             overflow-y-auto rounded rounded bg-white shadow-lg
@@ -433,7 +433,7 @@ export function AutoComplete<T>({
           ref={dataListRefCallback}
         >
           {isLoading && (
-            <Combobox.Option
+            <Combobox.Option<'li'>
               className={`${optionClassName(false, false)} cursor-auto`}
               disabled
               value=""
@@ -529,7 +529,7 @@ export function AutoComplete<T>({
             </Combobox.Option>
           )}
           {!listHasItems && (
-            <div className={`${optionClassName} cursor-auto`}>
+            <div className={`${optionClassName(false, false)} cursor-auto`}>
               {formsText.nothingFound()}
             </div>
           )}

--- a/specifyweb/frontend/js_src/lib/components/PickLists/definitions.ts
+++ b/specifyweb/frontend/js_src/lib/components/PickLists/definitions.ts
@@ -14,7 +14,7 @@ import { getField } from '../DataModel/helpers';
 import type { SerializedResource, TableFields } from '../DataModel/helperTypes';
 import type { SpecifyResource } from '../DataModel/legacyTypes';
 import { deserializeResource } from '../DataModel/serializers';
-import { tables } from '../DataModel/tables';
+import { genericTables, tables } from '../DataModel/tables';
 import type { PickList, PickListItem, Tables } from '../DataModel/types';
 import { hasToolPermission } from '../Permissions/helpers';
 
@@ -100,7 +100,7 @@ export function definePicklist(
 export const pickListTablesPickList = f.store(() =>
   definePicklist(
     '_TablesByName',
-    Object.values(tables).map(({ name, label }) =>
+    Object.values(genericTables).map(({ name, label }) =>
       createPickListItem(name.toLowerCase(), label)
     )
   )
@@ -147,7 +147,7 @@ export const getFrontEndPickLists = f.store<{
   // Like pickListTablesPickList, but indexed by tableId
   const tablesPickList = definePicklist(
     '_Tables',
-    Object.values(tables).map(({ tableId, label }) =>
+    Object.values(genericTables).map(({ tableId, label }) =>
       createPickListItem(tableId.toString(), label)
     )
   );

--- a/specifyweb/frontend/js_src/lib/components/Preferences/UserDefinitions.tsx
+++ b/specifyweb/frontend/js_src/lib/components/Preferences/UserDefinitions.tsx
@@ -34,7 +34,7 @@ import { camelToHuman } from '../../utils/utils';
 import { Link } from '../Atoms/Link';
 import { getField } from '../DataModel/helpers';
 import type { TableFields } from '../DataModel/helperTypes';
-import { tables } from '../DataModel/tables';
+import { genericTables } from '../DataModel/tables';
 import type { Collection, Tables } from '../DataModel/types';
 import { error, softError } from '../Errors/assert';
 import type { StatLayout } from '../Statistics/types';
@@ -72,7 +72,7 @@ const altKeyName = globalThis.navigator?.appVersion.includes('Mac')
  * Have to be careful as preferences may be used before schema is loaded
  */
 const tableLabel = (tableName: keyof Tables): LocalizedString =>
-  tables[tableName]?.label ?? camelToHuman(tableName);
+  genericTables[tableName]?.label ?? camelToHuman(tableName);
 
 export const userPreferenceDefinitions = {
   general: {

--- a/specifyweb/frontend/js_src/lib/components/QueryBuilder/Export.tsx
+++ b/specifyweb/frontend/js_src/lib/components/QueryBuilder/Export.tsx
@@ -9,7 +9,7 @@ import { filterArray } from '../../utils/types';
 import { keysToLowerCase } from '../../utils/utils';
 import type { SerializedResource } from '../DataModel/helperTypes';
 import type { SpecifyResource } from '../DataModel/legacyTypes';
-import { tables } from '../DataModel/tables';
+import { genericTables } from '../DataModel/tables';
 import type { SpQuery, SpQueryField, Tables } from '../DataModel/types';
 import { Dialog } from '../Molecules/Dialog';
 import { hasPermission } from '../Permissions/helpers';
@@ -84,7 +84,7 @@ export function QueryExportButtons({
   async function exportSelected() {
     const name = `${
       queryResource.isNew()
-        ? `${queryText.newQueryName()} ${tables[baseTableName].label}`
+        ? `${queryText.newQueryName()} ${genericTables[baseTableName].label}`
         : queryResource.get('name')
     } - ${new Date().toDateString()}.csv`;
 

--- a/specifyweb/frontend/js_src/lib/components/QueryBuilder/Line.tsx
+++ b/specifyweb/frontend/js_src/lib/components/QueryBuilder/Line.tsx
@@ -12,7 +12,7 @@ import { className } from '../Atoms/className';
 import { Select } from '../Atoms/Form';
 import { iconClassName, icons } from '../Atoms/Icons';
 import { schema } from '../DataModel/schema';
-import { getTable, tables } from '../DataModel/tables';
+import { genericTables, getTable } from '../DataModel/tables';
 import type { Tables } from '../DataModel/types';
 import { join } from '../Molecules';
 import { TableIcon } from '../Molecules/TableIcon';
@@ -535,7 +535,7 @@ export function QueryLine({
                         parser={fieldMeta.parser}
                         terminatingField={
                           isFieldComplete
-                            ? tables[baseTableName].getField(
+                            ? genericTables[baseTableName].getField(
                                 mappingPathToString(field.mappingPath)
                               )
                             : undefined

--- a/specifyweb/frontend/js_src/lib/components/QueryBuilder/helpers.ts
+++ b/specifyweb/frontend/js_src/lib/components/QueryBuilder/helpers.ts
@@ -7,7 +7,7 @@ import { group, KEY, removeKey, sortFunction, VALUE } from '../../utils/utils';
 import type { SerializedResource } from '../DataModel/helperTypes';
 import type { SpecifyResource } from '../DataModel/legacyTypes';
 import { serializeResource } from '../DataModel/serializers';
-import { getTable, tables } from '../DataModel/tables';
+import { genericTables, getTable, tables } from '../DataModel/tables';
 import type { SpQuery, SpQueryField, Tables } from '../DataModel/types';
 import { error } from '../Errors/assert';
 import { queryMappingLocalityColumns } from '../Leaflet/config';
@@ -367,7 +367,7 @@ const containsSpecifyUsername = (
     const includesUserValue = field.filters.some(({ startValue }) =>
       startValue.includes(currentUserValue)
     );
-    const terminatingField = tables[baseTableName].getField(
+    const terminatingField = genericTables[baseTableName].getField(
       mappingPathToString(field.mappingPath)
     );
     const endsWithSpecifyUser =

--- a/specifyweb/frontend/js_src/lib/components/SchemaConfig/Tables.tsx
+++ b/specifyweb/frontend/js_src/lib/components/SchemaConfig/Tables.tsx
@@ -6,7 +6,6 @@ import { commonText } from '../../localization/common';
 import { schemaText } from '../../localization/schema';
 import { wbPlanText } from '../../localization/wbPlan';
 import type { CacheDefinitions } from '../../utils/cache/definitions';
-import { f } from '../../utils/functools';
 import { localized } from '../../utils/types';
 import { sortFunction } from '../../utils/utils';
 import { Ul } from '../Atoms';
@@ -14,7 +13,7 @@ import { Button } from '../Atoms/Button';
 import { Input, Label } from '../Atoms/Form';
 import { Link } from '../Atoms/Link';
 import type { SpecifyTable } from '../DataModel/specifyTable';
-import { tables } from '../DataModel/tables';
+import { genericTables } from '../DataModel/tables';
 import { Dialog } from '../Molecules/Dialog';
 import { TableIcon } from '../Molecules/TableIcon';
 import { formatUrl } from '../Router/queryString';
@@ -84,16 +83,18 @@ export function TableList({
     'showHiddenTables'
   );
 
-  const sortedTables = React.useMemo(
-    () =>
-      Object.values(tables)
-        .filter(
-          filter?.bind(undefined, showHiddenTables) ??
-            (showHiddenTables ? f.true : ({ isSystem }): boolean => !isSystem)
-        )
-        .sort(sortFunction(({ name }) => name)),
-    [filter, showHiddenTables]
-  );
+  const sortedTables = React.useMemo(() => {
+    const allTables = Object.values(genericTables);
+    const filterFunction: ((table: SpecifyTable) => boolean) | undefined =
+      filter?.bind(undefined, showHiddenTables) ??
+      (showHiddenTables ? undefined : ({ isSystem }): boolean => !isSystem);
+    const filteredTables =
+      typeof filterFunction === 'function'
+        ? allTables.filter(filterFunction)
+        : allTables;
+
+    return filteredTables.sort(sortFunction(({ name }) => name));
+  }, [filter, showHiddenTables]);
 
   return (
     <>

--- a/specifyweb/frontend/js_src/lib/components/SchemaViewer/Table.tsx
+++ b/specifyweb/frontend/js_src/lib/components/SchemaViewer/Table.tsx
@@ -9,7 +9,7 @@ import { H2 } from '../Atoms';
 import { formatNumber } from '../Atoms/Internationalization';
 import { Link } from '../Atoms/Link';
 import { getField } from '../DataModel/helpers';
-import { getTable, tables } from '../DataModel/tables';
+import { genericTables, getTable, tables } from '../DataModel/tables';
 import type { Tables } from '../DataModel/types';
 import { TableIcon } from '../Molecules/TableIcon';
 import { NotFoundView } from '../Router/NotFoundView';
@@ -71,7 +71,7 @@ export const getSchemaViewerTables = () =>
       >
     >
   >()(
-    Object.values(tables).map(
+    Object.values(genericTables).map(
       (table) =>
         ({
           name: [

--- a/specifyweb/frontend/js_src/lib/components/SchemaViewer/schemaToTsv.tsx
+++ b/specifyweb/frontend/js_src/lib/components/SchemaViewer/schemaToTsv.tsx
@@ -2,7 +2,7 @@ import { formsText } from '../../localization/forms';
 import { schemaText } from '../../localization/schema';
 import { booleanFormatter } from '../../utils/parser/parse';
 import { getField } from '../DataModel/helpers';
-import { tables } from '../DataModel/tables';
+import { genericTables, tables } from '../DataModel/tables';
 import {
   javaTypeToHuman,
   localizedRelationshipTypes,
@@ -30,7 +30,7 @@ export const schemaToTsv = (): string =>
       schemaText.otherSideName(),
       schemaText.dependent(),
     ],
-    ...Object.values(tables).flatMap((table) => {
+    ...Object.values(genericTables).flatMap((table) => {
       const commonColumns = [
         table.name,
         table.label.replace('\n', ' '),

--- a/specifyweb/frontend/js_src/lib/components/Security/PreviewComponents.tsx
+++ b/specifyweb/frontend/js_src/lib/components/Security/PreviewComponents.tsx
@@ -6,7 +6,7 @@ import { userText } from '../../localization/user';
 import type { IR } from '../../utils/types';
 import { Input } from '../Atoms/Form';
 import { Link } from '../Atoms/Link';
-import { tables } from '../DataModel/tables';
+import { genericTables, tables } from '../DataModel/tables';
 import type { Tables } from '../DataModel/types';
 import { TableIcon } from '../Molecules/TableIcon';
 import { tableActions } from '../Permissions/definitions';
@@ -49,7 +49,7 @@ export function PreviewRow({
         ))}
         <div className="p-2" role="cell">
           <TableIcon label={false} name={tableName} />
-          {tables[tableName].label}
+          {genericTables[tableName].label}
         </div>
       </div>
       <div

--- a/specifyweb/frontend/js_src/lib/components/Security/registry.ts
+++ b/specifyweb/frontend/js_src/lib/components/Security/registry.ts
@@ -9,7 +9,7 @@ import { f } from '../../utils/functools';
 import type { IR, R, RA } from '../../utils/types';
 import { ensure, localized } from '../../utils/types';
 import { lowerToHuman } from '../../utils/utils';
-import { tables } from '../DataModel/tables';
+import { genericTables, tables } from '../DataModel/tables';
 import type { Tables } from '../DataModel/types';
 import {
   frontEndPermissions,
@@ -65,7 +65,7 @@ const buildRegistry = f.store((): IR<Registry> => {
     readonly actions: RA<string>;
     readonly groupName: LocalizedString;
   }> = [
-    ...Object.values(tables)
+    ...Object.values(genericTables)
       .filter(({ name }) => !f.has(toolTables(), name))
       .map(({ name, label, isHidden, isSystem }) => ({
         resource: tableNameToResourceName(name),

--- a/specifyweb/frontend/js_src/lib/components/SpecifyNetwork/Map.tsx
+++ b/specifyweb/frontend/js_src/lib/components/SpecifyNetwork/Map.tsx
@@ -9,7 +9,7 @@ import type { RA } from '../../utils/types';
 import { filterArray } from '../../utils/types';
 import type { SerializedResource } from '../DataModel/helperTypes';
 import type { SpecifyResource } from '../DataModel/legacyTypes';
-import { getTableById, tables } from '../DataModel/tables';
+import { genericTables, getTableById, tables } from '../DataModel/tables';
 import type { SpQuery, Tables } from '../DataModel/types';
 import type { LeafletInstance } from '../Leaflet/addOns';
 import { LoadingScreen } from '../Molecules/Dialog';
@@ -173,7 +173,7 @@ export function extractQueryTaxonId(
   const idField = tables.Taxon.idField;
   const pairedFields = filterArray(
     fields.flatMap(({ mappingPath }, index) =>
-      tables[baseTableName].getField(
+      genericTables[baseTableName].getField(
         getGenericMappingPath(mappingPath).join('.')
       ) === idField
         ? fields[index]?.filters.map(({ type, isNot, startValue }) =>

--- a/specifyweb/frontend/js_src/lib/components/Statistics/hooks.tsx
+++ b/specifyweb/frontend/js_src/lib/components/Statistics/hooks.tsx
@@ -17,7 +17,7 @@ import {
   deserializeResource,
   serializeResource,
 } from '../DataModel/serializers';
-import { tables } from '../DataModel/tables';
+import { genericTables } from '../DataModel/tables';
 import type { SpQuery, SpQueryField, Tables } from '../DataModel/types';
 import { queryFieldFilters } from '../QueryBuilder/FieldFilter';
 import { makeQueryField } from '../QueryBuilder/fromTree';
@@ -28,13 +28,13 @@ import type {
   CustomStat,
   DefaultStat,
   DynamicQuerySpec,
+  PartialQueryFieldWithPath,
   QueryBuilderStat,
   QuerySpec,
   StatFormatterSpec,
   StatLayout,
   StatsSpec,
 } from './types';
-import type { PartialQueryFieldWithPath } from './types';
 
 /**
  * Returns state which gets updated everytime backend stat is fetched. Used for dynamic categories since they don't
@@ -231,7 +231,7 @@ export const querySpecToResource = (
     addMissingFields('SpQuery', {
       name: label,
       contextName: querySpec.tableName,
-      contextTableId: tables[querySpec.tableName].tableId,
+      contextTableId: genericTables[querySpec.tableName].tableId,
       countOnly: false,
       selectDistinct: querySpec.isDistinct ?? false,
       fields: makeSerializedFieldsFromPaths(

--- a/specifyweb/frontend/js_src/lib/components/Syncer/syncers.ts
+++ b/specifyweb/frontend/js_src/lib/components/Syncer/syncers.ts
@@ -8,7 +8,7 @@ import { formatDisjunction } from '../Atoms/Internationalization';
 import { parseJavaClassName } from '../DataModel/resource';
 import type { LiteralField, Relationship } from '../DataModel/specifyField';
 import type { SpecifyTable } from '../DataModel/specifyTable';
-import { getTable, getTableById, tables } from '../DataModel/tables';
+import { genericTables, getTable, getTableById } from '../DataModel/tables';
 import type { Tables } from '../DataModel/types';
 import { error } from '../Errors/assert';
 import {
@@ -424,7 +424,7 @@ export const syncers = {
       (fieldName) => {
         if (fieldName === undefined || tableName === undefined)
           return undefined;
-        const field = tables[tableName].getFields(fieldName);
+        const field = genericTables[tableName].getFields(fieldName);
         if (field === undefined && mode !== 'silent')
           console[mode === 'strict' ? 'error' : 'warn'](
             `Unknown field: ${fieldName}`

--- a/specifyweb/frontend/js_src/lib/components/Toolbar/QueryTablesEdit.tsx
+++ b/specifyweb/frontend/js_src/lib/components/Toolbar/QueryTablesEdit.tsx
@@ -12,7 +12,7 @@ import { Button } from '../Atoms/Button';
 import { Label, Select } from '../Atoms/Form';
 import { ReadOnlyContext } from '../Core/Contexts';
 import type { SpecifyTable } from '../DataModel/specifyTable';
-import { tables } from '../DataModel/tables';
+import { genericTables } from '../DataModel/tables';
 import type { Tables } from '../DataModel/types';
 import { Dialog } from '../Molecules/Dialog';
 import { userPreferences } from '../Preferences/userPreferences';
@@ -56,14 +56,14 @@ export function TablesListEdit({
   readonly onChange: (table: RA<SpecifyTable>) => void;
   readonly onClose: () => void;
 }): JSX.Element {
-  const allTables = Object.values(tables)
+  const allTables = Object.values(genericTables)
     .filter(
       ({ isSystem, isHidden }) =>
         isNoRestrictionMode || (!isSystem && !isHidden)
     )
     .map(({ name, label }) => ({ name, label }));
   const handleChanged = (items: RA<string>): void =>
-    handleChange(items.map((name) => tables[name as keyof Tables]));
+    handleChange(items.map((name) => genericTables[name as keyof Tables]));
   return (
     <Dialog
       buttons={

--- a/specifyweb/frontend/js_src/lib/components/Toolbar/TreeRepair.tsx
+++ b/specifyweb/frontend/js_src/lib/components/Toolbar/TreeRepair.tsx
@@ -21,7 +21,7 @@ import { icons } from '../Atoms/Icons';
 import { Link } from '../Atoms/Link';
 import { LoadingContext } from '../Core/Contexts';
 import type { SpecifyResource } from '../DataModel/legacyTypes';
-import { tables } from '../DataModel/tables';
+import { genericTables } from '../DataModel/tables';
 import type { TaxonTreeDef } from '../DataModel/types';
 import {
   getDisciplineTrees,
@@ -116,7 +116,7 @@ export function TreeSelectDialog({
                       >
                         <TableIcon label={false} name={treeName} />
                         {localized(treeDefinition?.get('name')) ??
-                          tables[treeName].label}
+                          genericTables[treeName].label}
                       </Link.Default>
                       {typeof treeDefinition === 'object' && (
                         <ResourceEdit

--- a/specifyweb/frontend/js_src/lib/components/TreeView/Actions.tsx
+++ b/specifyweb/frontend/js_src/lib/components/TreeView/Actions.tsx
@@ -15,7 +15,7 @@ import { LoadingContext } from '../Core/Contexts';
 import type { AnySchema, AnyTree } from '../DataModel/helperTypes';
 import type { SpecifyResource } from '../DataModel/legacyTypes';
 import type { SpecifyTable } from '../DataModel/specifyTable';
-import { tables } from '../DataModel/tables';
+import { genericTables } from '../DataModel/tables';
 import { DeleteButton } from '../Forms/DeleteButton';
 import { getPref } from '../InitialContext/remotePrefs';
 import { Dialog } from '../Molecules/Dialog';
@@ -226,7 +226,7 @@ function EditRecordDialog<SCHEMA extends AnyTree>({
     SpecifyResource<AnySchema> | undefined
   >(
     React.useCallback(() => {
-      const table = tables[tableName] as SpecifyTable<AnyTree>;
+      const table = genericTables[tableName] as SpecifyTable<AnyTree>;
       const parentNode = new table.Resource({ id: nodeId });
       let node = parentNode;
       if (addNew) {
@@ -276,7 +276,7 @@ function ActiveAction<SCHEMA extends AnyTree>({
   if (!['move', 'merge', 'synonymize', 'desynonymize'].includes(type))
     throw new Error('Invalid action type');
 
-  const table = tables[tableName] as SpecifyTable<AnyTree>;
+  const table = genericTables[tableName] as SpecifyTable<AnyTree>;
   const treeName = table.label;
 
   const [showPrompt, setShowPrompt] = React.useState(type === 'desynonymize');
@@ -441,7 +441,7 @@ function NodeDeleteButton({
   const resource = React.useMemo(
     () =>
       typeof nodeId === 'number'
-        ? new tables[tableName].Resource({ id: nodeId })
+        ? new genericTables[tableName].Resource({ id: nodeId })
         : undefined,
     [tableName, nodeId]
   );

--- a/specifyweb/frontend/js_src/lib/components/TreeView/index.tsx
+++ b/specifyweb/frontend/js_src/lib/components/TreeView/index.tsx
@@ -22,7 +22,7 @@ import type {
 } from '../DataModel/helperTypes';
 import type { SpecifyResource } from '../DataModel/legacyTypes';
 import type { SpecifyTable } from '../DataModel/specifyTable';
-import { getTable, tables } from '../DataModel/tables';
+import { genericTables, getTable } from '../DataModel/tables';
 import { ErrorBoundary } from '../Errors/ErrorBoundary';
 import { useMenuItem } from '../Header/MenuContext';
 import { getPref } from '../InitialContext/remotePrefs';
@@ -97,7 +97,7 @@ function TreeView<SCHEMA extends AnyTree>({
     SerializedResource<FilterTablesByEndsWith<'TreeDefItem'>>
   >;
 }): JSX.Element | null {
-  const table = tables[tableName] as SpecifyTable<AnyTree>;
+  const table = genericTables[tableName] as SpecifyTable<AnyTree>;
 
   const rankIds = treeDefinitionItems.map(({ rankId }) => rankId);
 

--- a/specifyweb/frontend/js_src/lib/components/WbPlanView/__tests__/uploadPlanParser.test.ts
+++ b/specifyweb/frontend/js_src/lib/components/WbPlanView/__tests__/uploadPlanParser.test.ts
@@ -2,7 +2,7 @@ import mappingLines1 from '../../../tests/fixtures/mappinglines.1.json';
 import uploadPlan1 from '../../../tests/fixtures/uploadplan.1.json';
 import { requireContext } from '../../../tests/helpers';
 import type { IR, RA } from '../../../utils/types';
-import { tables } from '../../DataModel/tables';
+import { genericTables } from '../../DataModel/tables';
 import type { MappingLine } from '../Mapper';
 import type { UploadPlan } from '../uploadPlanParser';
 import { parseUploadPlan } from '../uploadPlanParser';
@@ -11,7 +11,7 @@ requireContext();
 
 test('parseUploadPlan', () => {
   expect(parseUploadPlan(uploadPlan1.uploadPlan as UploadPlan)).toEqual({
-    baseTable: tables[mappingLines1.baseTableName as 'CollectionObject'],
+    baseTable: genericTables[mappingLines1.baseTableName as 'CollectionObject'],
     lines: mappingLines1.lines as RA<MappingLine>,
     mustMatchPreferences: mappingLines1.mustMatchPreferences as IR<boolean>,
   });

--- a/specifyweb/frontend/js_src/lib/components/WbPlanView/autoMapper.ts
+++ b/specifyweb/frontend/js_src/lib/components/WbPlanView/autoMapper.ts
@@ -15,7 +15,7 @@ import { findArrayDivergencePoint } from '../../utils/utils';
 import type { AnyTree } from '../DataModel/helperTypes';
 import type { Relationship } from '../DataModel/specifyField';
 import type { SpecifyTable } from '../DataModel/specifyTable';
-import { getTable, strictGetTable, tables } from '../DataModel/tables';
+import { genericTables, getTable, strictGetTable } from '../DataModel/tables';
 import type { Tables } from '../DataModel/types';
 import {
   getTreeDefinitionItems,
@@ -998,7 +998,7 @@ export class AutoMapper {
  * Tables that have relationships to themself
  */
 export const circularTables = f.store<RA<SpecifyTable>>(() =>
-  Object.values(tables).filter(({ relationships, name }) =>
+  Object.values(genericTables).filter(({ relationships, name }) =>
     relationships.some(({ relatedTable }) => relatedTable.name === name)
   )
 );

--- a/specifyweb/frontend/js_src/lib/components/WebLinks/Element.tsx
+++ b/specifyweb/frontend/js_src/lib/components/WebLinks/Element.tsx
@@ -10,7 +10,7 @@ import type { AnySchema } from '../DataModel/helperTypes';
 import type { SpecifyResource } from '../DataModel/legacyTypes';
 import type { LiteralField, Relationship } from '../DataModel/specifyField';
 import type { SpecifyTable } from '../DataModel/specifyTable';
-import { strictGetTable, tables } from '../DataModel/tables';
+import { genericTables, strictGetTable } from '../DataModel/tables';
 import { ResourceMapping } from '../Formatters/Components';
 import { XmlEditorShell } from '../Formatters/Element';
 import { useResourcePreview } from '../Formatters/Preview';
@@ -50,7 +50,7 @@ export function WebLinkWrapper(): JSX.Element {
               }
             >
               <option value="">{schemaText.withoutTable()}</option>
-              {Object.values(tables).map(({ name, label }) => (
+              {Object.values(genericTables).map(({ name, label }) => (
                 <option key={name} value={name}>
                   {label}
                 </option>

--- a/specifyweb/frontend/js_src/lib/tests/updateDataModel.ts
+++ b/specifyweb/frontend/js_src/lib/tests/updateDataModel.ts
@@ -1,4 +1,4 @@
-import { tables } from '../components/DataModel/tables';
+import { genericTables, tables } from '../components/DataModel/tables';
 import { setDevelopmentGlobal } from '../utils/types';
 import { group, sortFunction } from '../utils/utils';
 
@@ -31,7 +31,7 @@ function regenerate(): string {
   const index = `export type Tables = {${Object.keys(tables)
     .map((tableName) => `readonly ${tableName}: ${tableName}`)
     .join(';')}};`;
-  const tableTypes = Object.entries(tables)
+  const tableTypes = Object.entries(genericTables)
     .map(
       ([tableName, { literalFields, relationships }]) =>
         `export type ${tableName} = {${Object.entries({


### PR DESCRIPTION
In https://github.com/microsoft/TypeScript/wiki/Performance#extendeddiagnostics, I saw that you can run this command to see what step of TypeScript takes the most time:

```sh
npx tsc --extendedDiagnostics
```

That told me that out of 17s it takes to run TypeScript on our codebase (on m1 mac), 16s was spent checking types.

I wanted to see if there places where we could optimize code a bit to simplify the job for TypeScript

Following instructions in https://github.com/microsoft/TypeScript/wiki/Performance-Tracing I run this:

```sh
npx tsc --generateTrace ~/Downloads/nameOfDirectoryToCreate --incremental false
```

That generated a performance trace report.

Then, I uploaded that trace (~/Downloads/nameOfDirectoryToCreate/trace.json) into https://www.speedscope.app/ and enabled Left heavy view. 

![Screenshot 2023-11-29 at 21 48 10](https://github.com/specify/specify7/assets/40512816/18a87b6b-8396-4469-91aa-913b51144fd0)


That showed that nearly 4s is spent in a single place:

https://github.com/specify/specify7/blob/602fd7d9bd2fd67d4a2fa0aa3b523f789775faca/specifyweb/frontend/js_src/lib/components/SchemaConfig/Tables.tsx#L87-L96

The issue is that by calling `Object.values(tables)`, we are getting a giant union of very different types (each table has a very different type because the type is `RA<SpecifyTables<keyof Tables>>`). So then when we try to .filter() over it, TypeScript has to do a lot of work making sure each union member has some common subtype.

The solution is to simplify the above type to `RA<SpecifyTables<AnySchema>>` - in this case, we don't care about each individual table schema, but only care about the fact that tables have "isSystem" and "name" fields.

---

Then I noticed many more places in the code where we do `Object.values(tables)`, `Object.entries(tables)` or `tables[tableName]` where `tableName` is `keyof Tables` - in all these cases, a giant union is created, but we don't care about a type of any particular table, but about the aggregate type common to all tables. Thus I introduced a `genericTables` table, which has type `RR<keyof Tables, SpecifyTable<AnySchema>>`.

tables should be used when you care about a particular table `table.Accession` or set of tables `table['${treeName}TreeDef']`.
If you don't care about the specifics of each individual table, but care about tables in general, use `genericTables` instead.

---

Then I went over few more places in the code and similarly resolved identified issues (had similar problem in business rule defs)

---

At the end, type check time went down from 16s to 9s.
While the biggest bottlenecks have been addressed, if someone wants to spend a bit more time on this, we could get it down by ~4s more as there are still many candidates for optimization:

![Screenshot 2023-11-29 at 21 56 45](https://github.com/specify/specify7/assets/40512816/40672621-10b6-4902-8ddf-2394b23307e4)
