### PR TITLE
Add name field to view set when missing

### DIFF
--- a/specifyweb/frontend/js_src/lib/components/FormEditor/Create.tsx
+++ b/specifyweb/frontend/js_src/lib/components/FormEditor/Create.tsx
@@ -27,6 +27,7 @@ import { createViewDefinition } from './createView';
 import type { AllTableViews } from './fetchAllViews';
 import { fetchAllViews } from './fetchAllViews';
 import type { FormEditorOutlet } from './index';
+import { FormEditorContext } from './index';
 
 export function CreateFormDefinition({
   table,
@@ -245,6 +246,10 @@ function ChooseName({
   );
 
   const navigate = useNavigate();
+
+  const { appResource } = React.useContext(FormEditorContext)!;
+  const newName = appResource.get('name');
+
   return (
     <Dialog
       buttons={
@@ -261,7 +266,13 @@ function ChooseName({
         onSubmit={(): void => {
           const uniqueName = getUnique(name);
           setViewSets(
-            createViewDefinition(viewSets, uniqueName, table, template),
+            createViewDefinition(
+              viewSets,
+              uniqueName,
+              table,
+              template,
+              newName
+            ),
             [uniqueName]
           );
           navigate(resolveRelative(`./${uniqueName}`));

--- a/specifyweb/frontend/js_src/lib/components/FormEditor/Create.tsx
+++ b/specifyweb/frontend/js_src/lib/components/FormEditor/Create.tsx
@@ -248,7 +248,6 @@ function ChooseName({
   const navigate = useNavigate();
 
   const { appResource } = React.useContext(FormEditorContext)!;
-  const newName = appResource.get('name');
 
   return (
     <Dialog
@@ -266,13 +265,11 @@ function ChooseName({
         onSubmit={(): void => {
           const uniqueName = getUnique(name);
           setViewSets(
-            createViewDefinition(
-              viewSets,
-              uniqueName,
-              table,
-              template,
-              newName
-            ),
+            {
+              ...createViewDefinition(viewSets, uniqueName, table, template),
+              name:
+                viewSets.name === '' ? appResource.get('name') : viewSets.name,
+            },
             [uniqueName]
           );
           navigate(resolveRelative(`./${uniqueName}`));

--- a/specifyweb/frontend/js_src/lib/components/FormEditor/Editor.tsx
+++ b/specifyweb/frontend/js_src/lib/components/FormEditor/Editor.tsx
@@ -41,7 +41,7 @@ import { FormEditorContext } from './index';
 import { getViewDefinitionIndexes } from './Table';
 import { formDefinitionSpec } from './viewSpec';
 
-export function FormEditorWrapper(): JSX.Element {
+export function FormEditor(): JSX.Element {
   const { tableName = '', viewName = '' } = useParams();
   const table = getTable(tableName);
   const {

--- a/specifyweb/frontend/js_src/lib/components/FormEditor/Routes.tsx
+++ b/specifyweb/frontend/js_src/lib/components/FormEditor/Routes.tsx
@@ -22,9 +22,7 @@ export const formEditorRoutes = toReactRoutes([
           {
             path: ':viewName',
             element: async () =>
-              import('./Editor').then(
-                ({ FormEditorWrapper }) => FormEditorWrapper
-              ),
+              import('./Editor').then(({ FormEditor }) => FormEditor),
           },
         ],
       },

--- a/specifyweb/frontend/js_src/lib/components/FormEditor/__tests__/__snapshots__/index.test.ts.snap
+++ b/specifyweb/frontend/js_src/lib/components/FormEditor/__tests__/__snapshots__/index.test.ts.snap
@@ -2,6 +2,7 @@
 
 exports[`Can edit a form definition 1`] = `
 {
+  "name": "Fish Views",
   "viewDefs": [
     {
       "legacyEditableDialog": true,

--- a/specifyweb/frontend/js_src/lib/components/FormEditor/__tests__/createView.test.ts
+++ b/specifyweb/frontend/js_src/lib/components/FormEditor/__tests__/createView.test.ts
@@ -225,6 +225,7 @@ const viewSets = (): ViewSets =>
         legacyTable: 'edu.ku.brc.specify.datamodel.ObjectAttachmentIFace',
       },
     ],
+    name: viewDefinition.name,
   });
 
 /** Reformat the result to reduce snapshot size and make it more readable */
@@ -419,6 +420,7 @@ test('Create new view definition', () =>
         title: 'CollectionObjectAttachment',
       },
     ],
+    name: 'CollectionObjectAttachment',
   }));
 
 test('Add new view definition based on existing', () =>
@@ -612,4 +614,5 @@ test('Add new view definition based on existing', () =>
         table: '[table CollectionObjectAttachment]',
       },
     ],
+    name: 'CollectionObjectAttachment',
   }));

--- a/specifyweb/frontend/js_src/lib/components/FormEditor/createView.ts
+++ b/specifyweb/frontend/js_src/lib/components/FormEditor/createView.ts
@@ -18,12 +18,11 @@ export const createViewDefinition = (
   /** The name is expected to be already unique */
   name: LocalizedString,
   table: SpecifyTable,
-  template: ViewDefinition | 'new',
-  newName: string
+  template: ViewDefinition | 'new'
 ): ViewSets =>
   template === 'new'
-    ? createNewView(viewSets, name, table, newName)
-    : createViewFromTemplate(viewSets, name, template, newName);
+    ? createNewView(viewSets, name, table)
+    : createViewFromTemplate(viewSets, name, template);
 
 /**
  * Build a list of tables for which the "formTable" display type should be
@@ -45,8 +44,7 @@ type Definition = ViewSets['viewDefs'][number];
 function createNewView(
   viewSets: ViewSets,
   name: LocalizedString,
-  table: SpecifyTable,
-  newName: string
+  table: SpecifyTable
 ): ViewSets {
   const formName = getUniqueDefinitionName(name, viewSets);
   const formTableName = getUniqueDefinitionName(`${name} Table`, viewSets);
@@ -103,7 +101,6 @@ function createNewView(
 
   return {
     ...viewSets,
-    name: viewSets.name === '' ? newName : viewSets.name,
     views: [...viewSets.views, view],
     viewDefs: [
       ...viewSets.viewDefs,
@@ -258,8 +255,7 @@ const getUniqueDefinitionName = (
 function createViewFromTemplate(
   viewSets: ViewSets,
   name: LocalizedString,
-  template: ViewDefinition,
-  newName: string
+  template: ViewDefinition
 ): ViewSets {
   const logContext = getLogContext();
   const { view, viewDefinitions } = parseFormView(template);
@@ -322,7 +318,6 @@ function createViewFromTemplate(
 
   return {
     ...viewSets,
-    name: viewSets.name === '' ? newName : viewSets.name,
     views: [...viewSets.views, updatedView],
     viewDefs: [...viewSets.viewDefs, ...updatedViewDefinitions],
   };

--- a/specifyweb/frontend/js_src/lib/components/FormEditor/createView.ts
+++ b/specifyweb/frontend/js_src/lib/components/FormEditor/createView.ts
@@ -18,11 +18,12 @@ export const createViewDefinition = (
   /** The name is expected to be already unique */
   name: LocalizedString,
   table: SpecifyTable,
-  template: ViewDefinition | 'new'
+  template: ViewDefinition | 'new',
+  newName: string
 ): ViewSets =>
   template === 'new'
-    ? createNewView(viewSets, name, table)
-    : createViewFromTemplate(viewSets, name, template);
+    ? createNewView(viewSets, name, table, newName)
+    : createViewFromTemplate(viewSets, name, template, newName);
 
 /**
  * Build a list of tables for which the "formTable" display type should be
@@ -44,7 +45,8 @@ type Definition = ViewSets['viewDefs'][number];
 function createNewView(
   viewSets: ViewSets,
   name: LocalizedString,
-  table: SpecifyTable
+  table: SpecifyTable,
+  newName: string
 ): ViewSets {
   const formName = getUniqueDefinitionName(name, viewSets);
   const formTableName = getUniqueDefinitionName(`${name} Table`, viewSets);
@@ -101,6 +103,7 @@ function createNewView(
 
   return {
     ...viewSets,
+    name: viewSets.name === '' ? newName : viewSets.name,
     views: [...viewSets.views, view],
     viewDefs: [
       ...viewSets.viewDefs,
@@ -255,7 +258,8 @@ const getUniqueDefinitionName = (
 function createViewFromTemplate(
   viewSets: ViewSets,
   name: LocalizedString,
-  template: ViewDefinition
+  template: ViewDefinition,
+  newName: string
 ): ViewSets {
   const logContext = getLogContext();
   const { view, viewDefinitions } = parseFormView(template);
@@ -318,6 +322,7 @@ function createViewFromTemplate(
 
   return {
     ...viewSets,
+    name: viewSets.name === '' ? newName : viewSets.name,
     views: [...viewSets.views, updatedView],
     viewDefs: [...viewSets.viewDefs, ...updatedViewDefinitions],
   };

--- a/specifyweb/frontend/js_src/lib/components/FormEditor/index.tsx
+++ b/specifyweb/frontend/js_src/lib/components/FormEditor/index.tsx
@@ -25,7 +25,7 @@ export function FormEditor(props: AppResourceTabProps): JSX.Element {
     <XmlEditor
       context={FormEditorContext}
       props={props}
-      rootTagName="viewsets"
+      rootTagName="viewset"
       routes={formEditorRoutes}
       spec={viewSetsSpec()}
     />

--- a/specifyweb/frontend/js_src/lib/components/FormEditor/spec.ts
+++ b/specifyweb/frontend/js_src/lib/components/FormEditor/spec.ts
@@ -34,6 +34,10 @@ export const viewSetsSpec = f.store(() =>
       syncers.xmlChildren('viewdef'),
       syncers.map(resolvedViewDefSpec())
     ),
+    name: pipe(
+      syncers.xmlAttribute('name', 'empty'),
+      syncers.default<string>('')
+    ),
   })
 );
 

--- a/specifyweb/frontend/js_src/lib/components/Formatters/index.tsx
+++ b/specifyweb/frontend/js_src/lib/components/Formatters/index.tsx
@@ -62,7 +62,7 @@ function RenderRoutes({
   return jsxElement ?? <NotFoundView container={false} />;
 }
 
-export function WrappedXmlEditor<SPEC extends BaseSpec<SimpleXmlNode>>({
+function WrappedXmlEditor<SPEC extends BaseSpec<SimpleXmlNode>>({
   props,
   rootTagName,
   spec,

--- a/specifyweb/frontend/js_src/lib/components/Syncer/syncers.ts
+++ b/specifyweb/frontend/js_src/lib/components/Syncer/syncers.ts
@@ -36,7 +36,7 @@ export const syncers = {
   /**
    * Getting an XML attribute, but with a lot of bells and whistles
    */
-  xmlAttribute: <MODE extends 'empty' | 'required' | 'skip'>(
+  xmlAttribute: (
     attribute: string,
     /**
      * Modes:
@@ -45,7 +45,7 @@ export const syncers = {
      *   required - if there is no value, trigger an error
      *   skip - optional attribute, if there is no value, skip it
      */
-    mode: MODE,
+    mode: 'empty' | 'required' | 'skip',
     /** If true, trims the value. Also, converts "" to undefined */
     trim = true
   ) =>


### PR DESCRIPTION
Fixes #4366

Work in progress


### Checklist

- [x] Self-review the PR after opening it to make sure the changes look good
      and self-explanatory (or properly documented)
- [x] Add automated tests
- [x] Add relevant issue to release milestone

### Testing instructions

- open app resource 
- click add resource 
- click form definition 
- click New button (do not choose from the list) 
- define a name for your form def
- click save on the bottom right 
- click a table 
- click create 
- click NEW button 
- define a name
- save 
- change visual editor mode to XML Editor mode. 
==> verify the viewset name attribute is defined in the xml
- reproduce all above steps but instead of "click NEW button" to create a table, choose from the list. 
- reproduce all above steps but instead of "click New button" to create a new definition choose from the lust 

Summary: 
- create a form def from scratch with table from scratch 
- create a form def from scratch with table from list
- create a form def from list with table from scratch 
- create a form def from list with table from list 
