### PR TITLE
fix(a11y): minor improvements

### DIFF
--- a/specifyweb/frontend/js_src/lib/components/Atoms/Form.tsx
+++ b/specifyweb/frontend/js_src/lib/components/Atoms/Form.tsx
@@ -341,9 +341,7 @@ export const Select = wrap<
      *   are undefined
      */
     onChange(event): void {
-      const options = Array.from(
-        (event.target as HTMLSelectElement).querySelectorAll('option')
-      );
+      const options = Array.from(event.target.options);
       const [unselected, selected] = split(options, ({ selected }) => selected);
       /*
        * Selected options in an optional multiple select are clashing with

--- a/specifyweb/frontend/js_src/lib/components/DataModel/resource.ts
+++ b/specifyweb/frontend/js_src/lib/components/DataModel/resource.ts
@@ -265,6 +265,7 @@ const uniqueFields = [
   'timestampCreated',
   'version',
   'isCurrent',
+  'isPrimary',
   'timestampModified',
 ];
 

--- a/specifyweb/frontend/js_src/lib/components/FormSliders/Slider.tsx
+++ b/specifyweb/frontend/js_src/lib/components/FormSliders/Slider.tsx
@@ -27,7 +27,7 @@ export function Slider({
   const max = Math.max(1, count);
   const resolvedValue = Number.isNaN(pendingValue) ? '' : pendingValue + 1;
   return count > 0 ? (
-    <div className="flex justify-center gap-2 print:hidden">
+    <nav className="flex justify-center gap-2 print:hidden">
       <Button.Small
         aria-label={formsText.firstRecord()}
         disabled={value === 0 || handleChange === undefined}
@@ -100,6 +100,6 @@ export function Slider({
       >
         {icons.chevronDoubleRight}
       </Button.Small>
-    </div>
+    </nav>
   ) : null;
 }

--- a/specifyweb/frontend/js_src/lib/components/Header/Logo.tsx
+++ b/specifyweb/frontend/js_src/lib/components/Header/Logo.tsx
@@ -29,7 +29,7 @@ export function Logo({
     `}
         href="/specify/"
       >
-        {/* Both logs are loaded to prevent flickering on collapse/expand */}
+        {/* Both logos are loaded to prevent flickering on collapse/expand */}
         <img
           alt=""
           className={`

--- a/specifyweb/frontend/js_src/lib/components/Login/index.tsx
+++ b/specifyweb/frontend/js_src/lib/components/Login/index.tsx
@@ -136,6 +136,7 @@ function LegacyLogin({
           {userText.username()}
           <Input.Text
             autoCapitalize="none"
+            autoComplete="username"
             autoCorrect="off"
             defaultValue=""
             forwardRef={validationRef}
@@ -146,6 +147,7 @@ function LegacyLogin({
         <Label.Block>
           {userText.password()}
           <Input.Generic
+            autoComplete="current-password"
             defaultValue=""
             forwardRef={passwordRef}
             name="password"

--- a/specifyweb/frontend/js_src/lib/hooks/__tests__/useBooleanState.test.ts
+++ b/specifyweb/frontend/js_src/lib/hooks/__tests__/useBooleanState.test.ts
@@ -155,7 +155,7 @@ test('Test state updates whenever hook is called multiple times', () => {
   expect(result.current[0]).toBe(true);
 });
 
-test('Test state updates whenever hook is called multiple times', () => {
+test('Test state updates whenever hook is called multiple times in a row', () => {
   const { result } = renderHook(() => useBooleanState(true));
 
   act(() => {


### PR DESCRIPTION
Minor a11y improvements and small bug fixes


### Checklist

- [x] Self-review the PR after opening it to make sure the changes look good
      and self-explanatory (or properly documented)

### Testing instructions

1. In query builder, add an "In" filter for the "Agent -> Agent Type" field - open the combo box - select multiple values - text in the options should be legible in Chrome and Firefox
2. Open Address form directly (open a form for creating any resource, and replace table name in the URL with Address) - set "Is Primary" and "Is Checked" - clone the resource - "Is Checked" and "Is Primary" should not be checked
3. The area in record sets where you select what is the current resource and go to next/prev resource should visually look the same as before
4. Autocomplete on the login page should work better now (but I don't know how we can test this)