### PR TITLE
Fix incorrect usage of function to define preferences

### DIFF
--- a/specifyweb/frontend/js_src/lib/components/Preferences/UserDefinitions.tsx
+++ b/specifyweb/frontend/js_src/lib/components/Preferences/UserDefinitions.tsx
@@ -1625,7 +1625,7 @@ export const userPreferenceDefinitions = {
             defaultValue: false,
             type: 'java.lang.Boolean',
           }),
-          queryParamtersFromForm: defineItem<boolean>({
+          queryParamtersFromForm: definePref<boolean>({
             title: preferencesText.queryParamtersFromForm(),
             requiresReload: false,
             visible: true,


### PR DESCRIPTION
Caused by #4299 merging into `production`

### Checklist

- [x] Self-review the PR after opening it to make sure the changes look good
      and self-explanatory (or properly documented)

### Testing instructions
- ensure Specify is accessible and the `Show query filters when running a Report from a Form` preference behaves correctly (see the testing instructions outlined in https://github.com/specify/specify7/pull/4299#issue-2044959670)
