### PR TITLE
fix(TableList): make lists of tables consistent

### DIFF
--- a/specifyweb/frontend/js_src/lib/components/Permissions/helpers.ts
+++ b/specifyweb/frontend/js_src/lib/components/Permissions/helpers.ts
@@ -27,7 +27,7 @@ export function hasTablePermission(
   action: typeof tableActions[number],
   collectionId = schema.domainLevelIds.collection
 ): boolean {
-  const isReadOnly = getCache('forms', 'readOnlyMode');
+  const isReadOnly = getCache('forms', 'readOnlyMode') ?? false;
   if (isReadOnly && action !== 'read') return false;
   if (
     getTablePermissions()[collectionId][tableNameToResourceName(tableName)][

--- a/specifyweb/frontend/js_src/lib/components/SchemaConfig/__tests__/Tables.test.ts
+++ b/specifyweb/frontend/js_src/lib/components/SchemaConfig/__tests__/Tables.test.ts
@@ -1,0 +1,39 @@
+import { requireContext } from '../../../tests/helpers';
+import { overwriteReadOnly } from '../../../utils/types';
+import { schema } from '../../DataModel/schema';
+import { tables } from '../../DataModel/tables';
+import { getTablePermissions } from '../../Permissions';
+import { tableNameToResourceName } from '../../Security/utils';
+import { tablesFilter } from '../Tables';
+
+requireContext();
+
+describe('tablesFilter', () => {
+  test('include all', () =>
+    expect(tablesFilter(true, true, true, tables.WorkbenchRowImage)).toBe(
+      true
+    ));
+
+  test('showHiddenTables excludes hidden and system', () =>
+    expect(tablesFilter(false, true, true, tables.Institution)).toBe(false));
+
+  test('showNoAccessTables excludes table without permission', () => {
+    const tablePermissions =
+      getTablePermissions()[schema.domainLevelIds.collection][
+        tableNameToResourceName('AgentGeography')
+      ];
+    overwriteReadOnly(tablePermissions, 'read', false);
+    expect(tablesFilter(true, false, true, tables.AgentGeography)).toBe(false);
+    overwriteReadOnly(tablePermissions, 'read', true);
+  });
+
+  test('showAdvancedTables excludes non-common tables', () =>
+    expect(tablesFilter(true, true, false, tables.AgentVariant)).toBe(false));
+
+  test('selectedTables includes any selected table', () =>
+    expect(
+      tablesFilter(false, false, false, tables.GeographyTreeDefItem, [
+        'GeographyTreeDefItem',
+      ])
+    ).toBe(true));
+});

--- a/specifyweb/frontend/js_src/lib/components/Security/PreviewTables.tsx
+++ b/specifyweb/frontend/js_src/lib/components/Security/PreviewTables.tsx
@@ -12,6 +12,7 @@ import type { PermissionsQueryItem } from '../Permissions';
 import { getTablePermissions } from '../Permissions';
 import type { PreviewCell } from './Preview';
 import { PreviewRow } from './PreviewComponents';
+import { isUncommonPermissionTable } from './registry';
 import { resourceNameToTable } from './utils';
 
 export function PreviewTables({
@@ -35,7 +36,7 @@ export function PreviewTables({
             )
             .map((entry) => {
               const table = resourceNameToTable(entry.resource);
-              return isSystem === (table.isSystem || table.isHidden)
+              return isSystem === isUncommonPermissionTable(table)
                 ? ([table.name, entry] as const)
                 : undefined;
             })

--- a/specifyweb/frontend/js_src/lib/components/Security/registry.ts
+++ b/specifyweb/frontend/js_src/lib/components/Security/registry.ts
@@ -9,6 +9,7 @@ import { f } from '../../utils/functools';
 import type { IR, R, RA } from '../../utils/types';
 import { ensure, localized } from '../../utils/types';
 import { lowerToHuman } from '../../utils/utils';
+import type { SpecifyTable } from '../DataModel/specifyTable';
 import { genericTables, tables } from '../DataModel/tables';
 import type { Tables } from '../DataModel/types';
 import {
@@ -57,6 +58,11 @@ type WritableRegistry = {
   isInstitutional: boolean;
 };
 
+export const isUncommonPermissionTable = ({
+  isSystem,
+  isHidden,
+}: SpecifyTable): boolean => isSystem || isHidden;
+
 /** Build a registry of all permissions, their labels and possible actions */
 const buildRegistry = f.store((): IR<Registry> => {
   const rules: RA<{
@@ -67,12 +73,12 @@ const buildRegistry = f.store((): IR<Registry> => {
   }> = [
     ...Object.values(genericTables)
       .filter(({ name }) => !f.has(toolTables(), name))
-      .map(({ name, label, isHidden, isSystem }) => ({
-        resource: tableNameToResourceName(name),
-        localized: [schemaText.table(), label],
+      .map((table) => ({
+        resource: tableNameToResourceName(table.name),
+        localized: [schemaText.table(), table.label],
         actions: tableActions,
         groupName: localized(
-          isSystem || isHidden ? userText.advancedTables() : ''
+          isUncommonPermissionTable(table) ? userText.advancedTables() : ''
         ),
       })),
     ...Object.entries(toolDefinitions()).map(([name, { label }]) => ({

--- a/specifyweb/frontend/js_src/lib/components/Toolbar/ListEdit.tsx
+++ b/specifyweb/frontend/js_src/lib/components/Toolbar/ListEdit.tsx
@@ -1,3 +1,11 @@
+/**
+ * A two-column list with buttons for moving entires
+ * between the columns.
+ *
+ * First column is for selected values, second one for
+ * possible values
+ */
+
 import React from 'react';
 import type { LocalizedString } from 'typesafe-i18n';
 
@@ -10,9 +18,8 @@ import { split } from '../../utils/utils';
 import { Button } from '../Atoms/Button';
 import { Label, Select } from '../Atoms/Form';
 import { ReadOnlyContext } from '../Core/Contexts';
-import type { Tables } from '../DataModel/types';
 
-export function ListEdit({
+export function ListEdit<T extends string = string>({
   defaultValues,
   selectedValues,
   allItems,
@@ -20,17 +27,17 @@ export function ListEdit({
   availableLabel,
   onChange: handleRawChange,
 }: {
-  readonly defaultValues: RA<string>;
-  readonly selectedValues: RA<string>;
+  readonly defaultValues: RA<T>;
+  readonly selectedValues: RA<T>;
   readonly allItems: RA<{
-    readonly name: string;
+    readonly name: T;
     readonly label: string;
   }>;
   readonly selectedLabel: LocalizedString;
   readonly availableLabel: LocalizedString;
-  readonly onChange: (items: RA<string>) => void;
+  readonly onChange: (items: RA<T>) => void;
 }): JSX.Element {
-  const handleChange = (items: RA<string>): void =>
+  const handleChange = (items: RA<T>): void =>
     handleRawChange(
       JSON.stringify(items) === JSON.stringify(defaultValues) ? [] : items
     );
@@ -42,8 +49,8 @@ export function ListEdit({
     ({ name }) => !selectedValues.includes(name)
   );
 
-  const [selectedSubset, setSelectedSubset] = React.useState<RA<string>>([]);
-  const [possibleSubset, setPossibleSubset] = React.useState<RA<string>>([]);
+  const [selectedSubset, setSelectedSubset] = React.useState<RA<T>>([]);
+  const [possibleSubset, setPossibleSubset] = React.useState<RA<T>>([]);
 
   function handleMoveUp(): void {
     const firstIndex =
@@ -59,7 +66,7 @@ export function ListEdit({
     handleMove(selectedSubset, insertionIndex);
   }
 
-  function handleMove(selected: RA<string>, insertionIndex: number): void {
+  function handleMove(selected: RA<T>, insertionIndex: number): void {
     const remainingTables = selectedValues.filter(
       (name) => !selected.includes(name)
     );
@@ -119,8 +126,8 @@ export function ListEdit({
             multiple
             size={10}
             value={selectedSubset}
-            onValuesChange={(tables): void =>
-              setSelectedSubset(tables as RA<keyof Tables>)
+            onValuesChange={(values): void =>
+              setSelectedSubset(values as RA<LocalizedString & T>)
             }
           >
             {selectedItems.map(({ name, label }) => (
@@ -154,8 +161,8 @@ export function ListEdit({
             multiple
             size={10}
             value={possibleSubset}
-            onValuesChange={(tables): void =>
-              setPossibleSubset(tables as RA<keyof Tables>)
+            onValuesChange={(values): void =>
+              setPossibleSubset(values as RA<LocalizedString & T>)
             }
           >
             {possibleItems.map(({ name, label }) => (

--- a/specifyweb/frontend/js_src/lib/components/Toolbar/QueryTablesEdit.tsx
+++ b/specifyweb/frontend/js_src/lib/components/Toolbar/QueryTablesEdit.tsx
@@ -11,6 +11,7 @@ import { genericTables } from '../DataModel/tables';
 import type { Tables } from '../DataModel/types';
 import { Dialog } from '../Molecules/Dialog';
 import { userPreferences } from '../Preferences/userPreferences';
+import { tablesFilter } from '../SchemaConfig/Tables';
 import { ListEdit } from './ListEdit';
 import { defaultQueryTablesConfig, useQueryTables } from './QueryTablesWrapper';
 
@@ -52,14 +53,15 @@ export function TablesListEdit({
   readonly onChange: (table: RA<SpecifyTable>) => void;
   readonly onClose: () => void;
 }): JSX.Element {
+  const selectedValues = selectedTables.map(({ name }) => name);
   const allTables = Object.values(genericTables)
-    .filter(
-      ({ isSystem, isHidden }) =>
-        isNoRestrictionMode || (!isSystem && !isHidden)
+    .filter((table) =>
+      tablesFilter(isNoRestrictionMode, false, true, table, selectedValues)
     )
     .map(({ name, label }) => ({ name, label }));
-  const handleChanged = (items: RA<string>): void =>
-    handleChange(items.map((name) => genericTables[name as keyof Tables]));
+
+  const handleChanged = (items: RA<keyof Tables>): void =>
+    handleChange(items.map((name) => genericTables[name]));
   return (
     <Dialog
       buttons={
@@ -74,12 +76,12 @@ export function TablesListEdit({
       header={header}
       onClose={handleClose}
     >
-      <ListEdit
+      <ListEdit<keyof Tables>
         allItems={allTables}
         availableLabel={schemaText.possibleTables()}
         defaultValues={defaultTables}
         selectedLabel={schemaText.selectedTables()}
-        selectedValues={selectedTables.map(({ name }) => name)}
+        selectedValues={selectedValues}
         onChange={handleChanged}
       />
     </Dialog>

--- a/specifyweb/frontend/js_src/lib/components/WbPlanView/Components.tsx
+++ b/specifyweb/frontend/js_src/lib/components/WbPlanView/Components.tsx
@@ -6,9 +6,8 @@ import { Button } from '../Atoms/Button';
 import type { SpecifyTable } from '../DataModel/specifyTable';
 import type { Tables } from '../DataModel/types';
 import { Dialog, dialogClassNames } from '../Molecules/Dialog';
-import { hasTablePermission } from '../Permissions/helpers';
 import { userPreferences } from '../Preferences/userPreferences';
-import { TableList } from '../SchemaConfig/Tables';
+import { TableList, tablesFilter } from '../SchemaConfig/Tables';
 
 export function ListOfBaseTables({
   onClick: handleClick,
@@ -25,13 +24,18 @@ export function ListOfBaseTables({
     'wbPlanView',
     'showNoAccessTables'
   );
+
   const filter = React.useCallback(
-    (showHiddenTables: boolean, { name, overrides }: SpecifyTable) =>
-      (isNoRestrictionMode || (!overrides.isSystem && !overrides.isHidden)) &&
-      (overrides.isCommon || showHiddenTables) &&
-      (showNoAccessTables || hasTablePermission(name, 'create')),
+    (showAdvancedTables: boolean, table: SpecifyTable) =>
+      tablesFilter(
+        isNoRestrictionMode,
+        showNoAccessTables,
+        showAdvancedTables,
+        table
+      ),
     [isNoRestrictionMode, showNoAccessTables]
   );
+
   return (
     <TableList
       cacheKey="wbPlanViewUi"


### PR DESCRIPTION
Make list of tables in different places consistent with each other
Also refactor code to make inconsistencies in the future less likely

Fixes #4342

Test this only after #4312 is merged
Testing instructions:

- Queries:
  1. Open "Queries" dialog
  2. Click "New"
  3. See list of queries
  4. Click on the pencil icon at the top of the dialog
  5. See list of tables in the first column - should be the same list as in step 3
  6. Should be able to edit the list (move some tables from Selected to Possible or back), and see that change be reflected in the "New Query" dialog
  7. Tables you don't have read access to should be hidden in the "Selected Tables" and "Possible Tables" column
- Workbench -> Data Mapper -> Base table selection dialog
  1. Dialog should contain only 20 tables when "Show advanced tables" is not checked
  2. When clicking on "Show advanced tables", all unhidden, non system tables that you have read access to are visible
- Schema Config
  1. Should show all non sysytem, unhidden tables that you have read access to
  2. When clicking on "Show All Tables", should also show hidden and system tables
