### PR TITLE
Set default value before calling update

### DIFF
--- a/specifyweb/frontend/js_src/lib/hooks/useResourceValue.tsx
+++ b/specifyweb/frontend/js_src/lib/hooks/useResourceValue.tsx
@@ -164,7 +164,7 @@ export function useResourceValue<
   );
 
   // Set default value
-  React.useEffect(() => {
+  React.useLayoutEffect(() => {
     if (field === undefined || resource === undefined) return;
 
     if (


### PR DESCRIPTION
The issue was the default value was being set after updateValue was being called (since LayoutEffect gets called before Effect). So, even `setValue` never received the default value (even though the resource had the default value). 

That is, the underlying object had `#########` as the catalog number, but state only gets updated by updateValue which didn't have the default value at the time of calling.

Funny enough this issue does not happen in React's StrictMode, just because since the hook to set default value gets called after the second hook, So, during the next cycle (React calls all effect twice in strict mode), the updateValue had the default value (because of mutation), so it updated the state correctly. It was fun to see everything working locally but not on the test panel (since production mode doesn't do StrictMode)