### PR TITLE
build(package.json): remove version from package.json

### DIFF
--- a/specifyweb/frontend/js_src/package-lock.json
+++ b/specifyweb/frontend/js_src/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "specify7-frontend",
-  "version": "7.8.5",
+  "version": "1.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "specify7-frontend",
-      "version": "7.8.5",
+      "version": "1.0.0",
       "license": "GPL-2.0",
       "dependencies": {
         "@codemirror/lang-json": "^6.0.0",

--- a/specifyweb/frontend/js_src/package.json
+++ b/specifyweb/frontend/js_src/package.json
@@ -1,6 +1,6 @@
 {
   "name": "specify7-frontend",
-  "version": "7.8.5",
+  "version": "1.0.0",
   "private": true,
   "description": "Specify software manages species and specimen data for biological research collections. As a database platform, it tracks specimen transactions, links images to specimen records and publishes data to the Internet.",
   "license": "GPL-2.0",


### PR DESCRIPTION
Remove version from package.json (or rather set it to 1.0.0 as version number must be included). Reasons:

- We forget to update this version number so it get's out of date
- It is redundant with the way we set versions right now (using git tag name)
- Since our package.json is not an npm module, version does not matter
- We want to gradually reduce references to specific versions of specify - ideally there would be no specify 6, and no specify 7.x.x - just specify


### Checklist

- [x] Self-review the PR after opening it to make sure the changes look good
      and self-explanatory (or properly documented)