### PR TITLE
Use ResourceView instead of ResourceLink in TreeViewer

### DIFF
--- a/specifyweb/frontend/js_src/lib/components/Formatters/Preview.tsx
+++ b/specifyweb/frontend/js_src/lib/components/Formatters/Preview.tsx
@@ -77,19 +77,18 @@ export function useResourcePreview(table: SpecifyTable): {
                 className="flex gap-2 rounded bg-[color:var(--form-background)] p-2"
                 key={index}
               >
-                {output !== undefined && (
-                  <ResourceLink
-                    component={Link.Icon}
-                    props={{
-                      icon: 'eye',
-                    }}
-                    resource={resource}
-                    resourceView={{
-                      onDeleted: (): void =>
-                        setResources(removeItem(resources, index)),
-                    }}
-                  />
-                )}
+                <ResourceLink
+                  component={Link.Icon}
+                  props={{
+                    icon: 'eye',
+                  }}
+                  resource={resource}
+                  resourceView={{
+                    onDeleted: (): void =>
+                      setResources(removeItem(resources, index)),
+                  }}
+                />
+
                 <output className="whitespace-pre-wrap">{output}</output>
               </div>
             );


### PR DESCRIPTION
Debugging issues for Tree viewer for a decent time, I realized that ResourceLink has been causing issues specifically in TreeViewer as seen in https://github.com/specify/specify7/pull/4230 and https://github.com/specify/specify7/pull/4340, and https://github.com/specify/specify7/issues/4347.

For the first two PRs, I've been able to find ways still using  `ResourceLink`. However for https://github.com/specify/specify7/issues/4347, it is tricky since `setResource` is used to handle cloned resources. 
https://github.com/specify/specify7/blob/b365affc238a1e1dcd7a7a5f39f67d74050998fb/specifyweb/frontend/js_src/lib/components/TreeView/Actions.tsx#L251
Since the state is passed to `ResourceLink`, it gets changed whenever a cloned resource is created. This closes the dialog:
https://github.com/specify/specify7/blob/b365affc238a1e1dcd7a7a5f39f67d74050998fb/specifyweb/frontend/js_src/lib/components/Molecules/ResourceLink.tsx#L44

So, to solve the problem, we could either
1. Add  a boolean state in EditRecordDialog  (used in tree, parent of ResourceLink) to keep ResourceLink open, and pass that prop down to ResourceLink.
2. Make a new state that stores the cloned resource, and render ResourceView for this state.
3. Use ResourceView from the beginning.

Currently, I've implemented the third one. @maxpatiiuk ideas on above/new solutions? I would rather keep ResourceLink to just do one thing: show a link, and the resource, and not worry about parent component for anything so didn't do the first solution. The second solution seems half-way to the third one so didn't go with second one.