### PR TITLE
fix(Dialog): improve useFreezeDialogSize logic

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -10,7 +10,9 @@ jobs:
     # "push" event is not triggered for forks, so need to listen for
     # pull_requests, but only for external ones, so as not to run the action
     # twice
-    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == true
+    if:
+      github.event_name != 'pull_request' ||
+      github.event.pull_request.head.repo.fork == true
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -27,6 +29,8 @@ jobs:
           elif [[ $GITHUB_REF == refs/tags/* ]]; then
             VERSION=${GITHUB_REF#refs/tags/}
           elif [[ $GITHUB_REF == refs/heads/* ]]; then
+            # Docker does not like / in tag names, so replace them with -
+            # See https://github.com/specify/specify7-test-panel/issues/110#issuecomment-1943045253
             VERSION=$(echo ${GITHUB_REF#refs/heads/} | sed -r 's#/+#-#g')
             if [ "${{ github.event.repository.default_branch }}" = "$VERSION" ]; then
               VERSION=edge
@@ -50,7 +54,7 @@ jobs:
           echo "version=${VERSION}" >> $GITHUB_OUTPUT
           echo "tags=${TAGS}" >> $GITHUB_OUTPUT
           echo "created=$(date -u +'%Y-%m-%dT%H:%M:%SZ')" >> $GITHUB_OUTPUT
-          
+
           # Determine the platforms based on the branch
           PLATFORMS="linux/amd64"
           REF_NAME=$(echo "${GITHUB_REF#refs/*/}")
@@ -60,7 +64,7 @@ jobs:
             PLATFORMS="linux/arm64"
           fi
           echo "platforms=${PLATFORMS}" >> $GITHUB_ENV
-      
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
 

--- a/specifyweb/frontend/js_src/lib/components/Atoms/Internationalization.ts
+++ b/specifyweb/frontend/js_src/lib/components/Atoms/Internationalization.ts
@@ -48,7 +48,11 @@ declare namespace Intl {
     public constructor(
       locales?: RA<string> | string,
       options?: {
-        readonly unit: 'byte'; // TODO: Expand unit
+        /*
+         * Full list of possible units:
+         * https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat/NumberFormat#unit_2
+         */
+        readonly unit: 'byte';
         readonly notation:
           | 'compact'
           | 'engineering'

--- a/specifyweb/frontend/js_src/lib/components/Molecules/Dialog.tsx
+++ b/specifyweb/frontend/js_src/lib/components/Molecules/Dialog.tsx
@@ -14,10 +14,11 @@ import { useCachedState } from '../../hooks/useCachedState';
 import { useId } from '../../hooks/useId';
 import { listen } from '../../utils/events';
 import { f } from '../../utils/functools';
-import { KEY } from '../../utils/utils';
+import { KEY, removeKey } from '../../utils/utils';
 import { Button, DialogContext } from '../Atoms/Button';
 import { className, dialogIconTriggers } from '../Atoms/className';
 import { dialogIcons } from '../Atoms/Icons';
+import { SECOND } from '../Atoms/timeUnits';
 import { LoadingContext } from '../Core/Contexts';
 import {
   useHighContrast,
@@ -276,7 +277,8 @@ export function Dialog({
     container,
     isOpen,
     dimensionsKey,
-    handleResize
+    handleResize,
+    `${containerClassName}${contentClassName}`
   );
 
   const [rememberPosition] = userPreferences.use(
@@ -315,26 +317,24 @@ export function Dialog({
     [positionKey]
   );
 
-  useFreezeDialogSize(container, dimensionsKey);
-
   const isFullScreen = containerClassName.includes(dialogClassNames.fullScreen);
 
   const draggableContainer: Props['contentElement'] = React.useCallback(
     (props: React.ComponentPropsWithRef<'div'>, children: React.ReactNode) => (
       <Draggable
         // Don't allow moving the dialog past the window bounds
+        bounds="parent"
+        // Don't allow moving when in full-screen
+        cancel={`#${id('full-screen')}`}
+        defaultClassName=""
+        // Don't need any extra classNames
+        defaultClassNameDragged=""
+        defaultClassNameDragging=""
+        defaultPosition={initialPosition}
+        // Allow moving the dialog when hovering over the header line
         handle={`#${id('handle')}`}
         nodeRef={containerRef}
         onStop={handleDragged}
-        bounds="parent"
-        // Allow moving the dialog when hovering over the header line
-        cancel={`#${id('full-screen')}`}
-        defaultClassName=""
-        // Don't allow moving when in full-screen
-        defaultClassNameDragging=""
-        defaultPosition={initialPosition}
-        // Don't need any extra classNames
-        defaultClassNameDragged=""
       >
         <div {...props}>{children}</div>
       </Draggable>
@@ -539,7 +539,8 @@ function useDialogSize(
   container: HTMLElement | null,
   isOpen: boolean,
   dimensionsKey: string | undefined,
-  handleResize: ((container: HTMLElement) => void) | undefined
+  handleResize: ((container: HTMLElement) => void) | undefined,
+  resizeKey: string
 ): { readonly width: number; readonly height: number } | undefined {
   const [rememberSize] = userPreferences.use(
     'general',
@@ -548,13 +549,20 @@ function useDialogSize(
   );
   const sizeKey = rememberSize ? dimensionsKey : undefined;
   const [dialogSizes = {}, setDialogSizes] = useCachedState('dialogs', 'sizes');
+  const dialogSizesRef = React.useRef(dialogSizes);
+  dialogSizesRef.current = dialogSizes;
+
+  const handleResized = useFreezeDialogSize(
+    sizeKey === undefined ? null : container,
+    `${sizeKey ?? ''}${resizeKey}`
+  );
+
   /*
    * If two dialogs with the same dimensionsKey are rendered, changing one dialog's
    * dimensions shouldn't affect the other
    */
-
   const initialSize = React.useMemo(() => {
-    const sizes = dialogSizes[sizeKey ?? ''];
+    const sizes = dialogSizesRef.current[sizeKey ?? ''];
     return typeof sizes === 'object'
       ? {
           width: sizes[0],
@@ -568,14 +576,19 @@ function useDialogSize(
     if (
       !isOpen ||
       container === null ||
-      (handleResize === undefined && sizeKey === undefined) ||
-      globalThis.ResizeObserver === undefined
+      (handleResize === undefined && sizeKey === undefined)
     )
       return undefined;
 
-    const observer = new globalThis.ResizeObserver(() => {
+    const observer = new ResizeObserver(() => {
       handleResize?.(container);
+      handleResized?.();
       if (typeof sizeKey === 'string') {
+        /*
+         * Looking at the style attributes rather than actual element size to
+         * record whether the user resized the dialog (rather than dialog
+         * resized due to browser window change)
+         */
         const width = f.parseInt(container.style.width);
         const height = f.parseInt(container.style.height);
         if (typeof width === 'number' && typeof height === 'number')
@@ -588,7 +601,7 @@ function useDialogSize(
     observer.observe(container);
 
     return (): void => observer.disconnect();
-  }, [isOpen, container, handleResize, sizeKey]);
+  }, [isOpen, container, handleResized, handleResize, sizeKey, setDialogSizes]);
 
   return initialSize;
 }
@@ -605,44 +618,72 @@ function useTitleChangeNotice(dimensionKey: string | undefined): void {
   }, [dimensionKey]);
 }
 
+/**
+ * Don't freeze the dialog size during the first 2 seconds since it's opening
+ * to give time for data to load (i.e. the loader might be taller than the
+ * actual content, or the content might have moved around while loading)
+ */
+const freezeSizeAfter = 2 * SECOND;
+
+/**
+ * Try to reduce layout shifts by preventing the dialog size from shrinking
+ * if dialog wasn't explicitly resized by the user
+ */
 function useFreezeDialogSize(
-  containerSizeRef: HTMLDivElement | null,
-  dimensionKey: string | undefined
-): void {
+  containerSizeRef: HTMLElement | null,
+  sizeKey: string
+): () => void {
+  const handleResized = React.useRef<(() => void) | undefined>(undefined);
   React.useEffect(() => {
-    if (dimensionKey === undefined) return;
-    if (containerSizeRef === null) return undefined;
+    if (sizeKey === undefined || containerSizeRef === null) return;
     let oldHeight = containerSizeRef.offsetHeight;
     let oldWidth = containerSizeRef.offsetWidth;
-    const resizeObserver = new ResizeObserver(() => {
+    const openTime = Date.now();
+
+    handleResized.current = (): void => {
+      const timeSinceOpen = Date.now() - openTime;
+      if (timeSinceOpen < freezeSizeAfter) return;
+
       const newHeight = containerSizeRef.offsetHeight;
       const newWidth = containerSizeRef.offsetWidth;
 
       const width = f.parseInt(containerSizeRef.style.width);
       const height = f.parseInt(containerSizeRef.style.height);
-      const hasBeenChanged =
+      const userResizedDialog =
         typeof width === 'number' && typeof height === 'number';
 
-      if (oldHeight !== undefined && newHeight < oldHeight && !hasBeenChanged) {
-        containerSizeRef.style.minHeight = `${oldHeight}px`;
+      /*
+       * Using min width/height rather than width/height because width/height
+       * are reserved for the user (they are set when user resizes the dialog).
+       * This allows to determine if the user resized the dialog or not.
+       *
+       * The drawback though is that min-width takes precedence over max-width,
+       * thus could cause dialog size overflow
+       */
+      if (
+        oldHeight !== undefined &&
+        newHeight < oldHeight &&
+        !userResizedDialog
+      ) {
+        containerSizeRef.style.minHeight = `min(100vh, ${oldHeight}px)`;
       } else oldHeight = newHeight;
 
-      if (oldWidth !== undefined && newWidth < oldWidth && !hasBeenChanged) {
-        containerSizeRef.style.minWidth = `${oldWidth}px`;
+      if (oldWidth !== undefined && newWidth < oldWidth && !userResizedDialog) {
+        containerSizeRef.style.minWidth = `min(100vw, ${oldWidth}px)`;
       } else oldWidth = newWidth;
 
-      if (hasBeenChanged) {
+      if (userResizedDialog) {
         containerSizeRef.style.minHeight = '';
         containerSizeRef.style.minWidth = '';
       }
-    });
+    };
 
-    resizeObserver.observe(containerSizeRef);
-
-    return () => {
-      resizeObserver.disconnect();
+    return (): void => {
+      handleResized.current = undefined;
       containerSizeRef.style.minHeight = '';
       containerSizeRef.style.minWidth = '';
     };
-  }, [containerSizeRef, dimensionKey]);
+  }, [containerSizeRef, sizeKey]);
+
+  return React.useCallback(() => handleResized.current?.(), []);
 }

--- a/specifyweb/frontend/js_src/lib/components/Molecules/Dialog.tsx
+++ b/specifyweb/frontend/js_src/lib/components/Molecules/Dialog.tsx
@@ -278,7 +278,8 @@ export function Dialog({
     isOpen,
     dimensionsKey,
     handleResize,
-    `${containerClassName}${contentClassName}`
+    `${containerClassName}${contentClassName}`,
+    modal
   );
 
   const [rememberPosition] = userPreferences.use(
@@ -540,7 +541,8 @@ function useDialogSize(
   isOpen: boolean,
   dimensionsKey: string | undefined,
   handleResize: ((container: HTMLElement) => void) | undefined,
-  resizeKey: string
+  resizeKey: string,
+  modal: boolean
 ): { readonly width: number; readonly height: number } | undefined {
   const [rememberSize] = userPreferences.use(
     'general',
@@ -553,7 +555,7 @@ function useDialogSize(
   dialogSizesRef.current = dialogSizes;
 
   const handleResized = useFreezeDialogSize(
-    sizeKey === undefined ? null : container,
+    sizeKey === undefined || !modal ? null : container,
     `${sizeKey ?? ''}${resizeKey}`
   );
 

--- a/specifyweb/frontend/js_src/lib/components/Molecules/Dialog.tsx
+++ b/specifyweb/frontend/js_src/lib/components/Molecules/Dialog.tsx
@@ -14,7 +14,7 @@ import { useCachedState } from '../../hooks/useCachedState';
 import { useId } from '../../hooks/useId';
 import { listen } from '../../utils/events';
 import { f } from '../../utils/functools';
-import { KEY, removeKey } from '../../utils/utils';
+import { KEY } from '../../utils/utils';
 import { Button, DialogContext } from '../Atoms/Button';
 import { className, dialogIconTriggers } from '../Atoms/className';
 import { dialogIcons } from '../Atoms/Icons';

--- a/specifyweb/frontend/js_src/lib/components/Molecules/SvgIcon.tsx
+++ b/specifyweb/frontend/js_src/lib/components/Molecules/SvgIcon.tsx
@@ -16,7 +16,7 @@ export function SvgIcon({
   readonly label: string | undefined;
   readonly className: string;
   readonly autoGenerate?: boolean;
-}) {
+}): JSX.Element {
   const shortName = nameMapper()[name] ?? getShortName(name);
   const autoName = name.startsWith(shortName[0]) ? name : shortName;
   const [from, to] = colorMapper()[name] ?? [

--- a/specifyweb/frontend/js_src/lib/components/SpecifyNetwork/Overlay.tsx
+++ b/specifyweb/frontend/js_src/lib/components/SpecifyNetwork/Overlay.tsx
@@ -61,7 +61,8 @@ export function useBrokerData(
       // Prefer the species name from an aggregator over local as it is more trustworthy
       occurrence === undefined
         ? undefined
-        : extractBrokerField(occurrence, 'gbif', 'dwc:scientificName') ??
+        : // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
+          extractBrokerField(occurrence, 'gbif', 'dwc:scientificName') ||
           localSpecies,
     [occurrence, localSpecies]
   );

--- a/specifyweb/frontend/js_src/lib/components/SpecifyNetwork/hooks.tsx
+++ b/specifyweb/frontend/js_src/lib/components/SpecifyNetwork/hooks.tsx
@@ -5,9 +5,7 @@ import type { RA } from '../../utils/types';
 import type { BrokerRecord } from './fetchers';
 import { fetchName, fetchOccurrence } from './fetchers';
 
-export function useOccurrence(
-  guid: string | undefined = ''
-): RA<BrokerRecord> | undefined {
+export function useOccurrence(guid = ''): RA<BrokerRecord> | undefined {
   return useAsyncState(
     React.useCallback(
       async () => (guid === '' ? [] : fetchOccurrence(guid)),
@@ -17,12 +15,10 @@ export function useOccurrence(
   )[0];
 }
 
-export function useSpecies(
-  speciesName: string | undefined
-): RA<BrokerRecord> | undefined {
+export function useSpecies(speciesName = ''): RA<BrokerRecord> | undefined {
   return useAsyncState(
     React.useCallback(
-      async () => (speciesName === undefined ? [] : fetchName(speciesName)),
+      async () => (speciesName === '' ? [] : fetchName(speciesName)),
       [speciesName]
     ),
     false

--- a/specifyweb/frontend/js_src/lib/hooks/useCachedState.tsx
+++ b/specifyweb/frontend/js_src/lib/hooks/useCachedState.tsx
@@ -17,7 +17,7 @@ import type { GetOrSet } from '../utils/types';
  * Can display some sort of loading message while the value is undefined
  */
 export function useCachedState<
-  CATEGORY extends string & keyof CacheDefinitions,
+  CATEGORY extends keyof CacheDefinitions,
   KEY extends string & keyof CacheDefinitions[CATEGORY]
 >(
   category: CATEGORY,


### PR DESCRIPTION
See PR description in https://github.com/specify/specify7/pull/4433#issuecomment-1943078176

<details>
<summary>Old Description</summary>
Fixes #4385 

### Checklist

- [ ] Self-review the PR after opening it to make sure the changes look good
      and self-explanatory (or properly documented)
- [x] Add relevant issue to release milestone

### Testing instructions

- open app resource
- click on add resource 
- click form definition 
- verify that the dialog to define the name of the def is smaller than before 

</details>

Testing instructions

Verify that https://github.com/specify/specify7/issues/4519 is fixed
Verify that https://github.com/specify/specify7/issues/4511 is fixed
Verify that opening GeoMap in full screen, and then reducing the browser window size does not cause dialog to overflow (should not have horizontal scroll bar)