### PR TITLE
Add link to GitHub comment regarding Tree GUIDs

### DIFF
--- a/specifyweb/businessrules/guid_rules.py
+++ b/specifyweb/businessrules/guid_rules.py
@@ -3,9 +3,14 @@ from .orm_signal_handler import orm_signal_handler
 
 from specifyweb.specify.models import Taxon, Geography
 
+
 @orm_signal_handler('pre_save')
 def set_guids(sender, obj):
-    if not hasattr(obj, 'guid'): return
-    if sender in (Taxon, Geography): return
+    if not hasattr(obj, 'guid'):
+        return
+
+    # See https://github.com/specify/specify7/issues/4243#issuecomment-1836990623
+    if sender in (Taxon, Geography):
+        return
     if obj.guid is None or obj.guid.strip() == "":
         obj.guid = str(uuid4())


### PR DESCRIPTION
From @maxpatiiuk:

> The reasoning (and that decision was originally made 10 or 20 years ago in sp6 and carried over into sp7) is that people would assign their own GUIDs OR they would get data from some source and use that source's GUIDs.
> 
> i.e specify is not a Taxa management system, so we are not in the business of assigning GUIDs for Taxa (same for Geography)
> we are in the business of Collection Object management, so we are assigning GUIDs for that
> 
> though that is a bit idealistic as we don't provide easy enough ways to get taxa authority data into specify, and we definitely don't have an easy way to update the taxa with updates in the taxa authority or to even keep them in sync.
> 
> so I suppose this decision was part of us being a bit more opinionated/trying to enforce the practices we belive are good - but in this case we didn't go all the way to actually make those good practices easy on people.
> 
> so yeah, I would be ok with adding a global pref for that (AND WE NEED INSTITUTIONAL PREFERENCES - pretty urgently - so many features are held back because of lack of that)

- https://github.com/specify/specify7/issues/4243#issuecomment-1836990623

This adds a link to a GitHub issue comment (copied above) which both acts as a short term reminder about the issue, and provides context regarding the reasoning of the lines in the first place.   