### PR TITLE
tests: await async tree tests

### DIFF
--- a/specifyweb/frontend/js_src/lib/components/PickLists/__tests__/treeLevelPicklist.test.ts
+++ b/specifyweb/frontend/js_src/lib/components/PickLists/__tests__/treeLevelPicklist.test.ts
@@ -43,30 +43,36 @@ const melasResponse = {
 
 overrideAjax('/api/specify/taxon/2/', animaliaResponse);
 overrideAjax('/api/specify/taxon/3/', chordataResponse);
+overrideAjax('/api/specify/taxon/?limit=1&parent=2&orderby=rankid', {
+  objects: [chordataResponse],
+  meta: {
+    limit: 1,
+    offset: 0,
+    total_count: 2,
+  },
+});
 
 test('fetchLowestChildRank', async () => {
-  const animalia = new tables.Taxon.Resource({ id: 2 });
+  const animalia = new tables.Taxon.Resource(
+    { id: 2 },
+    { noBusinessRules: true }
+  );
   await animalia.fetch();
 
-  expect(fetchLowestChildRank(animalia)).resolves.toBe(30);
+  await expect(fetchLowestChildRank(animalia)).resolves.toBe(30);
 });
 
 describe('fetchPossibleRanks', () => {
-  overrideAjax('/api/specify/taxon/?limit=1&parent=2&orderby=rankid', {
-    objects: [chordataResponse],
-    meta: {
-      limit: 1,
-      offset: 0,
-      total_count: 2,
-    },
-  });
   test('fetchPossibleRanks', async () => {
-    const animalia = new tables.Taxon.Resource({ id: 2 });
+    const animalia = new tables.Taxon.Resource(
+      { id: 2 },
+      { noBusinessRules: true }
+    );
     await animalia.fetch();
 
     const lowestChildRank = await fetchLowestChildRank(animalia);
 
-    expect(
+    await expect(
       fetchPossibleRanks(lowestChildRank, animalia.id, 'Taxon')
     ).resolves.toEqual([
       {
@@ -85,12 +91,15 @@ describe('fetchPossibleRanks', () => {
     },
   });
   test('only next enforced is fetched', async () => {
-    const chordata = new tables.Taxon.Resource({ id: 3 });
+    const chordata = new tables.Taxon.Resource(
+      { id: 3 },
+      { noBusinessRules: true }
+    );
     await chordata.fetch();
 
     const lowestChildRank = await fetchLowestChildRank(chordata);
 
-    expect(
+    await expect(
       fetchPossibleRanks(lowestChildRank, chordata.id, 'Taxon')
     ).resolves.toEqual([
       {

--- a/specifyweb/frontend/js_src/lib/components/QueryBuilder/fromTree.ts
+++ b/specifyweb/frontend/js_src/lib/components/QueryBuilder/fromTree.ts
@@ -183,7 +183,7 @@ export async function queryFromTree(
     getTreeTable(tableName),
     `Unable to contract a tree query from the ${tableName} table`
   );
-  const node = new tree.Resource({ id: nodeId });
+  const node = new tree.Resource({ id: nodeId }, { noBusinessRules: true });
   await node.fetch();
 
   const query = createQuery(

--- a/specifyweb/frontend/js_src/lib/utils/__tests__/functools.test.ts
+++ b/specifyweb/frontend/js_src/lib/utils/__tests__/functools.test.ts
@@ -49,14 +49,13 @@ test('f.log', () => {
   expect(consoleLog).toHaveBeenCalledWith('Console', 'log');
 });
 
-test('f.all', async () => {
-  await expect(
+test('f.all', async () =>
+  expect(
     f.all({
       a: Promise.resolve('a1'),
       b: 'b1',
     })
-  ).resolves.toEqual({ a: 'a1', b: 'b1' });
-});
+  ).resolves.toEqual({ a: 'a1', b: 'b1' }));
 
 describe('f.sum', () => {
   test('empty case', () => expect(f.sum([])).toBe(0));


### PR DESCRIPTION
When using `expect(...).resolves`, a promise is returned
I forgot to await that promise in a few tests
This meant that if test fails, the failure would be printed in the console, but the test would still be considered passing

We already have an ESLint rule that cathes this case, but, because there are too many errors highlighted, it got lost in the noise - something I definitely want to fix (as soon as xml-editor is out)

### Checklist

- [x] Self-review the PR after opening it to make sure the changes look good
      and self-explanatory (or properly documented)
- [x] Add automated tests