### PR TITLE
feat(Atoms): prevent numeric input from changing on scroll

### DIFF
--- a/specifyweb/frontend/js_src/lib/components/Atoms/Form.tsx
+++ b/specifyweb/frontend/js_src/lib/components/Atoms/Form.tsx
@@ -17,6 +17,7 @@ export const Label = {
   Block: wrap('Label.Block', 'label', className.label),
   Inline: wrap('Label.Inline', 'label', className.labelForCheckbox),
 };
+
 /**
  * Forms are used throughout for accessibility and usability reasons (helps
  * screen readers describe the page, allows for submitting the form with the
@@ -52,6 +53,7 @@ export const Form = wrap(
     },
   })
 );
+
 /*
  * Don't highlight missing required and pattern mismatch fields until focus
  * loss
@@ -67,6 +69,28 @@ export const withHandleBlur = <TYPE extends InputType>(
     handleBlur?.(event);
   },
 });
+
+/**
+ * Prevent scroll wheel accidentally changing input value.
+ *
+ * See https://stackoverflow.com/a/69497807/8584605
+ */
+// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
+export const withPreventWheel = <TYPE extends InputType>(
+  handleWheel: ((event: React.WheelEvent<TYPE>) => void) | undefined
+) => ({
+  onWheel(event: React.WheelEvent<TYPE>): void {
+    const target = event.target as TYPE;
+
+    if (target.type === 'number') {
+      target.blur();
+      setTimeout(() => target.focus(), 0);
+    }
+
+    handleWheel?.(event);
+  },
+});
+
 export const Input = {
   Radio: wrap<
     'input',
@@ -198,6 +222,7 @@ export const Input = {
         }
         withHandleBlur(props.onBlur).onBlur(event);
       },
+      ...withPreventWheel(props.onWheel),
       readOnly: isReadOnly,
     })
   ),
@@ -224,6 +249,7 @@ export const Input = {
         );
         props.onChange?.(event);
       },
+      ...withPreventWheel(props.onWheel),
       readOnly: isReadOnly,
     })
   ),


### PR DESCRIPTION
Fixes https://github.com/specify/specify7/issues/4245

To test:
Make sure that https://github.com/specify/specify7/issues/4245 does not happen for numeric inputs in the following two places:
- numeric field that is part of the form (like the one you see the video in https://github.com/specify/specify7/issues/4245)
- numeric field that occurs outside the form (i.e the input field that shows the index of current item in the sub view)

(those input fields look the same, but are different in the code)