### PR TITLE
Handle null item titles for tree rank picklists

### DIFF
--- a/specifyweb/frontend/js_src/lib/components/PickLists/TreeLevelPickList.tsx
+++ b/specifyweb/frontend/js_src/lib/components/PickLists/TreeLevelPickList.tsx
@@ -41,12 +41,12 @@ const fetchPossibleRanks = async (
       return (enforcedIndex === 0 ? ranks : ranks.slice(0, enforcedIndex)).map(
         (rank) => ({
           value: rank.resource_uri,
-          title: rank.title?.length === 0 ? rank.name : rank.title!,
+          title: (rank.title?.length ?? 0) === 0 ? rank.name : rank.title!,
         })
       );
     });
 
-export const fetchLowestChildRank = async (
+const fetchLowestChildRank = async (
   resource: SpecifyResource<AnyTree>
 ): Promise<number> =>
   resource.isNew()
@@ -127,3 +127,8 @@ export function TreeLevelComboBox(props: DefaultComboBoxProps): JSX.Element {
     />
   );
 }
+
+export const exportsForTests = {
+  fetchPossibleRanks,
+  fetchLowestChildRank,
+};

--- a/specifyweb/frontend/js_src/lib/components/PickLists/__tests__/treeLevelPicklist.test.ts
+++ b/specifyweb/frontend/js_src/lib/components/PickLists/__tests__/treeLevelPicklist.test.ts
@@ -1,0 +1,110 @@
+import { overrideAjax } from '../../../tests/ajax';
+import { requireContext } from '../../../tests/helpers';
+import type { SerializedResource } from '../../DataModel/helperTypes';
+import { schema } from '../../DataModel/schema';
+import type { Taxon } from '../../DataModel/types';
+import { exportsForTests } from '../TreeLevelPickList';
+
+const { fetchPossibleRanks, fetchLowestChildRank } = exportsForTests;
+
+requireContext();
+
+const animaliaResponse: Partial<SerializedResource<Taxon>> = {
+  _tableName: 'Taxon',
+  id: 2,
+  fullName: 'Animalia',
+  parent: '/api/specify/taxon/1/',
+  definition: '/api/specify/taxontreedef/1/',
+  definitionItem: '/api/specify/taxontreedefitem/21/',
+  rankId: 10,
+};
+
+const chordataResponse = {
+  _tableName: 'Taxon',
+  id: 3,
+  fullname: 'Chordata',
+  name: 'Chordata',
+  rankid: 30,
+  definition: '/api/specify/taxontreedef/1/',
+  definitionitem: '/api/specify/taxontreedefitem/10/',
+  parent: '/api/specify/taxon/2/',
+};
+
+const melasResponse = {
+  _tableName: 'Taxon',
+  id: 4,
+  fullname: 'Ameiurus',
+  name: 'Ameiurus',
+  rankid: 180,
+  definition: '/api/specify/taxontreedef/1/',
+  definitionitem: '/api/specify/taxontreedefitem/9/',
+  parent: '/api/specify/taxon/3/',
+};
+
+overrideAjax('/api/specify/taxon/2/', animaliaResponse);
+overrideAjax('/api/specify/taxon/3/', chordataResponse);
+
+test('fetchLowestChildRank', async () => {
+  const animalia = new schema.models.Taxon.Resource({ id: 2 });
+  await animalia.fetch();
+
+  expect(fetchLowestChildRank(animalia)).resolves.toBe(30);
+});
+
+describe('fetchPossibleRanks', () => {
+  overrideAjax('/api/specify/taxon/?limit=1&parent=2&orderby=rankid', {
+    objects: [chordataResponse],
+    meta: {
+      limit: 1,
+      offset: 0,
+      total_count: 2,
+    },
+  });
+  test('fetchPossibleRanks', async () => {
+    const animalia = new schema.models.Taxon.Resource({ id: 2 });
+    await animalia.fetch();
+
+    const lowestChildRank = await fetchLowestChildRank(animalia);
+
+    expect(
+      fetchPossibleRanks(lowestChildRank, animalia.id, 'Taxon')
+    ).resolves.toEqual([
+      {
+        title: 'Kingdom',
+        value: '/api/specify/taxontreedefitem/21/',
+      },
+    ]);
+  });
+
+  overrideAjax('/api/specify/taxon/?limit=1&parent=3&orderby=rankid', {
+    objects: [melasResponse],
+    meta: {
+      limit: 1,
+      offset: 0,
+      total_count: 2,
+    },
+  });
+  test('only next enforced is fetched', async () => {
+    const chordata = new schema.models.Taxon.Resource({ id: 3 });
+    await chordata.fetch();
+
+    const lowestChildRank = await fetchLowestChildRank(chordata);
+
+    expect(
+      fetchPossibleRanks(lowestChildRank, chordata.id, 'Taxon')
+    ).resolves.toEqual([
+      {
+        title: 'Kingdom',
+        value: '/api/specify/taxontreedefitem/21/',
+      },
+      {
+        title: 'Phylum',
+        value: '/api/specify/taxontreedefitem/10/',
+      },
+      {
+        title: 'Class',
+        value: '/api/specify/taxontreedefitem/12/',
+      },
+    ]);
+  });
+});


### PR DESCRIPTION
Inadvertently caused by the changes in #4273.

If the <TREE>defitem had a `NULL` title, the null title would be utilized as the picklist's title, leading to the picklist value (the resource uri of the treedefitem) to be displayed instead, as demonstrated in the following screenshot. 
![Screenshot from 2024-01-03 14-49-57](https://github.com/specify/specify7/assets/64045831/61a25011-d06e-4144-b49a-fcd66cac59d4)

The intended behavior is to use the treedefitem's name if the title is either null or an empty string. 
To prevent a similar mistake in the future, I have written automated tests to cover the functions defined in `TreeLevelPicklist.tsx`

### Testing Instructions
On a database with NULL treedefitem titles, following the testing instructions in https://github.com/specify/specify7/pull/4273#issue-2034443957

The following databases should have NULL titles for most treedefitems:
- coldFish
- gree
- dukebryo
- KUFish_5_16_23 
- KU_Fish_2023 
- KU_Fish_DEMO

(You can determine if the title for a treedefitem is NULL by running a query using `<TREE> Tree Definition Item` as a base table and adding a `title -> empty` field to the query)