### PR TITLE
Better handle picklists in WorkBench

### DIFF
--- a/specifyweb/workbench/upload/scoping.py
+++ b/specifyweb/workbench/upload/scoping.py
@@ -96,13 +96,14 @@ def extend_columnoptions(colopts: ColumnOptions, collection, tablename: str, fie
     picklistname = schemaitem and schemaitem.picklistname
     picklist_model = getattr(models, 'Picklist')
 
-    picklists = picklistname and picklist_model.objects.filter(name=picklistname)
-    collection_picklists = picklists.objects.filter(collection=collection)
 
-    if len(collection_picklists) == 0:
-        picklist = picklists[0]
+    if picklistname is None:
+        picklist = None
     else:
-        picklist = collection_picklists[0]
+        picklists = picklist_model.objects.filter(name=picklistname)
+        collection_picklists = picklists.filter(collection=collection)
+        
+        picklist = picklists[0] if len(collection_picklists) == 0 else collection_picklists[0]
 
     return ExtendedColumnOptions(
         column=colopts.column,

--- a/specifyweb/workbench/upload/scoping.py
+++ b/specifyweb/workbench/upload/scoping.py
@@ -96,7 +96,7 @@ def extend_columnoptions(colopts: ColumnOptions, collection, tablename: str, fie
     picklistname = schemaitem and schemaitem.picklistname
     picklist_model = getattr(models, 'Picklist')
 
-    if picklistname is None or not isinstance(picklistname, str):
+    if not isinstance(picklistname, str):
         picklist = None
     else:
         picklists = picklist_model.objects.filter(name=picklistname)

--- a/specifyweb/workbench/upload/scoping.py
+++ b/specifyweb/workbench/upload/scoping.py
@@ -94,7 +94,15 @@ def extend_columnoptions(colopts: ColumnOptions, collection, tablename: str, fie
 
     schemaitem = schema_items and schema_items[0]
     picklistname = schemaitem and schemaitem.picklistname
-    picklist = picklistname and getattr(models, 'Picklist').objects.get(name=picklistname, collection=collection)
+    picklist_model = getattr(models, 'Picklist')
+
+    picklists = picklistname and picklist_model.objects.filter(name=picklistname)
+    collection_picklists = picklists.objects.filter(collection=collection)
+
+    if len(collection_picklists) == 0:
+        picklist = picklists[0]
+    else:
+        picklist = collection_picklists[0]
 
     return ExtendedColumnOptions(
         column=colopts.column,

--- a/specifyweb/workbench/upload/scoping.py
+++ b/specifyweb/workbench/upload/scoping.py
@@ -96,8 +96,7 @@ def extend_columnoptions(colopts: ColumnOptions, collection, tablename: str, fie
     picklistname = schemaitem and schemaitem.picklistname
     picklist_model = getattr(models, 'Picklist')
 
-
-    if picklistname is None:
+    if picklistname is None or not isinstance(picklistname, str):
         picklist = None
     else:
         picklists = picklist_model.objects.filter(name=picklistname)


### PR DESCRIPTION
Fixes #1064
Fixes #2682

This follows the frontend implementation for fetching picklists, which is provided below. 
https://github.com/specify/specify7/blob/0a47efcd66919958dad31e46bebdbc31b2ff436e/specifyweb/frontend/js_src/lib/components/PickLists/fetch.ts#L52-L54
https://github.com/specify/specify7/blob/0a47efcd66919958dad31e46bebdbc31b2ff436e/specifyweb/frontend/js_src/lib/components/PickLists/fetch.ts#L65-L73

The behavior runs a query on picklists by the name and collection. If there are no such picklists, it then removes the filter by collection and searches globally. 
If there are duplicate picklists, the first returned result is selected. 

### Testing Instructions
- For #1064: 
  - Find a database which has two picklists with the same name 
    - Due to the uniqueness rule stating Picklist name must be unique to Collection, this may be easily done via inserting a new picklist with SQL
  - Format a field on any table with one of the picklists (note: only one picklist with the name will be shown in the schema config)
  - Perform a Workbench Validation/Upload utilizing the field which is formatted with the picklist. 

- For #2682:
  - Format a field on any table with a picklist which is scoped to a collection which is not the currently logged in collection
  - Perform a Workbench Validation/Upload in a collection not scoped to the picklist utilizing the field which is formatted with the picklist.