### PR TITLE
Correct WorkBench dialog heading so 'Timestamp Modified' becomes 'Timestamp Uploaded' 

### DIFF
--- a/specifyweb/frontend/js_src/lib/components/Toolbar/WbsDialog.tsx
+++ b/specifyweb/frontend/js_src/lib/components/Toolbar/WbsDialog.tsx
@@ -119,7 +119,7 @@ function TableHeader({
         </th>
         <th scope="col">
           <Button.LikeLink onClick={(): void => handleSort('dateUploaded')}>
-            {getField(tables.Workbench, 'timestampModified').label}
+              {wbText.dataSetTimestampUploaded()}
             <SortIndicator fieldName="dateUploaded" sortConfig={sortConfig} />
           </Button.LikeLink>
         </th>

--- a/specifyweb/frontend/js_src/lib/components/Toolbar/WbsDialog.tsx
+++ b/specifyweb/frontend/js_src/lib/components/Toolbar/WbsDialog.tsx
@@ -119,7 +119,7 @@ function TableHeader({
         </th>
         <th scope="col">
           <Button.LikeLink onClick={(): void => handleSort('dateUploaded')}>
-              {wbText.dataSetTimestampUploaded()}
+            {wbText.dataSetTimestampUploaded()}
             <SortIndicator fieldName="dateUploaded" sortConfig={sortConfig} />
           </Button.LikeLink>
         </th>

--- a/specifyweb/frontend/js_src/lib/localization/workbench.ts
+++ b/specifyweb/frontend/js_src/lib/localization/workbench.ts
@@ -1349,6 +1349,9 @@ export const wbText = createDictionary({
     'uk-ua': 'Набір даних',
     'de-ch': 'Datensatz',
   },
+  dataSetTimestampUploaded: {
+    'en-us': 'Timestamp Uploaded',
+  },
   dataSetUploadedLabel: {
     'en-us': '(Uploaded, Read-Only)',
     'ru-ru': '(Загружено, только для чтения)',


### PR DESCRIPTION
Fixes #4011

This essentially undoes the change @maxpatiiuk made in December 2022 (https://github.com/specify/specify7/commit/43cf24ded9ea95580ff69dc8833435d2c52215a0), but instead of using `commonText.uploaded`, it defines a new string consistent with the 'Timestamp' nomenclature. 

### Checklist

- [X] Self-review the PR after opening it to make sure the changes look good
      and self-explanatory (or properly documented)
- [ ] Add automated tests
- [X] Add relevant issue to release milestone

### Testing instructions

<img width="766" alt="image" src="https://github.com/specify/specify7/assets/37256050/558dd190-4df6-4ca6-a084-bad19e1f22a3">

1. Open the WorkBench dialog
2. Verify that 'Timestamp Uploaded' is shown instead of 'Timestamp Created'
3. Verify sorting works correctly