### PR TITLE
Better handling of filters when checking resources in local collections

### DIFF
--- a/specifyweb/frontend/js_src/lib/components/DataModel/__tests__/businessRules.test.ts
+++ b/specifyweb/frontend/js_src/lib/components/DataModel/__tests__/businessRules.test.ts
@@ -1,3 +1,4 @@
+import { overrideAjax } from '../../../tests/ajax';
 import { mockTime, requireContext } from '../../../tests/helpers';
 import { overwriteReadOnly } from '../../../utils/types';
 import { getResourceApiUrl } from '../resource';
@@ -88,5 +89,84 @@ describe('DNASequence business rules', () => {
     expect(dNASequence.get('compG')).toBe(2);
     expect(dNASequence.get('compC')).toBe(1);
     expect(dNASequence.get('ambiguousResidues')).toBe(4);
+  });
+});
+
+describe('uniqueness rules', () => {
+  overrideAjax(
+    '/api/specify/collectionobject/?domainfilter=false&catalognumber=000000001&collection=4&offset=0',
+    {
+      objects: [
+        {
+          id: 1,
+          catalogNumber: '000000001',
+          collection: '/api/specify/collection/4/',
+        },
+      ],
+      meta: {
+        limit: 20,
+        offset: 0,
+        total_count: 1,
+      },
+    }
+  );
+  test('simple uniqueness rule', async () => {
+    const collectionObject = new schema.models.CollectionObject.Resource({
+      collection: '/api/specify/collection/4/',
+      catalogNumber: '000000001',
+    });
+    await collectionObject.businessRuleManager?.checkField('catalogNumber');
+    expect(collectionObject.saveBlockers?.blockers).toMatchInlineSnapshot(`
+      {
+        "br-uniqueness-catalognumber": {
+          "deferred": false,
+          "fieldName": "catalognumber",
+          "reason": "Value must be unique to Collection",
+          "resource": {
+            "_tableName": "CollectionObject",
+            "catalognumber": "000000001",
+            "collection": "/api/specify/collection/4/",
+          },
+        },
+      }
+    `);
+  });
+
+  test('rule with local collection', async () => {
+    const accessionId = 1;
+    const accession = new schema.models.Accession.Resource({
+      id: accessionId,
+    });
+
+    const accessionAgent1 = new schema.models.AccessionAgent.Resource({
+      accession: getResourceApiUrl('Accession', accessionId),
+      agent: getResourceApiUrl('Agent', 1),
+      role: 'Borrower',
+    });
+    const accessionAgent2 = new schema.models.AccessionAgent.Resource({
+      accession: getResourceApiUrl('Accession', accessionId),
+      agent: getResourceApiUrl('Agent', 1),
+      role: 'Borrower',
+    });
+
+    accession.set('accessionAgents', [accessionAgent1, accessionAgent2]);
+
+    await accessionAgent2.businessRuleManager?.checkField('role');
+
+    expect(accessionAgent2.saveBlockers?.blockers).toMatchInlineSnapshot(`
+      {
+        "br-uniqueness-role": {
+          "deferred": false,
+          "fieldName": "role",
+          "reason": "Values of Role and Agent must be unique to Accession",
+          "resource": {
+            "_tableName": "AccessionAgent",
+            "accession": "/api/specify/accession/1/",
+            "agent": "/api/specify/agent/1/",
+            "role": "Borrower",
+          },
+        },
+      }
+    `);
   });
 });

--- a/specifyweb/frontend/js_src/lib/components/DataModel/businessRules.ts
+++ b/specifyweb/frontend/js_src/lib/components/DataModel/businessRules.ts
@@ -10,7 +10,6 @@ import { businessRuleDefs } from './businessRuleDefs';
 import { backboneFieldSeparator, djangoLookupSeparator } from './helpers';
 import type { AnySchema, AnyTree, CommonFields } from './helperTypes';
 import type { SpecifyResource } from './legacyTypes';
-import { getResourceApiUrl } from './resource';
 import { SaveBlockers } from './saveBlockers';
 import type { LiteralField, Relationship } from './specifyField';
 import type { Collection, SpecifyModel } from './specifyModel';
