### PR TITLE
Enable formatted for a field format when available

### DIFF
--- a/specifyweb/frontend/js_src/lib/components/SchemaConfig/Format.tsx
+++ b/specifyweb/frontend/js_src/lib/components/SchemaConfig/Format.tsx
@@ -148,13 +148,13 @@ function FormatterLine({
   readonly onFormatted: (format: ItemType, value: string | null) => void;
 }): JSX.Element {
   const isReadOnly = React.useContext(ReadOnlyContext);
-  const enabled = name !== 'formatted' || field.isRelationship;
+  const enabled: boolean = name === 'formatted' && !field.isRelationship;
   return (
     <div className={className.labelForCheckbox}>
       <Label.Inline>
         <Input.Radio
           checked={name === getItemType(item)}
-          disabled={!enabled}
+          disabled={enabled}
           isReadOnly={isReadOnly}
           name={id('format')}
           value="none"
@@ -172,7 +172,7 @@ function FormatterLine({
       {values && (
         <PickList
           className="w-0 flex-1"
-          disabled={isReadOnly || !enabled}
+          disabled={isReadOnly || enabled}
           groups={values}
           label={label}
           value={value}

--- a/specifyweb/frontend/js_src/lib/components/SchemaConfig/Format.tsx
+++ b/specifyweb/frontend/js_src/lib/components/SchemaConfig/Format.tsx
@@ -148,13 +148,18 @@ function FormatterLine({
   readonly onFormatted: (format: ItemType, value: string | null) => void;
 }): JSX.Element {
   const isReadOnly = React.useContext(ReadOnlyContext);
-  const enabled = name === 'formatted' && !field.isRelationship;
+  const enabled =
+    name === 'none' || name === 'pickList'
+      ? true
+      : name === 'webLink' || name === 'formatted'
+      ? !field.isRelationship
+      : false;
   return (
     <div className={className.labelForCheckbox}>
       <Label.Inline>
         <Input.Radio
           checked={name === getItemType(item)}
-          disabled={enabled}
+          disabled={!enabled}
           isReadOnly={isReadOnly}
           name={id('format')}
           value="none"
@@ -172,7 +177,7 @@ function FormatterLine({
       {values && (
         <PickList
           className="w-0 flex-1"
-          disabled={isReadOnly || enabled}
+          disabled={isReadOnly || !enabled}
           groups={values}
           label={label}
           value={value}

--- a/specifyweb/frontend/js_src/lib/components/SchemaConfig/Format.tsx
+++ b/specifyweb/frontend/js_src/lib/components/SchemaConfig/Format.tsx
@@ -148,7 +148,7 @@ function FormatterLine({
   readonly onFormatted: (format: ItemType, value: string | null) => void;
 }): JSX.Element {
   const isReadOnly = React.useContext(ReadOnlyContext);
-  const enabled: boolean = name === 'formatted' && !field.isRelationship;
+  const enabled = name === 'formatted' && !field.isRelationship;
   return (
     <div className={className.labelForCheckbox}>
       <Label.Inline>


### PR DESCRIPTION
Fixes #4466

### Checklist

- [x] Self-review the PR after opening it to make sure the changes look good
      and self-explanatory (or properly documented)
- [x] Add relevant issue to release milestone

### Testing instructions

Go to schema config
Select loan table
Select loanNumber
Try to select a field format -> 'Formatted'
