### PR TITLE
Show Localized Field Lables" button when unsaved changes in app resources

### DIFF
--- a/specifyweb/frontend/js_src/lib/components/DataModel/__tests__/businessRules.test.ts
+++ b/specifyweb/frontend/js_src/lib/components/DataModel/__tests__/businessRules.test.ts
@@ -1,7 +1,10 @@
+import { renderHook } from '@testing-library/react';
+
 import { overrideAjax } from '../../../tests/ajax';
 import { mockTime, requireContext } from '../../../tests/helpers';
 import { overwriteReadOnly } from '../../../utils/types';
 import { getResourceApiUrl } from '../resource';
+import { useSaveBlockers } from '../saveBlockers';
 import { schema } from '../schema';
 import { tables } from '../tables';
 
@@ -112,39 +115,36 @@ describe('uniqueness rules', () => {
     }
   );
   test('simple uniqueness rule', async () => {
-    const collectionObject = new schema.models.CollectionObject.Resource({
+    const collectionObject = new tables.CollectionObject.Resource({
       collection: '/api/specify/collection/4/',
       catalogNumber: '000000001',
     });
     await collectionObject.businessRuleManager?.checkField('catalogNumber');
-    expect(collectionObject.saveBlockers?.blockers).toMatchInlineSnapshot(`
-      {
-        "br-uniqueness-catalognumber": {
-          "deferred": false,
-          "fieldName": "catalognumber",
-          "reason": "Value must be unique to Collection",
-          "resource": {
-            "_tableName": "CollectionObject",
-            "catalognumber": "000000001",
-            "collection": "/api/specify/collection/4/",
-          },
-        },
-      }
-    `);
+
+    const { result } = renderHook(() =>
+      useSaveBlockers(
+        collectionObject,
+        tables.CollectionObject.getField('catalogNumber')
+      )
+    );
+
+    expect(result.current[0]).toStrictEqual([
+      'Value must be unique to Collection',
+    ]);
   });
 
   test('rule with local collection', async () => {
     const accessionId = 1;
-    const accession = new schema.models.Accession.Resource({
+    const accession = new tables.Accession.Resource({
       id: accessionId,
     });
 
-    const accessionAgent1 = new schema.models.AccessionAgent.Resource({
+    const accessionAgent1 = new tables.AccessionAgent.Resource({
       accession: getResourceApiUrl('Accession', accessionId),
       agent: getResourceApiUrl('Agent', 1),
       role: 'Borrower',
     });
-    const accessionAgent2 = new schema.models.AccessionAgent.Resource({
+    const accessionAgent2 = new tables.AccessionAgent.Resource({
       accession: getResourceApiUrl('Accession', accessionId),
       agent: getResourceApiUrl('Agent', 1),
       role: 'Borrower',
@@ -154,20 +154,12 @@ describe('uniqueness rules', () => {
 
     await accessionAgent2.businessRuleManager?.checkField('role');
 
-    expect(accessionAgent2.saveBlockers?.blockers).toMatchInlineSnapshot(`
-      {
-        "br-uniqueness-role": {
-          "deferred": false,
-          "fieldName": "role",
-          "reason": "Values of Role and Agent must be unique to Accession",
-          "resource": {
-            "_tableName": "AccessionAgent",
-            "accession": "/api/specify/accession/1/",
-            "agent": "/api/specify/agent/1/",
-            "role": "Borrower",
-          },
-        },
-      }
-    `);
+    const { result } = renderHook(() =>
+      useSaveBlockers(accessionAgent2, tables.AccessionAgent.getField('role'))
+    );
+
+    expect(result.current[0]).toStrictEqual([
+      'Values of Role and Agent must be unique to Accession',
+    ]);
   });
 });

--- a/specifyweb/frontend/js_src/lib/components/FormEditor/Editor.tsx
+++ b/specifyweb/frontend/js_src/lib/components/FormEditor/Editor.tsx
@@ -40,6 +40,7 @@ import type { FormEditorOutlet } from './index';
 import { FormEditorContext } from './index';
 import { getViewDefinitionIndexes } from './Table';
 import { formDefinitionSpec } from './viewSpec';
+import { UnloadProtectsContext } from '../Router/UnloadProtect';
 
 export function FormEditor(): JSX.Element {
   const { tableName = '', viewName = '' } = useParams();
@@ -72,6 +73,8 @@ export function FormEditor(): JSX.Element {
     layout === 'vertical'
       ? userText.switchToHorizontalLayout()
       : userText.switchToVerticalLayout();
+
+  const unloadProtects = React.useContext(UnloadProtectsContext)!;
 
   return table === undefined ||
     view === undefined ||
@@ -150,7 +153,7 @@ export function FormEditor(): JSX.Element {
             ? icons.switchVertical
             : icons.switchHorizontal}
         </Button.Small>
-        <UseLabelsSchema />
+        <UseLabelsSchema disabled={unloadProtects.length > 0} />
         {/* FEATURE: ability to preview the form in a dialog */}
         {/* FEATURE: ability to preview the form in a form table */}
       </div>
@@ -184,7 +187,11 @@ export function FormEditor(): JSX.Element {
   );
 }
 
-function UseLabelsSchema(): JSX.Element {
+function UseLabelsSchema({
+  disabled,
+}: {
+  readonly disabled: boolean;
+}): JSX.Element {
   const [useFieldLabels = true, setUseFieldLabels] = useCachedState(
     'forms',
     'useFieldLabels'
@@ -196,7 +203,7 @@ function UseLabelsSchema(): JSX.Element {
   };
 
   return (
-    <Button.Secondary onClick={update}>
+    <Button.Secondary onClick={update} disabled={disabled}>
       {useFieldLabels
         ? formsText.showDataModelLabels()
         : formsText.showFieldLabels()}


### PR DESCRIPTION
Fixes #4421 

### Checklist

- [x] Self-review the PR after opening it to make sure the changes look good
      and self-explanatory (or properly documented)
- [x] Add relevant issue to release milestone

### Testing instructions

- open app resource 
- open a view definition 
- click on "Show Localized/Data Model Field Labels" button 
- verify it works 
- make a change in the view def
- verify that the button to change the field label is disabled 
