### PR TITLE
Add query list back to Add Stats Dialog

### DIFF
--- a/specifyweb/frontend/js_src/lib/components/Statistics/AddStatDialog.tsx
+++ b/specifyweb/frontend/js_src/lib/components/Statistics/AddStatDialog.tsx
@@ -1,4 +1,3 @@
-import { queries } from '@testing-library/react';
 import React from 'react';
 
 import { useBooleanState } from '../../hooks/useBooleanState';
@@ -52,7 +51,7 @@ export function AddStatDialog({
   const [newQuery, setNewQuery] = React.useState<
     SpecifyResource<SpQuery> | undefined
   >(undefined);
-  const [isCreating, setIsCreating, unsetIsCreating] = useBooleanState(false);
+  const [isCreating, setIsCreating, unsetIsCreating] = useBooleanState();
   React.useLayoutEffect(() => {
     handleLoadInitial();
     return cleanThrottledPromises;
@@ -85,29 +84,27 @@ export function AddStatDialog({
     >
       <div>
         <H3 className="text-lg">{statsText.selectFromQueries()}</H3>
-        {Array.isArray(queries) && (
-          <ReadOnlyContext.Provider value>
-            <QueryListDialog
-              getQuerySelectCallback={(query) => () => {
-                handleAdd(
-                  {
-                    type: 'CustomStat',
-                    label: localized(query.name),
-                    querySpec: queryToSpec(query),
-                    itemValue: undefined,
-                  },
-                  -1
-                );
-                handleClose();
-              }}
-              // Never used
-              newQueryUrl="/specify/command/test-error"
-              onClose={handleClose}
-            >
-              {({ children }): JSX.Element => children}
-            </QueryListDialog>
-          </ReadOnlyContext.Provider>
-        )}
+        <ReadOnlyContext.Provider value>
+          <QueryListDialog
+            getQuerySelectCallback={(query) => () => {
+              handleAdd(
+                {
+                  type: 'CustomStat',
+                  label: localized(query.name),
+                  querySpec: queryToSpec(query),
+                  itemValue: undefined,
+                },
+                -1
+              );
+              handleClose();
+            }}
+            // Never used
+            newQueryUrl="/specify/command/test-error"
+            onClose={handleClose}
+          >
+            {({ children }): JSX.Element => children}
+          </QueryListDialog>
+        </ReadOnlyContext.Provider>
       </div>
       <div>
         <H3 className="text-lg">{statsText.selectFromAvailableDefault()}</H3>


### PR DESCRIPTION
Looks like an issue with merging changes from production.

Testing instructions
1. Go to stats page, and go into edit mode.
2. Click on "Add" in a category.
3. `xml-editor` does not show any queries (even though queries exist) while this branch does.
4. Make sure you can queries to the stats page from the paginated list

Before:
![image](https://github.com/specify/specify7/assets/61122018/d22fd7e2-1c60-4d39-8a52-420de23ab0da)

Now:
![image](https://github.com/specify/specify7/assets/61122018/00cc1e75-9f40-4469-b846-fcee284c2930)
