### PR TITLE
Ignore usertype when searching for Common dir

### DIFF
--- a/specifyweb/context/app_resource.py
+++ b/specifyweb/context/app_resource.py
@@ -30,10 +30,6 @@ disciplines = ElementTree.parse(disc_file)
 discipline_dirs = dict( (disc.attrib['name'], disc.attrib.get('folder', disc.attrib['name']))
     for disc in disciplines.findall('discipline') )
 
-# Defines which fields to ignore when looking up
-class Ignore(object):
-    pass
-
 # get_app_resource is the main interface provided by this module
 def get_app_resource(collection, user, resource_name):
     """Fetch the named app resource in the context of the given user and collection.
@@ -138,14 +134,19 @@ def get_app_resource_from_db(collection, user, level, resource_name):
         # The resource does not exist in the database at the given level.
         return None
 
+# Defines which fields to ignore when looking up
+class Ignore(object):
+    pass
+
 def get_app_resource_dirs_for_level(collection, user, level):
     """Returns a queryset of SpAppResourceDir that match the user/collection context
     at the given level of the hierarchy. In principle the queryset should represent
     a single row. The queryset is returned so that the django ORM can use it to
     build a IN clause when selecting the actual SpAppResource row, resulting in
     a single query to get the resource."""
-    usertype = get_usertype(user)
-    discipline = collection.discipline
+
+    usertype = get_usertype(user) if user is not None else None
+    discipline = collection.discipline if collection is not None else None
 
     # Define what the filters (WHERE clause) are for each level.
     filter_levels = {

--- a/specifyweb/export/feed.py
+++ b/specifyweb/export/feed.py
@@ -8,7 +8,7 @@ from xml.etree import ElementTree as ET
 from django.conf import settings
 
 from .dwca import make_dwca
-from ..context.app_resource import get_app_resource
+from ..context.app_resource import get_app_resource, get_app_resource_from_db
 from ..notifications.models import Message
 from ..specify.models import Spappresourcedata, Collection, Specifyuser
 
@@ -20,14 +20,8 @@ class MissingFeedResource(Exception):
     pass
 
 def get_feed_resource():
-    try:
-        return Spappresourcedata.objects.get(
-            spappresource__name="ExportFeed",
-            spappresource__spappresourcedir__usertype="Common",
-            spappresource__spappresourcedir__discipline=None,
-        ).data
-    except Spappresourcedata.DoesNotExist:
-        return None
+    from_db = get_app_resource_from_db(None, None, 'Common', 'ExportFeed')
+    return None if from_db is None else from_db[0]
 
 def update_feed(force=False, notify_user=None):
     feed_resource = get_feed_resource()


### PR DESCRIPTION
Implements second solution in
https://github.com/specify/specify7/issues/3956#issuecomment-1853251752

Note: This will cause unexpected behavior if resources with same name appears under multiple usertypes at Global level ("Common"). I don't know if that case happens or not.

@grantfitzsimmons Have you ever seen that?