### PR TITLE
Ensure files are only downloaded once

### DIFF
--- a/specifyweb/frontend/js_src/lib/components/Molecules/FilePicker.tsx
+++ b/specifyweb/frontend/js_src/lib/components/Molecules/FilePicker.tsx
@@ -132,9 +132,10 @@ export const downloadFile = async (
   text: string
 ): Promise<void> =>
   new Promise((resolve) => {
+    let fileDownloaded = false;
     const iframe = document.createElement('iframe');
     iframe.addEventListener('load', () => {
-      if (iframe.contentWindow === null) return;
+      if (iframe.contentWindow === null || fileDownloaded) return;
       const element = iframe.contentWindow.document.createElement('a');
       element.setAttribute(
         'href',
@@ -146,6 +147,7 @@ export const downloadFile = async (
       iframe.contentWindow.document.body.append(element);
 
       element.click();
+      fileDownloaded = true;
       globalThis.setTimeout(() => {
         iframe.remove();
         resolve();


### PR DESCRIPTION
Fixes #2638 

The issue here is that for certain browsers the `load` event was being triggered twice where the `iframe.contentWindow` was not null
https://github.com/specify/specify7/blob/1e9be50f5bfd2a72101fbe4854781492a48a27d1/specifyweb/frontend/js_src/lib/components/Molecules/FilePicker.tsx#L136-L153

The load event was being fired and caught both when the `iframe` was appended to the document and when the content within the iframe was being closed. In both cases the `iframe.contentWindow` was not null, so the initial return was never caught and the `element.click()` was called twice. 
https://github.com/specify/specify7/blob/1e9be50f5bfd2a72101fbe4854781492a48a27d1/specifyweb/frontend/js_src/lib/components/Molecules/FilePicker.tsx#L155-L158

### Checklist

- [x] Self-review the PR after opening it to make sure the changes look good
      and self-explanatory (or properly documented)
- [ ] Add automated tests
- [ ] Add relevant issue to release milestone

### Testing instructions
In each of Google Chrome, Firefox, and Safari, try actions which would download a file directly, not using the Notification system. 
(#2638 did not affect files downloaded from the notification system) 

Here are a few places in Specify where this can be accomplished:
(This likely do not _all_ need to be tested, as they all utilize the same `downloadFile` function for functionality)

- Exporting Query Results (when at least one result is selected)
- Downloading Statistics as TSV
- Downloading an AppResource
- Downloading a Viewset
- Downloading the content of the Crash Report Visualizer as HTML
  - Accessible by navigating to `/specify/developer/crash-report-visualizer`
- Downloading System/Specify information from the About Specify page
  - Accessible via User Tools
- Downloading the Specify datamodel/schema from the Database Schema page
  - Accessible via User Tools 
 
 If other browsers are tested, please mention them in your comment. 