### PR TITLE
Add an option to delete new formatter def with conditional formatter

### DIFF
--- a/specifyweb/frontend/js_src/lib/components/Formatters/Fields.tsx
+++ b/specifyweb/frontend/js_src/lib/components/Formatters/Fields.tsx
@@ -24,11 +24,9 @@ import type { Formatter } from './spec';
 export function Fields({
   table,
   fields: [fields, setFields],
-  onDelete: handleDelete,
 }: {
   readonly table: SpecifyTable;
   readonly fields: GetSet<Formatter['definition']['fields'][number]['fields']>;
-  readonly onDelete: (() => void) | undefined;
 }): JSX.Element {
   const [displayFormatter, setDisplayFormatter] = React.useState(false);
   return (
@@ -40,14 +38,14 @@ export function Fields({
            *   table layout with list layout
            */
           className={`
-           grid-table min-w-[35rem]
-           gap-y-4 gap-x-4
-           ${
-             displayFormatter
-               ? 'grid-cols-[min-content_max-content_auto_min-content]'
-               : 'grid-cols-[min-content_1fr_min-content]'
-           }
-         `}
+            grid-table min-w-[35rem]
+            gap-y-4 gap-x-4
+            ${
+              displayFormatter
+                ? 'grid-cols-[min-content_max-content_auto_min-content]'
+                : 'grid-cols-[min-content_1fr_min-content]'
+            }
+          `}
         >
           <thead>
             <tr>
@@ -70,16 +68,6 @@ export function Fields({
                 onRemove={(): void => setFields(removeItem(fields, index))}
               />
             ))}
-            <tr>
-              <td className="col-span-3 !gap-2">
-                {typeof handleDelete === 'function' && (
-                  <Button.Danger onClick={handleDelete}>
-                    {resourcesText.deleteDefinition()}
-                  </Button.Danger>
-                )}
-              </td>
-              <td />
-            </tr>
           </tbody>
         </table>
       )}

--- a/specifyweb/frontend/js_src/lib/components/Formatters/Formatter.tsx
+++ b/specifyweb/frontend/js_src/lib/components/Formatters/Formatter.tsx
@@ -179,7 +179,7 @@ function Definitions({
             ]}
             table={table}
           />
-          <div className="flex">
+          <div className="inline-flex">
             {index === 0 ? null : (
               <Button.Danger
                 onClick={(): void =>
@@ -189,7 +189,6 @@ function Definitions({
                 {resourcesText.deleteDefinition()}
               </Button.Danger>
             )}
-            <span className="-ml-2 flex-1" />
           </div>
         </div>
       ))}

--- a/specifyweb/frontend/js_src/lib/components/Formatters/Formatter.tsx
+++ b/specifyweb/frontend/js_src/lib/components/Formatters/Formatter.tsx
@@ -178,13 +178,19 @@ function Definitions({
               (fields): void => handleChanged({ value, fields }, index),
             ]}
             table={table}
-            onDelete={
-              trimmedFields.length < 2
-                ? undefined
-                : (): void =>
-                    handleChange(removeItem(formatter.definition.fields, index))
-            }
           />
+          <div className="flex">
+            {index === 0 ? null : (
+              <Button.Danger
+                onClick={(): void =>
+                  handleChange(removeItem(formatter.definition.fields, index))
+                }
+              >
+                {resourcesText.deleteDefinition()}
+              </Button.Danger>
+            )}
+            <span className="-ml-2 flex-1" />
+          </div>
         </div>
       ))}
       {!isReadOnly && hasCondition ? (


### PR DESCRIPTION
Fixes #4368 

Testing instructions: 

- open record formatters
- create a new formatter or open an existing one 
- check 'Conditional Formatter'
- select the field 
- click 'Add Definition' 
=> verify the newly created definition can be deleted without having to add a field by clicking on "Delete Definition". 