### PR TITLE
fix(Preferences): correctly render dynamic titles

### DIFF
--- a/specifyweb/frontend/js_src/eslint.config.js
+++ b/specifyweb/frontend/js_src/eslint.config.js
@@ -52,22 +52,6 @@ module.exports = [
           },
         },
       ],
-      'jest/require-hook': [
-        'warn',
-        {
-          /*
-           * This config option does not seem to work at the moment, but keeping
-           * it here in case it will start working in the future
-           */
-          allowedFunctionCalls: [
-            'requireContext',
-            'mockTime',
-            'snapshot',
-            'theories',
-            'overrideAjax',
-          ],
-        },
-      ],
     },
   },
   {

--- a/specifyweb/frontend/js_src/lib/components/Preferences/UserDefinitions.tsx
+++ b/specifyweb/frontend/js_src/lib/components/Preferences/UserDefinitions.tsx
@@ -547,6 +547,7 @@ export const userPreferenceDefinitions = {
             container: 'div',
           }),
           source: definePref<string>({
+            // eslint-disable-next-line react/jsx-no-useless-fragment
             title: <></>,
             requiresReload: false,
             // This item is rendered inside of WelcomePageModePreferenceItem

--- a/specifyweb/frontend/js_src/lib/components/Preferences/index.tsx
+++ b/specifyweb/frontend/js_src/lib/components/Preferences/index.tsx
@@ -2,6 +2,8 @@
  * Edit user preferences
  */
 
+import { title } from 'node:process';
+
 import React from 'react';
 import { useNavigate } from 'react-router-dom';
 import type { LocalizedString } from 'typesafe-i18n';
@@ -175,9 +177,15 @@ export function PreferencesContent({
               forwardRef={forwardRefs?.bind(undefined, index)}
               id={category}
             >
-              <h3 className="text-2xl">{title as LocalizedString}</h3>
+              <h3 className="text-2xl">
+                {typeof title === 'function' ? title() : title}
+              </h3>
               {description !== undefined && (
-                <p>{description as LocalizedString}</p>
+                <p>
+                  {typeof description === 'function'
+                    ? description()
+                    : description}
+                </p>
               )}
               {subCategories.map(
                 ([subcategory, { title, description = undefined, items }]) => (
@@ -189,7 +197,7 @@ export function PreferencesContent({
                       <h4
                         className={`${className.headerGray} text-xl md:text-center`}
                       >
-                        {title as LocalizedString}
+                        {typeof title === 'function' ? title() : title}
                       </h4>
                       <div className="flex flex-1 justify-end">
                         <Button.Small
@@ -217,7 +225,11 @@ export function PreferencesContent({
                       </div>
                     </div>
                     {description !== undefined && (
-                      <p>{description as LocalizedString}</p>
+                      <p>
+                        {typeof description === 'function'
+                          ? description()
+                          : description}
+                      </p>
                     )}
                     {items.map(([name, item]) => {
                       const canEdit =
@@ -244,13 +256,21 @@ export function PreferencesContent({
                               `}
                             >
                               <FormatString
-                                text={item.title as LocalizedString}
+                                text={
+                                  typeof item.title === 'function'
+                                    ? item.title()
+                                    : item.title
+                                }
                               />
                             </p>
                             {item.description !== undefined && (
                               <p className="flex flex-1 justify-end text-gray-500 md:text-right">
                                 <FormatString
-                                  text={item.description as LocalizedString}
+                                  text={
+                                    typeof item.description === 'function'
+                                      ? item.description()
+                                      : item.description
+                                  }
                                 />
                               </p>
                             )}

--- a/specifyweb/frontend/js_src/lib/components/Preferences/index.tsx
+++ b/specifyweb/frontend/js_src/lib/components/Preferences/index.tsx
@@ -2,8 +2,6 @@
  * Edit user preferences
  */
 
-import { title } from 'node:process';
-
 import React from 'react';
 import { useNavigate } from 'react-router-dom';
 import type { LocalizedString } from 'typesafe-i18n';


### PR DESCRIPTION
Bug caused by incorrect merge conflict resolution in Preferences/index.tsx (thus function calls disappeared), followed by incorrect TypeScript error resolution (thus type assertion was added)