### PR TITLE
Display conditional field when Conditional Formatter checked

### DIFF
--- a/specifyweb/frontend/js_src/lib/components/Formatters/Fields.tsx
+++ b/specifyweb/frontend/js_src/lib/components/Formatters/Fields.tsx
@@ -40,14 +40,14 @@ export function Fields({
            *   table layout with list layout
            */
           className={`
-           grid-table min-w-[35rem]
-           gap-y-4 gap-x-4
-           ${
-             displayFormatter
-               ? 'grid-cols-[min-content_max-content_auto_min-content]'
-               : 'grid-cols-[min-content_1fr_min-content]'
-           }
-         `}
+            grid-table min-w-[35rem]
+            gap-y-4 gap-x-4
+            ${
+              displayFormatter
+                ? 'grid-cols-[min-content_max-content_auto_min-content]'
+                : 'grid-cols-[min-content_1fr_min-content]'
+            }
+          `}
         >
           <thead>
             <tr>

--- a/specifyweb/frontend/js_src/lib/components/Formatters/Formatter.tsx
+++ b/specifyweb/frontend/js_src/lib/components/Formatters/Formatter.tsx
@@ -51,7 +51,7 @@ function ConditionalMapping({
   );
 
   const [isConditionFieldDisplayed, setIsConditionFieldDisplayed] =
-    useTriggerState(formatter.definition.conditionField !== undefined || false);
+    useTriggerState(formatter.definition.conditionField !== undefined);
 
   function setConditionField(): void {
     setIsConditionFieldDisplayed(!isConditionFieldDisplayed);

--- a/specifyweb/frontend/js_src/lib/components/Formatters/Formatter.tsx
+++ b/specifyweb/frontend/js_src/lib/components/Formatters/Formatter.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 
+import { useTriggerState } from '../../hooks/useTriggerState';
 import { commonText } from '../../localization/common';
 import { resourcesText } from '../../localization/resources';
 import { f } from '../../utils/functools';
@@ -50,7 +51,7 @@ function ConditionalMapping({
   );
 
   const [isConditionFieldDisplayed, setIsConditionFieldDisplayed] =
-    React.useState(false);
+    useTriggerState(formatter.definition.conditionField !== undefined || false);
 
   function setConditionField(): void {
     setIsConditionFieldDisplayed(!isConditionFieldDisplayed);


### PR DESCRIPTION
Fixes #4369 

Testing instructions: 
- open record formatters
- open an existing one
- if "Conditional Formatter" is checked: 
   => verify the field pick list for the field is displayed bellow at opening. (Without having to check again the box) 
- if "Conditional Formatter" is NOT checked: 
   => verify the field pick list for the field is NOT displayed bellow at opening.
- When "Conditional Formatter" is checked: 
   => verify that when unchecking the box the field pick list disappears. 