### PR TITLE
Add 'Upload Plan' button to the Tools menu, allow importing/exporting data set mappings

### DIFF
--- a/specifyweb/frontend/js_src/lib/components/WorkBench/Template.tsx
+++ b/specifyweb/frontend/js_src/lib/components/WorkBench/Template.tsx
@@ -114,16 +114,6 @@ function WbView({
           {commonText.tools()}
         </Button.Small>
         <span className="-ml-1 flex-1" />
-        {/* This button is here for debugging only */}
-        <Button.Small
-          className={`
-            wb-show-plan
-            ${process.env.NODE_ENV === 'development' ? '' : 'hidden'}
-          `}
-          onClick={f.never}
-        >
-          [DEV] Show Plan
-        </Button.Small>
         {canUpdate || isMapped ? (
           <Link.Small href={`/specify/workbench/plan/${dataSetId}/`}>
             {wbPlanText.dataMapper()}
@@ -205,13 +195,21 @@ function WbView({
       >
         {hasPermission('/workbench/dataset', 'transfer') &&
         hasTablePermission('SpecifyUser', 'read') ? (
-          <Button.Small
-            aria-haspopup="dialog"
-            className="wb-change-data-set-owner"
+          <>
+            <Button.Small
+              aria-haspopup="dialog"
+              className="wb-change-data-set-owner"
+              onClick={f.never}
+            >
+              {wbText.changeOwner()}
+            </Button.Small>
+            <Button.Small
+            className="wb-show-plan"
             onClick={f.never}
           >
-            {wbText.changeOwner()}
+            {wbText.uploadPlan()}
           </Button.Small>
+          </>
         ) : undefined}
         <Button.Small className="wb-export-data-set" onClick={f.never}>
           {commonText.export()}

--- a/specifyweb/frontend/js_src/lib/localization/workbench.ts
+++ b/specifyweb/frontend/js_src/lib/localization/workbench.ts
@@ -17,6 +17,9 @@ export const wbText = createDictionary({
     'uk-ua': 'WorkBench',
     'de-ch': 'WorkBench',
   },
+  uploadPlan: {
+    'en-us': 'Upload Plan',
+  },
   rollback: {
     'en-us': 'Roll Back',
     'ru-ru': 'Откат',


### PR DESCRIPTION
While this is not a full implementation of an import/export utility, this makes the upload plan dialog available to regular users

Fixes #1363

This adds an 'Upload Plan' button that lets the user see the full JSON upload plan. If the user shares this mapping, another user can import it by pasting it in the dialog and clicking 'Save'. This exposes the raw JSON plan that was previously only available in development (or by removing the class in dev tools). This is something that would greatly improve some of CSIRO's workflows.

![image](https://github.com/specify/specify7/assets/37256050/17dbaf45-41a2-45a8-b761-990dc88af5e4)

### Checklist

- [X] Self-review the PR after opening it to make sure the changes look good
      and self-explanatory (or properly documented)

### Testing instructions

1. Open a WorkBench data set
2. Create a mapping
3. Edit in grid view
4. Click 'Tools'
5. Click 'Upload Plan'
6. Verify it can be copied/updated and import into another data set