### PR TITLE
Move delete button from main spapp resource to edit dialog

### DIFF
--- a/specifyweb/frontend/js_src/lib/components/AppResources/Editor.tsx
+++ b/specifyweb/frontend/js_src/lib/components/AppResources/Editor.tsx
@@ -27,7 +27,6 @@ import type {
   SpViewSetObj as SpViewSetObject,
 } from '../DataModel/types';
 import { useResourceView } from '../Forms/BaseResourceView';
-import { DeleteButton } from '../Forms/DeleteButton';
 import { SaveButton } from '../Forms/Save';
 import { AppTitle } from '../Molecules/AppTitle';
 import { hasToolPermission } from '../Permissions/helpers';
@@ -221,11 +220,6 @@ export function AppResourceEditor({
 
   const footer = (
     <>
-      {!appResource.isNew() &&
-      hasToolPermission('resources', 'delete') &&
-      typeof handleDeleted === 'function' ? (
-        <DeleteButton resource={appResource} onDeleted={handleDeleted} />
-      ) : undefined}
       <span className="-ml-2 flex-1" />
       {formElement !== null &&
       hasToolPermission(
@@ -362,7 +356,13 @@ export function AppResourceEditor({
           <h3 className="overflow-auto whitespace-nowrap text-2xl">
             {formatted}
           </h3>
-          <AppResourceEditButton title={title}>{form()}</AppResourceEditButton>
+          <AppResourceEditButton
+            appResource={appResource}
+            title={title}
+            onDeleted={handleDeleted}
+          >
+            {form()}
+          </AppResourceEditButton>
         </div>
         <AppTitle title={formatted} />
       </div>

--- a/specifyweb/frontend/js_src/lib/components/AppResources/EditorComponents.tsx
+++ b/specifyweb/frontend/js_src/lib/components/AppResources/EditorComponents.tsx
@@ -25,8 +25,10 @@ import type { SerializedResource } from '../DataModel/helperTypes';
 import type { SpecifyResource } from '../DataModel/legacyTypes';
 import { useSaveBlockers } from '../DataModel/saveBlockers';
 import type { SpAppResource, SpViewSetObj } from '../DataModel/types';
+import { DeleteButton } from '../Forms/DeleteButton';
 import { Dialog } from '../Molecules/Dialog';
 import { downloadFile, FilePicker, fileToText } from '../Molecules/FilePicker';
+import { hasToolPermission } from '../Permissions/helpers';
 import { userPreferences } from '../Preferences/userPreferences';
 import type { BaseSpec } from '../Syncer';
 import type { SimpleXmlNode } from '../Syncer/xmlToJson';
@@ -59,9 +61,13 @@ export const appResourceIcon = (
 export function AppResourceEditButton({
   title,
   children,
+  appResource,
+  onDeleted: handleDeleted,
 }: {
   readonly title: LocalizedString;
   readonly children: JSX.Element;
+  readonly appResource: SpecifyResource<SpAppResource>;
+  readonly onDeleted: (() => void) | undefined;
 }): JSX.Element {
   const [isEditingMeta, handleEditingMeta, handleEditedMeta] =
     useBooleanState();
@@ -70,7 +76,20 @@ export function AppResourceEditButton({
       <DataEntry.Edit onClick={handleEditingMeta} />
       {isEditingMeta && (
         <Dialog
-          buttons={commonText.close()}
+          buttons={
+            <>
+              {!appResource.isNew() &&
+              hasToolPermission('resources', 'delete') &&
+              typeof handleDeleted === 'function' ? (
+                <DeleteButton
+                  resource={appResource}
+                  onDeleted={handleDeleted}
+                />
+              ) : undefined}
+              <span className="-ml-2 flex-1" />
+              <Button.DialogClose>{commonText.close()}</Button.DialogClose>
+            </>
+          }
           dimensionsKey="AppResourceEdit"
           header={title}
           onClose={handleEditedMeta}


### PR DESCRIPTION
Fixes #4422

### Checklist

- [x] Self-review the PR after opening it to make sure the changes look good
      and self-explanatory (or properly documented)
- [x] Add relevant issue to release milestone

### Testing instructions

- go to app resource 
- open a form definition 
- verify the delete button is not present anymore in the left bottom corner 
- click on the pencil next to the form definition title
- delete the form def using the delete button in the newly opened dialog

