### PR TITLE
Disable change label field when unsaved changes in app resource

### DIFF
--- a/specifyweb/frontend/js_src/lib/components/FormEditor/Editor.tsx
+++ b/specifyweb/frontend/js_src/lib/components/FormEditor/Editor.tsx
@@ -40,6 +40,7 @@ import type { FormEditorOutlet } from './index';
 import { FormEditorContext } from './index';
 import { getViewDefinitionIndexes } from './Table';
 import { formDefinitionSpec } from './viewSpec';
+import { UnloadProtectsContext } from '../Router/UnloadProtect';
 
 export function FormEditor(): JSX.Element {
   const { tableName = '', viewName = '' } = useParams();
@@ -72,6 +73,8 @@ export function FormEditor(): JSX.Element {
     layout === 'vertical'
       ? userText.switchToHorizontalLayout()
       : userText.switchToVerticalLayout();
+
+  const unloadProtects = React.useContext(UnloadProtectsContext)!;
 
   return table === undefined ||
     view === undefined ||
@@ -150,7 +153,7 @@ export function FormEditor(): JSX.Element {
             ? icons.switchVertical
             : icons.switchHorizontal}
         </Button.Small>
-        <UseLabelsSchema />
+        <UseLabelsSchema disabled={unloadProtects.length > 0} />
         {/* FEATURE: ability to preview the form in a dialog */}
         {/* FEATURE: ability to preview the form in a form table */}
       </div>
@@ -184,7 +187,11 @@ export function FormEditor(): JSX.Element {
   );
 }
 
-function UseLabelsSchema(): JSX.Element {
+function UseLabelsSchema({
+  disabled,
+}: {
+  readonly disabled: boolean;
+}): JSX.Element {
   const [useFieldLabels = true, setUseFieldLabels] = useCachedState(
     'forms',
     'useFieldLabels'
@@ -196,7 +203,7 @@ function UseLabelsSchema(): JSX.Element {
   };
 
   return (
-    <Button.Secondary onClick={update}>
+    <Button.Secondary onClick={update} disabled={disabled}>
       {useFieldLabels
         ? formsText.showDataModelLabels()
         : formsText.showFieldLabels()}

--- a/specifyweb/frontend/js_src/lib/components/FormEditor/Editor.tsx
+++ b/specifyweb/frontend/js_src/lib/components/FormEditor/Editor.tsx
@@ -31,6 +31,7 @@ import { SpecifyForm } from '../Forms/SpecifyForm';
 import { TableIcon } from '../Molecules/TableIcon';
 import { NotFoundView } from '../Router/NotFoundView';
 import { resolveRelative } from '../Router/queryString';
+import { UnloadProtectsContext } from '../Router/UnloadProtect';
 import { formatXmlNode } from '../Syncer/formatXmlNode';
 import type { XmlNode } from '../Syncer/xmlToJson';
 import { jsonToXml, xmlToJson } from '../Syncer/xmlToJson';
@@ -40,7 +41,6 @@ import type { FormEditorOutlet } from './index';
 import { FormEditorContext } from './index';
 import { getViewDefinitionIndexes } from './Table';
 import { formDefinitionSpec } from './viewSpec';
-import { UnloadProtectsContext } from '../Router/UnloadProtect';
 
 export function FormEditor(): JSX.Element {
   const { tableName = '', viewName = '' } = useParams();
@@ -199,7 +199,7 @@ function UseLabelsSchema(): JSX.Element {
   const unloadProtects = React.useContext(UnloadProtectsContext)!;
 
   return (
-    <Button.Secondary onClick={update} disabled={unloadProtects.length > 0}>
+    <Button.Secondary disabled={unloadProtects.length > 0} onClick={update}>
       {useFieldLabels
         ? formsText.showDataModelLabels()
         : formsText.showFieldLabels()}

--- a/specifyweb/frontend/js_src/lib/components/FormEditor/Editor.tsx
+++ b/specifyweb/frontend/js_src/lib/components/FormEditor/Editor.tsx
@@ -185,7 +185,7 @@ export function FormEditor(): JSX.Element {
   );
 }
 
-function UseLabelsSchema({}: {}): JSX.Element {
+function UseLabelsSchema(): JSX.Element {
   const [useFieldLabels = true, setUseFieldLabels] = useCachedState(
     'forms',
     'useFieldLabels'

--- a/specifyweb/frontend/js_src/lib/components/FormEditor/Editor.tsx
+++ b/specifyweb/frontend/js_src/lib/components/FormEditor/Editor.tsx
@@ -74,8 +74,6 @@ export function FormEditor(): JSX.Element {
       ? userText.switchToHorizontalLayout()
       : userText.switchToVerticalLayout();
 
-  const unloadProtects = React.useContext(UnloadProtectsContext)!;
-
   return table === undefined ||
     view === undefined ||
     viewDefinition === undefined ||
@@ -153,7 +151,7 @@ export function FormEditor(): JSX.Element {
             ? icons.switchVertical
             : icons.switchHorizontal}
         </Button.Small>
-        <UseLabelsSchema disabled={unloadProtects.length > 0} />
+        <UseLabelsSchema />
         {/* FEATURE: ability to preview the form in a dialog */}
         {/* FEATURE: ability to preview the form in a form table */}
       </div>
@@ -187,11 +185,7 @@ export function FormEditor(): JSX.Element {
   );
 }
 
-function UseLabelsSchema({
-  disabled,
-}: {
-  readonly disabled: boolean;
-}): JSX.Element {
+function UseLabelsSchema({}: {}): JSX.Element {
   const [useFieldLabels = true, setUseFieldLabels] = useCachedState(
     'forms',
     'useFieldLabels'
@@ -202,8 +196,10 @@ function UseLabelsSchema({
     globalThis.location.reload();
   };
 
+  const unloadProtects = React.useContext(UnloadProtectsContext)!;
+
   return (
-    <Button.Secondary onClick={update} disabled={disabled}>
+    <Button.Secondary onClick={update} disabled={unloadProtects.length > 0}>
       {useFieldLabels
         ? formsText.showDataModelLabels()
         : formsText.showFieldLabels()}


### PR DESCRIPTION
Fixes #4421



### Checklist

- [x] Self-review the PR after opening it to make sure the changes look good
      and self-explanatory (or properly documented)
- [x] Add relevant issue to release milestone

### Testing instructions
	•	open app resource
	•	open a view definition
	•	click on "Show Localized/Data Model Field Labels" button
	•	verify it works
	•	make a change in the view def
	•	verify that the button to change the field label is disabled
