### PR TITLE
fix(FormEditor): preserve top level comments

### DIFF
--- a/specifyweb/frontend/js_src/lib/components/FormEditor/spec.ts
+++ b/specifyweb/frontend/js_src/lib/components/FormEditor/spec.ts
@@ -14,7 +14,11 @@ import {
   toSimpleXmlNode,
   xmlToJson,
 } from '../Syncer/xmlToJson';
-import { createXmlSpec, getOriginalSyncerInput } from '../Syncer/xmlUtils';
+import {
+  createXmlSpec,
+  getOriginalSyncerInput,
+  setOriginalSyncerInput,
+} from '../Syncer/xmlUtils';
 
 export const viewSetsSpec = f.store(() =>
   createXmlSpec({
@@ -214,25 +218,29 @@ const resolvedViewDefSpec = () =>
         table: table.parsed,
         legacyTable: table.bad,
       }),
-      ({ table, legacyTable, ...node }) => ({
-        ...node,
-        table: {
-          parsed: table,
-          bad: legacyTable,
-        },
-        legacyGetTable: localized(
-          node.legacyGetTable ??
-            (node.name?.endsWith('Search') === true
-              ? 'edu.ku.brc.af.ui.forms.DataGetterForHashMap'
-              : 'edu.ku.brc.af.ui.forms.DataGetterForObj')
-        ),
-        legacySetTable: localized(
-          node.legacySetTable ??
-            (node.name?.endsWith('Search') === true
-              ? 'edu.ku.brc.af.ui.forms.DataSetterForHashMap'
-              : 'edu.ku.brc.af.ui.forms.DataSetterForObj')
-        ),
-      })
+      ({ table, legacyTable, ...node }) => {
+        const result = {
+          ...node,
+          table: {
+            parsed: table,
+            bad: legacyTable,
+          },
+          legacyGetTable: localized(
+            node.legacyGetTable ??
+              (node.name?.endsWith('Search') === true
+                ? 'edu.ku.brc.af.ui.forms.DataGetterForHashMap'
+                : 'edu.ku.brc.af.ui.forms.DataGetterForObj')
+          ),
+          legacySetTable: localized(
+            node.legacySetTable ??
+              (node.name?.endsWith('Search') === true
+                ? 'edu.ku.brc.af.ui.forms.DataSetterForHashMap'
+                : 'edu.ku.brc.af.ui.forms.DataSetterForObj')
+          ),
+        };
+        setOriginalSyncerInput(result, node.raw);
+        return result;
+      }
     )
   );
 


### PR DESCRIPTION
Fixes #3677

Explanation of why the issue was happening and why the fix fixes it:
- (in the below I will use the "raw XML" to denote the XmlNode type, as XmlNode is 1:1 convertible to XML string, unlike SimpleXmlNode, which makes some assumptions. see [definition of SimpleXmlNode for more information](https://github.com/specify/specify7/blob/issue-3677/specifyweb/frontend/js_src/lib/components/Syncer/xmlToJson.ts#L96))
- The parsing of individual form definition is a bit special in that there is a `raw` "escape hatch" that:   https://github.com/specify/specify7/blob/a819d6b7fb8491b6490b51ab84a856e80df3977f/specifyweb/frontend/js_src/lib/components/FormEditor/spec.ts#L276-L288
   (see the comment above it)
   In other words, when parsing the entire View Set file, we don't parse each viewdef, but leave them unparsed to not impact performance too much, but also to allow for editing raw XML for a single viewdef in the form editor (raw XML meaning with comments preserved)
- The "toSimpleXmlNode" call in the above code snippet is converting the XmlNode to SimpleXmlNode. This contains the updated raw XML (comments are part of the raw XML)
- Later, in the "object" syncer we take whatever raw XML the object had before we parsed it, and make sure that the same raw XML is used:
   https://github.com/specify/specify7/blob/issue-3677/specifyweb/frontend/js_src/lib/components/Syncer/syncers.ts#L303-L307
  - This is where the problem lies. When I was writing the syncer, I was assuming that the "raw XML" before we parsed it, and when we are building it back would remain the same. But this is not the case because the Form Definition editor lets users type comments - which modifies raw xml.
  - Solution: make the "raw XML" that the `getOriginalSyncerInput(shape)` returns be the modified raw XML.
  - That is what this PR does, but taking the raw XML from node.raw, and saving it into "result" (the "result" is later the value of  "shape" inside the "object" syncer): https://github.com/specify/specify7/blob/a819d6b7fb8491b6490b51ab84a856e80df3977f/specifyweb/frontend/js_src/lib/components/FormEditor/spec.ts#L241