### PR TITLE
Add proper key props to query builder wrappers

### DIFF
--- a/specifyweb/frontend/js_src/lib/components/QueryBuilder/ResultsWrapper.tsx
+++ b/specifyweb/frontend/js_src/lib/components/QueryBuilder/ResultsWrapper.tsx
@@ -222,7 +222,6 @@ export function useQueryResultsWrapper({
   }, [
     fields,
     baseTableName,
-    fetchResults,
     forceCollection,
     queryResource,
     queryRunCount,

--- a/specifyweb/frontend/js_src/lib/components/QueryBuilder/index.tsx
+++ b/specifyweb/frontend/js_src/lib/components/QueryBuilder/index.tsx
@@ -23,7 +23,7 @@ import { QueryBuilder } from './Wrapped';
 function useQueryRecordSet(): SpecifyResource<RecordSet> | false | undefined {
   const [recordsetid = ''] = useSearchParameter('recordsetid');
   const [recordSet] = useAsyncState<SpecifyResource<RecordSet> | false>(
-    React.useCallback(() => {
+    React.useCallback(async () => {
       if (!hasToolPermission('recordSets', 'read')) return false;
       const recordSetId = f.parseInt(recordsetid);
       if (recordSetId === undefined) return false;
@@ -84,7 +84,7 @@ function QueryById({
   const recordSet = useQueryRecordSet();
 
   return query === undefined || recordSet === undefined ? null : (
-    <QueryBuilderWrapper query={query} recordSet={recordSet} key={queryId} />
+    <QueryBuilderWrapper key={queryId} query={query} recordSet={recordSet} />
   );
 }
 
@@ -132,7 +132,7 @@ function NewQuery({
   const recordSet = useQueryRecordSet();
 
   return recordSet === undefined ? null : (
-    <QueryBuilderWrapper query={query} recordSet={recordSet} key={model.name} />
+    <QueryBuilderWrapper key={model.name} query={query} recordSet={recordSet} />
   );
 }
 

--- a/specifyweb/frontend/js_src/lib/components/QueryBuilder/index.tsx
+++ b/specifyweb/frontend/js_src/lib/components/QueryBuilder/index.tsx
@@ -84,7 +84,7 @@ function QueryById({
   const recordSet = useQueryRecordSet();
 
   return query === undefined || recordSet === undefined ? null : (
-    <QueryBuilderWrapper query={query} recordSet={recordSet} />
+    <QueryBuilderWrapper query={query} recordSet={recordSet} key={queryId} />
   );
 }
 
@@ -132,7 +132,7 @@ function NewQuery({
   const recordSet = useQueryRecordSet();
 
   return recordSet === undefined ? null : (
-    <QueryBuilderWrapper query={query} recordSet={recordSet} />
+    <QueryBuilderWrapper query={query} recordSet={recordSet} key={model.name} />
   );
 }
 


### PR DESCRIPTION
To test
1, Make sure going between queries in query builder doesn't cause a crash
2. To test for https://github.com/specify/specify7/issues/4294, 

> Create a new query using any tree table
> Add anything to the query
> Don't save and add a new query under a different table

Make sure the crash doesn't happen.