### PR TITLE
Display resource mapping inline when no customize field formatter

### DIFF
--- a/specifyweb/frontend/js_src/lib/components/Errors/Toasts.tsx
+++ b/specifyweb/frontend/js_src/lib/components/Errors/Toasts.tsx
@@ -69,6 +69,7 @@ export const SetToastsContext = React.createContext<
 >(() => error('SetToastsContext is not defined'));
 SetToastsContext.displayName = 'SetToasts';
 
+// REFACTOR: use native popover api https://developer.chrome.com/blog/introducing-popover-api
 function Toast({
   toast,
   onClose: handleClose,

--- a/specifyweb/frontend/js_src/lib/components/Formatters/Components.tsx
+++ b/specifyweb/frontend/js_src/lib/components/Formatters/Components.tsx
@@ -149,13 +149,11 @@ export function ResourceMapping({
   mapping: [mapping, setMapping],
   openIndex: [openIndex, setOpenIndex],
   isRequired = false,
-  displayedFormatter,
 }: {
   readonly table: SpecifyTable;
   readonly mapping: GetSet<RA<LiteralField | Relationship> | undefined>;
   readonly openIndex: GetSet<number | undefined>;
   readonly isRequired?: boolean;
-  readonly displayedFormatter?: boolean;
 }): JSX.Element {
   const sourcePath = React.useMemo(() => {
     const rawPath =
@@ -254,9 +252,7 @@ export function ResourceMapping({
 
   return (
     <Ul
-      className={
-        displayedFormatter === false ? 'flex w-[100%] flex-wrap gap-2' : ''
-      }
+      className="flex w-[100%] flex-wrap gap-2"
       onKeyDown={({ key }): void =>
         handleMappingLineKey({
           key,

--- a/specifyweb/frontend/js_src/lib/components/Formatters/Components.tsx
+++ b/specifyweb/frontend/js_src/lib/components/Formatters/Components.tsx
@@ -67,7 +67,6 @@ export function FormattersPickList({
   return (
     <>
       <Input.Text
-        className="h-full"
         isReadOnly={isReadOnly}
         list={id('list')}
         placeholder={resourcesText.defaultInline()}

--- a/specifyweb/frontend/js_src/lib/components/Formatters/Components.tsx
+++ b/specifyweb/frontend/js_src/lib/components/Formatters/Components.tsx
@@ -254,9 +254,9 @@ export function ResourceMapping({
 
   return (
     <Ul
-      className={`
-        ${mappingLineProps.length > 1 ? 'flex' : ''}
-        w-[100%] flex-wrap gap-2`}
+      className={
+        displayedFormatter === false ? 'flex w-[100%] flex-wrap gap-2' : ''
+      }
       onKeyDown={({ key }): void =>
         handleMappingLineKey({
           key,
@@ -269,21 +269,17 @@ export function ResourceMapping({
         })
       }
     >
-      <div
-        className={displayedFormatter === false ? 'flex flex-wrap gap-2' : ''}
-      >
-        {join(
-          mappingLineProps.map((mappingDetails, index) => (
-            <li className="contents" key={index}>
-              <MappingElement
-                {...mappingDetails}
-                validation={validation[index]}
-              />
-            </li>
-          )),
-          mappingElementDivider
-        )}
-      </div>
+      {join(
+        mappingLineProps.map((mappingDetails, index) => (
+          <li className="contents" key={index}>
+            <MappingElement
+              {...mappingDetails}
+              validation={validation[index]}
+            />
+          </li>
+        )),
+        mappingElementDivider
+      )}
     </Ul>
   );
 }

--- a/specifyweb/frontend/js_src/lib/components/Formatters/Components.tsx
+++ b/specifyweb/frontend/js_src/lib/components/Formatters/Components.tsx
@@ -67,6 +67,7 @@ export function FormattersPickList({
   return (
     <>
       <Input.Text
+        className="h-full"
         isReadOnly={isReadOnly}
         list={id('list')}
         placeholder={resourcesText.defaultInline()}
@@ -148,11 +149,13 @@ export function ResourceMapping({
   mapping: [mapping, setMapping],
   openIndex: [openIndex, setOpenIndex],
   isRequired = false,
+  displayedFormatter,
 }: {
   readonly table: SpecifyTable;
   readonly mapping: GetSet<RA<LiteralField | Relationship> | undefined>;
   readonly openIndex: GetSet<number | undefined>;
   readonly isRequired?: boolean;
+  readonly displayedFormatter?: boolean;
 }): JSX.Element {
   const sourcePath = React.useMemo(() => {
     const rawPath =
@@ -266,7 +269,9 @@ export function ResourceMapping({
         })
       }
     >
-      <div>
+      <div
+        className={displayedFormatter === false ? 'flex flex-wrap gap-2' : ''}
+      >
         {join(
           mappingLineProps.map((mappingDetails, index) => (
             <li className="contents" key={index}>

--- a/specifyweb/frontend/js_src/lib/components/Formatters/Fields.tsx
+++ b/specifyweb/frontend/js_src/lib/components/Formatters/Fields.tsx
@@ -42,7 +42,7 @@ export function Fields({
             gap-y-4 gap-x-4
             ${
               displayFormatter
-                ? 'grid-cols-[min-content_max-content_auto_min-content]'
+                ? 'grid-cols-[min-content_1fr_auto_min-content]'
                 : 'grid-cols-[min-content_1fr_min-content]'
             }
           `}

--- a/specifyweb/frontend/js_src/lib/components/Formatters/Fields.tsx
+++ b/specifyweb/frontend/js_src/lib/components/Formatters/Fields.tsx
@@ -125,6 +125,7 @@ function Field({
       <td>
         <Input.Text
           aria-label={resourcesText.separator()}
+          className="h-full"
           isReadOnly={isReadOnly}
           value={field.separator}
           onValueChange={(separator): void =>
@@ -137,6 +138,7 @@ function Field({
       </td>
       <td>
         <ResourceMapping
+          displayedFormatter={displayFormatter}
           mapping={[
             field.field,
             (fieldMapping): void =>
@@ -157,6 +159,7 @@ function Field({
       <td>
         <Button.Small
           aria-label={commonText.remove()}
+          className="h-full"
           title={commonText.remove()}
           variant={className.dangerButton}
           onClick={handleRemove}
@@ -179,7 +182,7 @@ function FieldFormatter({
   if (lastField === undefined) return null;
   else if (!lastField.isRelationship)
     return (
-      <Label.Inline className="w-full">
+      <Label.Inline className="h-full w-full">
         <GenericFormatterPickList
           itemsPromise={fetchFieldFormatters}
           table={lastField.table}
@@ -195,7 +198,7 @@ function FieldFormatter({
     );
   else if (relationshipIsToMany(lastField))
     return (
-      <Label.Inline className="w-full">
+      <Label.Inline className="h-full w-full">
         <FormattersPickList
           table={lastField.relatedTable}
           type="aggregators"
@@ -211,7 +214,7 @@ function FieldFormatter({
     );
   else
     return (
-      <Label.Inline className="w-full">
+      <Label.Inline className="h-full w-full">
         {resourcesText.formatter()}
         <FormattersPickList
           table={lastField.relatedTable}

--- a/specifyweb/frontend/js_src/lib/components/Formatters/Fields.tsx
+++ b/specifyweb/frontend/js_src/lib/components/Formatters/Fields.tsx
@@ -138,7 +138,6 @@ function Field({
       </td>
       <td>
         <ResourceMapping
-          displayedFormatter={displayFormatter}
           mapping={[
             field.field,
             (fieldMapping): void =>

--- a/specifyweb/frontend/js_src/lib/components/Formatters/Fields.tsx
+++ b/specifyweb/frontend/js_src/lib/components/Formatters/Fields.tsx
@@ -39,7 +39,7 @@ export function Fields({
            */
           className={`
             grid-table min-w-[35rem] gap-y-4 gap-x-4
-            [&_td]:items-stretch
+            [&_td]:!items-stretch
             ${
               displayFormatter
                 ? 'grid-cols-[min-content_1fr_auto_min-content]'

--- a/specifyweb/frontend/js_src/lib/components/Formatters/Fields.tsx
+++ b/specifyweb/frontend/js_src/lib/components/Formatters/Fields.tsx
@@ -38,8 +38,8 @@ export function Fields({
            *   table layout with list layout
            */
           className={`
-            grid-table min-w-[35rem]
-            gap-y-4 gap-x-4
+            grid-table min-w-[35rem] gap-y-4 gap-x-4
+            [&_td]:items-stretch
             ${
               displayFormatter
                 ? 'grid-cols-[min-content_1fr_auto_min-content]'
@@ -125,7 +125,6 @@ function Field({
       <td>
         <Input.Text
           aria-label={resourcesText.separator()}
-          className="h-full"
           isReadOnly={isReadOnly}
           value={field.separator}
           onValueChange={(separator): void =>
@@ -158,7 +157,6 @@ function Field({
       <td>
         <Button.Small
           aria-label={commonText.remove()}
-          className="h-full"
           title={commonText.remove()}
           variant={className.dangerButton}
           onClick={handleRemove}
@@ -181,7 +179,7 @@ function FieldFormatter({
   if (lastField === undefined) return null;
   else if (!lastField.isRelationship)
     return (
-      <Label.Inline className="h-full w-full">
+      <Label.Inline className="w-full">
         <GenericFormatterPickList
           itemsPromise={fetchFieldFormatters}
           table={lastField.table}
@@ -197,7 +195,7 @@ function FieldFormatter({
     );
   else if (relationshipIsToMany(lastField))
     return (
-      <Label.Inline className="h-full w-full">
+      <Label.Inline className="w-full">
         <FormattersPickList
           table={lastField.relatedTable}
           type="aggregators"
@@ -213,7 +211,7 @@ function FieldFormatter({
     );
   else
     return (
-      <Label.Inline className="h-full w-full">
+      <Label.Inline className="w-full">
         {resourcesText.formatter()}
         <FormattersPickList
           table={lastField.relatedTable}

--- a/specifyweb/frontend/js_src/lib/utils/types.ts
+++ b/specifyweb/frontend/js_src/lib/utils/types.ts
@@ -155,6 +155,8 @@ export function setDevelopmentGlobal(name: string, value: unknown): void {
  * const tools = ['CollectionObject', 'Locality'] as const;
  * ensure<RA<TableName>>(tools);
  * ```
+ *
+ * REFACTOR: update typescript, and replace this function with TypeScript's satisfies operator
  */
 export const ensure =
   <T>() =>


### PR DESCRIPTION
Fixes #4380 

### Checklist

- [x] Self-review the PR after opening it to make sure the changes look good
      and self-explanatory (or properly documented)
- [x] Add relevant issue to release milestone

### Testing instructions

- open app resource 
- open formatters
- choose a table 
- add nested fields
- verify they are next to each other and not stacked above each other when "Customize Field Formatters" in not checked.  
