### PR TITLE
Form base user restrictions in the specify context viewset API call

### DIFF
--- a/specifyweb/context/app_resource.py
+++ b/specifyweb/context/app_resource.py
@@ -22,13 +22,31 @@ logger = logging.getLogger(__name__)
 DIR_LEVELS = ['Personal', 'UserType', 'Collection', 'Discipline', 'Common', 'Backstop']
 
 # At the discipline level of the hierarchy, filesystem resources are found in
-# the directories defined in "disciplines.xml".
-disc_file = os.path.join(settings.SPECIFY_CONFIG_DIR, "disciplines.xml")
+# the directories were defined in "disciplines.xml" but are now defined here.
+DISCIPLINE_DIRS = {
+    "fish": "fish",
+    "herpetology": "herpetology",
+    "paleobotany": "invertpaleo",
+    "invertpaleo": "invertpaleo",
+    "vertpaleo": "vertpaleo",
+    "bird": "bird",
+    "mammal": "mammal",
+    "insect": "insect",
+    "botany": "botany",
+    "invertebrate": "invertebrate",
+    "minerals": "minerals",
+    "anthropology": "anthropology",
+    # "vascplant": "botany",
+    # "fungi": "botany",
+}
 
-disciplines = ElementTree.parse(disc_file)
-
-discipline_dirs = dict( (disc.attrib['name'], disc.attrib.get('folder', disc.attrib['name']))
-    for disc in disciplines.findall('discipline') )
+FORM_RESOURCE_EXCLUDED_LST = [
+    "fish/fishbase.views.xml",
+    "accessions/accessions.views.xml",
+    "backstop/system.views.xml",
+    "backstop/editorpanel.views.xml",
+    "backstop/gbif.views.xml",
+]
 
 # get_app_resource is the main interface provided by this module
 def get_app_resource(collection, user, resource_name):


### PR DESCRIPTION
Fixes #4178 
In order to restrict the base forms a user can choose, the form xml files returned by the context viewset API endpoint needs to be restricted.  This change to the viewset function filters out viewsets where the user type is not encompassing or is in a new predefined list FORM_RESOURCE_EXCLUDED_LST.

A USER_TYPE_DIR_NAME_MAP is created to allow future mapping from user type to a directory name in the filesystem, although we might just use the lowercase function instead of a map.

Also, in an effort to reduced dependency on Specify 6, the retrieval of the disciplines.xml is removed and is instead statically defined in the constant variable DISCIPLINE_DIRS.

### Testing instructions

When logged in as a Manager, the only form files not given to the user are the ones listed in FORM_RESOURCE_EXCLUDED_LST, which at the moment are "fish/fishbase.views.xml", "accessions/accessions.views.xml", "backstop/system.views.xml", and "backstop/editorpanel.views.xml", "backstop/gbif.views.xml".  When logged in as a Guest, non of the manager forms should be given to the user.