@@ -234,65 +233,157 @@ export class BusinessRuleManager<SCHEMA extends AnySchema> {
       ),
     };
 
-    const hasSameValues = (
+    const getFieldValue = async (
+      resource: SpecifyResource<AnySchema>,
+      fieldName: string
+    ): Promise<{
+      readonly id: number | undefined;
+      readonly cid: string | undefined;
+      readonly value: number | string | null | undefined;
+    }> => {
+      const localCollection = resource.collection ?? {
+        models: [],
+        field: undefined,
+      };
+
+      const collectionField = localCollection.field;
+      if (
+        localCollection.related !== undefined &&
+        collectionField?.name === fieldName.split(djangoLookupSeparator)[0]
+      ) {
+        const related = localCollection.related;
+        const splitName = fieldName.split(djangoLookupSeparator);
+        return splitName.length === 1
+          ? ({ id: related.id, cid: related.cid, value: related.id } as const)
+          : getFieldValue(
+              related,
+              fieldName
+                .split(djangoLookupSeparator)
+                .slice(1)
+                .join(djangoLookupSeparator)
+            );
+      }
+
+      const related: SpecifyResource<AnySchema> | number | string | null =
+        await resource.getRelated(
+          fieldName.replaceAll(djangoLookupSeparator, backboneFieldSeparator)
+        );
+      return {
+        id: related?.id,
+        cid: related?.cid,
+        value:
+          related?.cid === undefined
+            ? (related as unknown as number | string | null)
+            : related.id,
+      } as const;
+    };
+
+    const generateFilters = async (
+      resource: SpecifyResource<AnySchema>,
+      fieldNames: RA<string>
+    ): Promise<
+      IR<{
+        readonly id: number | undefined;
+        readonly cid: string | undefined;
+        readonly value: number | string | null | undefined;
+      }>
+    > =>
+      Object.fromEntries(
+        await Promise.all(
+          fieldNames.map(async (fieldName) => [
+            fieldName,
+            await getFieldValue(resource, fieldName),
+          ])
+        )
+      );
+
+    const hasSameValues = async (
       other: SpecifyResource<SCHEMA>,
-      fieldValues: IR<number | string | null | undefined>
-    ): boolean => {
+      fieldValues: IR<{
+        readonly id: number | undefined;
+        readonly cid: string | undefined;
+        readonly value: number | string | null | undefined;
+      }>
+    ): Promise<boolean> => {
       if (other.id != null && other.id === this.resource.id) return false;
       if (other.cid === this.resource.cid) return false;
 
-      return Object.entries(fieldValues).reduce(
-        (result, [fieldName, value]) => {
-          const field = other.specifyModel.getField(fieldName);
-          const adjustedValue =
-            field?.isRelationship &&
-            typeof value === 'number' &&
-            field.type === 'many-to-one'
-              ? getResourceApiUrl(field.relatedModel.name, value)
-              : value;
-          return result && adjustedValue === other.get(fieldName);
-        },
-        true
+      const otherFilters = await generateFilters(
+        other,
+        Object.keys(fieldValues)
+      );
+
+      return Object.entries(otherFilters).every(
+        ([fieldName, otherFieldValues]) => {
+          const {
+            id: otherId,
+            cid: otherCid,
+            value: otherValue,
+          } = otherFieldValues;
+          const { id, cid, value } = fieldValues[fieldName];
+          if (otherCid !== undefined && cid !== undefined && otherCid === cid)
+            return true;
+          if (otherId !== undefined && id !== undefined && otherId === id)
+            return true;
+          return (
+            otherId === undefined &&
+            otherCid === undefined &&
+            otherValue === value
+          );
+        }
       );
     };
 
-    const filters = Object.fromEntries(
+    const localCollection = this.resource.collection ?? {
+      models: [],
+      field: undefined,
+    };
+
+    const filters = await generateFilters(this.resource, [
+      ...rule.fields,
+      ...rule.scopes,
+    ]);
+
+    const duplicates = filterArray(
       await Promise.all(
-        [...rule.fields, ...rule.scopes].map(async (field) => {
-          const related: SpecifyResource<AnySchema> | number | string | null =
-            await this.resource.getRelated(
-              field.replaceAll(djangoLookupSeparator, backboneFieldSeparator)
-            );
-          return [field, related.id === undefined ? related : related.id];
+        localCollection.models.map(async (other) => {
+          const isDuplicate = await hasSameValues(other, filters);
+          return isDuplicate ? other : undefined;
         })
       )
-    ) as unknown as Partial<
-      CommonFields &
-        Readonly<Record<string, boolean | number | string | null>> &
-        SCHEMA['fields'] & {
-          readonly orderby: string;
-        }
-    >;
-
-    if (
-      Object.entries(filters).some(([_field, value]) => value === undefined)
-    ) {
-      const localCollection = this.resource.collection ?? { models: [] };
-      const duplicates = localCollection.models.filter((other) =>
-        hasSameValues(other, filters as IR<number | string | null | undefined>)
-      );
-      if (duplicates.length > 0) {
-        overwriteReadOnly(invalidResponse, 'localDuplicates', duplicates);
-        return invalidResponse;
-      } else return { valid: true };
+    );
+    if (duplicates.length > 0) {
+      overwriteReadOnly(invalidResponse, 'localDuplicates', duplicates);
+      return invalidResponse;
     }
 
+    const partialFilters = Object.fromEntries(
+      Object.entries(filters).map(([fieldName, { value }]) => [
+        fieldName,
+        value,
+      ])
+    );
+
+    if (Object.values(partialFilters).includes(undefined))
+      return { valid: true };
+
     return new this.resource.specifyModel.LazyCollection({
-      filters,
+      filters: partialFilters as Partial<
+        CommonFields &
+          Readonly<Record<string, boolean | number | string | null>> &
+          SCHEMA['fields'] & { readonly orderby: string }
+      >,
     })
       .fetch()
-      .then((fetchedCollection) =>
-        fetchedCollection.models.length > 0 ? invalidResponse : { valid: true }
+      .then(async (fetchedCollection) =>
+        Promise.all(
+          fetchedCollection.models.map(async (others) =>
+            hasSameValues(others, filters)
+          )
+        )
+      )
+      .then((foundDuplicates) =>
+        foundDuplicates.includes(true) ? invalidResponse : { valid: true }
       );
   }
 

--- a/specifyweb/frontend/js_src/lib/components/DataModel/businessRules.ts
+++ b/specifyweb/frontend/js_src/lib/components/DataModel/businessRules.ts
@@ -51,7 +51,7 @@ export class BusinessRuleManager<SCHEMA extends AnySchema> {
   }
 
   public async checkField(
-    fieldName: keyof SCHEMA['fields']
+    fieldName: keyof SCHEMA['fields'] | keyof SCHEMA['toOneIndependent']
   ): Promise<RA<BusinessRuleResult<SCHEMA>>> {
     const processedFieldName = fieldName.toString().toLowerCase();
     const thisCheck: ResolvablePromise<string> = flippedPromise();

--- a/specifyweb/frontend/js_src/lib/components/DataModel/businessRules.ts
+++ b/specifyweb/frontend/js_src/lib/components/DataModel/businessRules.ts
@@ -249,7 +249,8 @@ export class BusinessRuleManager<SCHEMA extends AnySchema> {
       const collectionField = localCollection.field;
       if (
         localCollection.related !== undefined &&
-        collectionField?.name === fieldName.split(djangoLookupSeparator)[0]
+        collectionField?.name.toLowerCase() ===
+          fieldName.split(djangoLookupSeparator)[0].toLowerCase()
       ) {
         const related = localCollection.related;
         const splitName = fieldName.split(djangoLookupSeparator);


### PR DESCRIPTION
Fixes #4439 

### Checklist

- [x] Self-review the PR after opening it to make sure the changes look good
      and self-explanatory (or properly documented)
- [x] Add automated tests
- [x] Add relevant issue to release milestone

### Testing instructions
Ensure uniqueness rules which exist as a `to-many` relationship on another form (InteractionAgents on the Interaction form, Determination/Preparation on CollectionObject, etc.) are properly being checked and behave correctly. 
