### PR TITLE
feat(repository): add new PR template

### DIFF
--- a/.github/pull-request-template.md
+++ b/.github/pull-request-template.md
@@ -1,0 +1,15 @@
+Fixes #
+
+
+
+### Checklist
+
+- [ ] Self-review the PR after opening it to make sure the changes look good
+      and self-explanatory (or properly documented)
+- [ ] Add automated tests
+- [ ] Add relevant issue to release milestone
+
+### Testing instructions
+
+<!-- What are the steps to verify the fixes/changes in this PR? -->
+<!-- Can part of that be replaced by automated tests? -->


### PR DESCRIPTION
We changed our dev workflow to prioritize a lot of small PRs (great!). However, when creating PRs developer sometimes forget to:
- mention which issue the PR is resolving
- add testing instructions (so that testers don't have to manually ask for this again or test wrong thing)
- add automated tests (and structure code in a way that makes it easier to automate testing - prioritize small pure functions as they are easier to write unit tests for)
- a very important step for developers is, after opening the pull request, to do a self-review of all the code in the pull request. reasons:
  - you catch if there were any unexpected changes
  - you catch if you left any TODOs/unresolved issues
  - you catch if any changes are not clear/not self-explanatory and require a code comment (or pr comment) to better describe the reasoning behind them

To resolve this, I added a small PR template, that adds gentle reminders about things we may otherwise forget to do.
If some things are not applicable to a PR (i.e this PR does not have a related issue so `Fixes #` doesn't apply), feel free to just remove that part when creating the PR.

How does this sound? Any feedback on the PR template?

Also, the template contains comments like `<!-- some comment -->` - these are visible when editing the PR description, but are not otherwise rendered in the PR (thus, you don't have to bother about removing them)

### Checklist

- [x] Self-review the PR after opening it to make sure the changes look good
      and self-explanatory (or properly documented)