### PR TITLE
fix(AppResource): handle cases when linter throws exceptions

### DIFF
--- a/specifyweb/frontend/js_src/lib/components/AppResources/codeMirrorLinters.ts
+++ b/specifyweb/frontend/js_src/lib/components/AppResources/codeMirrorLinters.ts
@@ -23,7 +23,20 @@ export const createLinter =
     handleChange: (results: RA<Diagnostic>, view: EditorView) => void
   ): Extension =>
     linter((view) => {
-      const results = handler(view);
+      let results: RA<Diagnostic>;
+      try {
+        results = handler(view);
+      } catch (error) {
+        console.error(error);
+        results = [
+          {
+            from: 0,
+            to: 0,
+            severity: 'error',
+            message: (error as Error).message,
+          },
+        ];
+      }
       handleChange(results, view);
       return results;
     });

--- a/specifyweb/frontend/js_src/lib/components/DataModel/__tests__/specifyTable.test.ts
+++ b/specifyweb/frontend/js_src/lib/components/DataModel/__tests__/specifyTable.test.ts
@@ -197,10 +197,10 @@ describe('getFields', () => {
     expect(
       serialized(tables.Locality.getFields('locality.localityName'))
     ).toEqual(['[literalField Locality.localityName]']));
-  test('throws when trying to use dot notation on a literal field', () =>
-    expect(() => tables.CollectionObject.getFields('date1.date1')).toThrow(
-      /is not a relationship/u
-    ));
+  test('undefined when trying to use dot notation on a literal field', () => {
+    jest.spyOn(console, 'error').mockImplementation();
+    expect(tables.CollectionObject.getFields('date1.date1')).toBeUndefined();
+  });
 });
 
 describe('strictGetField', () => {

--- a/specifyweb/frontend/js_src/lib/components/DataModel/specifyTable.ts
+++ b/specifyweb/frontend/js_src/lib/components/DataModel/specifyTable.ts
@@ -365,7 +365,10 @@ export class SpecifyTable<SCHEMA extends AnySchema = AnySchema> {
       );
       if (subFields === undefined) return undefined;
       return [...fields, ...subFields];
-    } else throw new Error(`Field ${unparsedName} is not a relationship`);
+    } else {
+      console.error(`Field ${unparsedName} is not a relationship`);
+      return undefined;
+    }
   }
 
   public strictGetField(unparsedName: string): LiteralField | Relationship {


### PR DESCRIPTION
Fixes #4209

1. Don't throw an exception if invalid field name is entred
2. If linting fails in the app resource editor, show an error in the editor rather that nothing