### PR TITLE
Set lastFocusedRow to undefined when refreshing in tree

### DIFF
--- a/specifyweb/frontend/js_src/lib/components/TreeView/Actions.tsx
+++ b/specifyweb/frontend/js_src/lib/components/TreeView/Actions.tsx
@@ -123,8 +123,8 @@ export function TreeViewActions<SCHEMA extends AnyTree>({
             nodeId={focusedRow?.nodeId}
             tableName={tableName}
             onDeleted={() => {
+              handleRefresh();
               setFocusPath(focusPath?.slice(0, -1));
-              setTimeout(handleRefresh, 0);
             }}
           />
         </li>

--- a/specifyweb/frontend/js_src/lib/components/TreeView/Actions.tsx
+++ b/specifyweb/frontend/js_src/lib/components/TreeView/Actions.tsx
@@ -123,8 +123,8 @@ export function TreeViewActions<SCHEMA extends AnyTree>({
             nodeId={focusedRow?.nodeId}
             tableName={tableName}
             onDeleted={() => {
-              handleRefresh();
               setFocusPath(focusPath?.slice(0, -1));
+              setTimeout(handleRefresh, 0);
             }}
           />
         </li>

--- a/specifyweb/frontend/js_src/lib/components/TreeView/index.tsx
+++ b/specifyweb/frontend/js_src/lib/components/TreeView/index.tsx
@@ -281,7 +281,10 @@ function TreeView<SCHEMA extends AnyTree>({
             onRefresh={(): void => {
               // Force re-load
               setRows(undefined);
-              globalThis.setTimeout(() => setRows(rows), 0);
+              globalThis.setTimeout(() => {
+                setLastFocusedRow(undefined);
+                setRows(rows);
+              }, 0);
             }}
           />
         </ErrorBoundary>


### PR DESCRIPTION
Needed because `lastFocusedRow` doesn't get updated immediately (only gets updated when the focused node is rendered). This causes an issue where rows get updated (and TreeViewActions) are mounted again, but `lastFocusedRow` still refers to the node from the previous action before refresh (which will be the deleted node in case of deletion). Since `lastFocusedRow` isn't updated yet, businessrules get run for the deleted node (which doesn't exist, so 404 error)

Testing instructions
1. Go to a tree.
2. Click on a node, and delete it using trash icon or  by clicking on pencil icon and then clicking on delete button.
3. The `xml-editor` should throw 404 not found, this branch should not.