### PR TITLE
perf(interceptLogs): redirect Syncer log output

### DIFF
--- a/specifyweb/frontend/js_src/lib/components/AppResources/codeMirrorLinters.ts
+++ b/specifyweb/frontend/js_src/lib/components/AppResources/codeMirrorLinters.ts
@@ -7,7 +7,7 @@ import type { EditorView } from 'codemirror';
 import type { RA } from '../../utils/types';
 import { filterArray } from '../../utils/types';
 import { mappedFind } from '../../utils/utils';
-import { consoleLog } from '../Errors/interceptLogs';
+import { captureLogOutput } from '../Errors/interceptLogs';
 import type { LogPathPart } from '../Errors/logContext';
 import { getLogContext, pathKey, setLogContext } from '../Errors/logContext';
 import type { BaseSpec } from '../Syncer';
@@ -51,9 +51,7 @@ function parseXmlUsingSpec(
   const { serializer } = syncers.object(spec);
 
   const logContext = getLogContext();
-  const logIndexBefore = consoleLog.length;
-  serializer(simple);
-  const errors = consoleLog.slice(logIndexBefore);
+  const [errors] = captureLogOutput(() => serializer(simple));
   setLogContext(logContext);
 
   return filterArray(

--- a/specifyweb/frontend/js_src/lib/components/FormParse/index.ts
+++ b/specifyweb/frontend/js_src/lib/components/FormParse/index.ts
@@ -20,7 +20,7 @@ import type { SpecifyTable } from '../DataModel/specifyTable';
 import { getTable, strictGetTable } from '../DataModel/tables';
 import { error } from '../Errors/assert';
 import type { LogMessage } from '../Errors/interceptLogs';
-import { consoleLog } from '../Errors/interceptLogs';
+import { captureLogOutput } from '../Errors/interceptLogs';
 import {
   addContext,
   getLogContext,
@@ -86,9 +86,9 @@ export const getViewSetApiUrl = (viewName: string): string =>
         : undefined,
   });
 
-export const clearViewLocal = (viewName: string) => {
+export function clearViewLocal(viewName: string): void {
   views = removeKey(views, viewName);
-};
+}
 
 export const fetchView = async (
   name: string
@@ -141,9 +141,9 @@ export function parseViewDefinition(
         ): ParsedFormDefinition =>
           parseFormDefinition(viewDefinition, table)[0].definition;
 
-  const logIndexBefore = consoleLog.length;
-  const parsed = parser(viewDefinition, table);
-  const errors = consoleLog.slice(logIndexBefore);
+  const [errors, parsed] = captureLogOutput(() =>
+    parser(viewDefinition, table)
+  );
   setLogContext(logContext);
 
   return {

--- a/specifyweb/frontend/js_src/lib/components/Syncer/syncers.ts
+++ b/specifyweb/frontend/js_src/lib/components/Syncer/syncers.ts
@@ -289,7 +289,6 @@ export const syncers = {
       })
     ),
 
-  // ME: prevent logging to console in production
   /**
    * Run a nested spec (another syncer)
    */


### PR DESCRIPTION
Don't console.log the validation messages generated by the Syncer when in production (and if you want, we can enable the same in development).

Main reason:
Objects that have been outputted to the console are not garbage collected, thus using the Syncer causes memory leaks as more and more objects are outputted to console (for each validation message)

For similar reasons, Syncer validation messages are no longer going to be sent in the stack trace (otherwise they won't be garbage collectable)