### PR TITLE
Fix spelling mistake in leaving dialog

### DIFF
--- a/specifyweb/frontend/js_src/lib/localization/main.ts
+++ b/specifyweb/frontend/js_src/lib/localization/main.ts
@@ -231,7 +231,19 @@ export const mainText = createDictionary({
     'de-ch': 'Sind Sie sicher, dass Sie diese Seite verlassen wollen?',
   },
   leavePageConfirmationDescription: {
-    'en-us': 'Unsaved changes would be lost if you leave this page.',
+    'en-us': 'Unsaved changes will be lost if you leave this page.',
+    'ru-ru':
+      'Несохраненные изменения будут потеряны, если вы покинете эту страницу.',
+    'es-es': 'Los cambios no guardados se perderán si abandona esta página.',
+    'fr-fr': `
+      Les modifications non enregistrées seront perdues si vous quittez cette
+      page.
+    `,
+    'uk-ua': 'Незбережені зміни буде втрачено, якщо ви покинете цю сторінку.',
+    'de-ch': `
+      Nicht gespeicherte Änderungen gehen verloren, wenn Sie diese Seite
+      verlassen.
+    `,
   },
   leave: {
     'en-us': 'Leave',

--- a/specifyweb/frontend/js_src/lib/localization/main.ts
+++ b/specifyweb/frontend/js_src/lib/localization/main.ts
@@ -231,19 +231,7 @@ export const mainText = createDictionary({
     'de-ch': 'Sind Sie sicher, dass Sie diese Seite verlassen wollen?',
   },
   leavePageConfirmationDescription: {
-    'en-us': 'Unsaved changes would be lost if your leave this page.',
-    'ru-ru':
-      'Несохраненные изменения будут потеряны, если вы покинете эту страницу.',
-    'es-es': 'Los cambios no guardados se perderán si abandona esta página.',
-    'fr-fr': `
-      Les modifications non enregistrées seront perdues si vous quittez cette
-      page.
-    `,
-    'uk-ua': 'Незбережені зміни буде втрачено, якщо ви покинете цю сторінку.',
-    'de-ch': `
-      Nicht gespeicherte Änderungen gehen verloren, wenn Sie diese Seite
-      verlassen.
-    `,
+    'en-us': 'Unsaved changes would be lost if you leave this page.',
   },
   leave: {
     'en-us': 'Leave',


### PR DESCRIPTION
Fixes #4453

### Checklist

- [x] Self-review the PR after opening it to make sure the changes look good
      and self-explanatory (or properly documented)
- [x] Add relevant issue to release milestone

### Testing instructions

Go to schema config>uniqueness rules
add uniqueness rule
click close without saving
See correct spelling of 'Unsaved changes would be lost if you leave this page.'
