### PR TITLE
Prevent cloning dialog to close itslef

### DIFF
--- a/specifyweb/frontend/js_src/lib/components/Molecules/ResourceLink.tsx
+++ b/specifyweb/frontend/js_src/lib/components/Molecules/ResourceLink.tsx
@@ -25,7 +25,7 @@ export function ResourceLink<COMPONENT extends typeof Link['Icon']>({
   props: rawProps,
   resourceView,
   children,
-  autoClose,
+  autoClose = false,
 }: {
   readonly resource: SpecifyResource<AnySchema> | undefined;
   readonly component: COMPONENT;

--- a/specifyweb/frontend/js_src/lib/components/Molecules/ResourceLink.tsx
+++ b/specifyweb/frontend/js_src/lib/components/Molecules/ResourceLink.tsx
@@ -25,6 +25,7 @@ export function ResourceLink<COMPONENT extends typeof Link['Icon']>({
   props: rawProps,
   resourceView,
   children,
+  autoClose,
 }: {
   readonly resource: SpecifyResource<AnySchema> | undefined;
   readonly component: COMPONENT;
@@ -39,9 +40,12 @@ export function ResourceLink<COMPONENT extends typeof Link['Icon']>({
     >,
     'dialog' | 'onAdd' | 'onClose' | 'onSaved'
   >;
+  readonly autoClose: boolean;
 }): JSX.Element {
   const [isOpen, _, handleClose, handleToggle] = useBooleanState();
-  React.useEffect(handleClose, [resource]);
+  React.useEffect(() => {
+    if (autoClose) handleClose();
+  }, [resource]);
 
   function handleClosed(): void {
     handleClose();

--- a/specifyweb/frontend/js_src/lib/components/Molecules/ResourceLink.tsx
+++ b/specifyweb/frontend/js_src/lib/components/Molecules/ResourceLink.tsx
@@ -40,11 +40,11 @@ export function ResourceLink<COMPONENT extends typeof Link['Icon']>({
     >,
     'dialog' | 'onAdd' | 'onClose' | 'onSaved'
   >;
-  readonly autoClose: boolean;
+  readonly autoClose?: boolean;
 }): JSX.Element {
   const [isOpen, _, handleClose, handleToggle] = useBooleanState();
   React.useEffect(() => {
-    if (autoClose) handleClose();
+    if (autoClose === undefined || autoClose) handleClose();
   }, [resource]);
 
   function handleClosed(): void {

--- a/specifyweb/frontend/js_src/lib/components/Molecules/ResourceLink.tsx
+++ b/specifyweb/frontend/js_src/lib/components/Molecules/ResourceLink.tsx
@@ -44,7 +44,7 @@ export function ResourceLink<COMPONENT extends typeof Link['Icon']>({
 }): JSX.Element {
   const [isOpen, _, handleClose, handleToggle] = useBooleanState();
   React.useEffect(() => {
-    if (autoClose === undefined || autoClose) handleClose();
+    if (autoClose) handleClose();
   }, [resource]);
 
   function handleClosed(): void {

--- a/specifyweb/frontend/js_src/lib/components/TreeView/Actions.tsx
+++ b/specifyweb/frontend/js_src/lib/components/TreeView/Actions.tsx
@@ -247,6 +247,7 @@ function EditRecordDialog<SCHEMA extends AnyTree>({
         />
       ) : (
         <ResourceLink
+          autoClose={false}
           component={Link.Icon}
           props={{
             'aria-disabled': disabled,


### PR DESCRIPTION
Fixes #4347 

### Checklist

- [x] Self-review the PR after opening it to make sure the changes look good
      and self-explanatory (or properly documented)
- [ ] Add automated tests
- [x] Add relevant issue to release milestone

### Testing instructions

- open a tree 
- click on a node 
- click on edit button 
- click on clone 
- verify dialog doesn't close itself + verify cloning function works 
