### PR TITLE
refactor(TypeScript): make JSON.parse() safer

### DIFF
--- a/specifyweb/accounts/views.py
+++ b/specifyweb/accounts/views.py
@@ -375,6 +375,10 @@ def choose_collection(request) -> http.HttpResponse:
             return redirect_resp
 
     context = {
+        # toJson must be called instead of default json.dumps before sending
+        # data to the front-end. Unfortunately, that means the value is doubly
+        # json encoded (because django template calls json.dumps when
+        # json_script tag is used)
         'available_collections': toJson([obj_to_data(c) for c in available_collections]),
         'initial_value': request.COOKIES.get('collection', None),
         'next': redirect_to

--- a/specifyweb/frontend/js_src/lib/components/AttachmentsBulkImport/Import.tsx
+++ b/specifyweb/frontend/js_src/lib/components/AttachmentsBulkImport/Import.tsx
@@ -11,8 +11,7 @@ import { userText } from '../../localization/user';
 import { wbText } from '../../localization/workbench';
 import { ajax } from '../../utils/ajax';
 import { f } from '../../utils/functools';
-import type { RA, WritableArray } from '../../utils/types';
-import type { IR } from '../../utils/types';
+import type { IR, RA, WritableArray } from '../../utils/types';
 import { removeKey, sortFunction } from '../../utils/utils';
 import { Container } from '../Atoms';
 import { Button } from '../Atoms/Button';
@@ -75,7 +74,9 @@ export function AttachmentImportById(): JSX.Element | null {
   );
 }
 
-const fetchAndReconstructDataset = async (id: number) =>
+const fetchAndReconstructDataset = async (
+  id: number
+): Promise<FetchedDataSet> =>
   ajax<FetchedDataSet>(`/attachment_gw/dataset/${id}/`, {
     headers: { Accept: 'application/json' },
     method: 'GET',

--- a/specifyweb/frontend/js_src/lib/components/ChooseCollection/index.tsx
+++ b/specifyweb/frontend/js_src/lib/components/ChooseCollection/index.tsx
@@ -35,9 +35,12 @@ export function ChooseCollection(): JSX.Element {
         ]
           .flat()
           .filter(Boolean)}
-        availableCollections={JSON.parse(
-          parseDjangoDump('available-collections') ?? '[]'
-        )}
+        availableCollections={
+          // The value coming from the back-end is doubly JSON encoded
+          JSON.parse(parseDjangoDump('available-collections') ?? '[]') as RA<
+            SerializedRecord<Collection>
+          >
+        }
         // REFACTOR: store this on the front-end?
         initialValue={parseDjangoDump('initial-value') ?? null}
         nextUrl={parseDjangoDump<string>('next-url') ?? '/specify/'}

--- a/specifyweb/frontend/js_src/lib/components/Developer/CrashReportVisualizer.tsx
+++ b/specifyweb/frontend/js_src/lib/components/Developer/CrashReportVisualizer.tsx
@@ -53,7 +53,7 @@ export function CrashReportVisualizer(): JSX.Element {
 function JsonParser({ string }: { readonly string: string }): JSX.Element {
   const parsed = React.useMemo(() => {
     try {
-      return JSON.parse(string) as unknown;
+      return JSON.parse(string);
     } catch (error) {
       return (error as Error).toString();
     }

--- a/specifyweb/frontend/js_src/lib/components/FormEditor/__tests__/createView.test.ts
+++ b/specifyweb/frontend/js_src/lib/components/FormEditor/__tests__/createView.test.ts
@@ -241,7 +241,7 @@ const processViewSet = (viewSet: ViewSets): IR<unknown> =>
         ),
       })),
     })
-  );
+  ) as IR<unknown>;
 
 test('Create new view definition', () =>
   expect(

--- a/specifyweb/frontend/js_src/lib/components/Merging/autoMerge.ts
+++ b/specifyweb/frontend/js_src/lib/components/Merging/autoMerge.ts
@@ -132,7 +132,9 @@ function mergeField(
           return resourceInParent ?? resource;
         });
 
-        return resourcesToReturn.map((resource) => JSON.parse(resource));
+        return resourcesToReturn.map(
+          (resource) => JSON.parse(resource) as SerializedResource<AnySchema>
+        );
       } else
         return autoMerge(
           field.relatedTable,

--- a/specifyweb/frontend/js_src/lib/components/Preferences/BasePreferences.tsx
+++ b/specifyweb/frontend/js_src/lib/components/Preferences/BasePreferences.tsx
@@ -88,7 +88,7 @@ export class BasePreferences<DEFINITIONS extends GenericPreferences> {
   /**
    * Fetch preferences from back-end and update local cache with fetched values
    */
-  async fetch(): Promise<ResourceWithData> {
+  public async fetch(): Promise<ResourceWithData> {
     const entryPoint = await contextUnlockedPromise;
     if (entryPoint === 'main') {
       if (typeof this.resourcePromise === 'object') return this.resourcePromise;
@@ -117,7 +117,11 @@ export class BasePreferences<DEFINITIONS extends GenericPreferences> {
       this.resourcePromise = f
         .all({ valuesResource, defaultValuesResource })
         .then(({ valuesResource }) => {
-          this.setRaw(JSON.parse(valuesResource.data ?? '{}'));
+          this.setRaw(
+            JSON.parse(
+              valuesResource.data ?? '{}'
+            ) as PartialPreferences<DEFINITIONS>
+          );
           return valuesResource;
         });
 
@@ -455,7 +459,7 @@ const fetchResourceData = async (
 const fetchDefaultResourceData = async (
   fetchUrl: string,
   defaultResourceName: string
-): Promise<ResourceWithData> =>
+): Promise<Partial<ResourceWithData>> =>
   ajax(
     formatUrl(fetchUrl, {
       name: defaultResourceName,
@@ -467,7 +471,9 @@ const fetchDefaultResourceData = async (
     }
   )
     .then(({ data, status }) =>
-      status === Http.OK && data.trim().length > 0 ? JSON.parse(data) : {}
+      status === Http.OK && data.trim().length > 0
+        ? (JSON.parse(data) as ResourceWithData)
+        : {}
     )
     .catch((error) => {
       softFail(error);

--- a/specifyweb/frontend/js_src/lib/components/Preferences/Editor.tsx
+++ b/specifyweb/frontend/js_src/lib/components/Preferences/Editor.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import { useLiveState } from '../../hooks/useLiveState';
 import type { AppResourceTabProps } from '../AppResources/TabDefinitions';
 import { PreferencesContent } from '../Preferences';
+import type { PartialPreferences } from '../Preferences/BasePreferences';
 import { BasePreferences } from '../Preferences/BasePreferences';
 import { userPreferenceDefinitions } from '../Preferences/UserDefinitions';
 import { userPreferences } from '../Preferences/userPreferences';
@@ -24,7 +25,9 @@ export function UserPreferencesEditor({
         syncChanges: false,
       });
       userPreferences.setRaw(
-        JSON.parse(data === null || data.length === 0 ? '{}' : data)
+        JSON.parse(
+          data === null || data.length === 0 ? '{}' : data
+        ) as PartialPreferences<typeof userPreferenceDefinitions>
       );
       userPreferences.events.on('update', () =>
         handleChange(JSON.stringify(userPreferences.getRaw()))

--- a/specifyweb/frontend/js_src/lib/components/QueryBuilder/Import.tsx
+++ b/specifyweb/frontend/js_src/lib/components/QueryBuilder/Import.tsx
@@ -5,7 +5,6 @@ import { useAsyncState } from '../../hooks/useAsyncState';
 import { commonText } from '../../localization/common';
 import { queryText } from '../../localization/query';
 import { wbPlanText } from '../../localization/wbPlan';
-import { f } from '../../utils/functools';
 import type { RA } from '../../utils/types';
 import { filterArray } from '../../utils/types';
 import { getUniqueName } from '../../utils/uniquifyName';
@@ -78,7 +77,7 @@ export function QueryImport({
             onFileSelected={(file): void =>
               loading(
                 fileToText(file)
-                  .then<SerializedRecord<SpQuery>>(f.unary(JSON.parse))
+                  .then((text) => JSON.parse(text) as SerializedRecord<SpQuery>)
                   .then((query) => ({
                     ...query,
                     specifyuser: getResourceApiUrl(

--- a/specifyweb/frontend/js_src/lib/components/Security/MissingAgentsDialog.tsx
+++ b/specifyweb/frontend/js_src/lib/components/Security/MissingAgentsDialog.tsx
@@ -121,7 +121,7 @@ export function MissingAgentsDialog({
                   expectedErrors: [Http.BAD_REQUEST],
                 }).then(({ data, status }) =>
                   status === Http.BAD_REQUEST
-                    ? setResponse(JSON.parse(data))
+                    ? setResponse(JSON.parse(data) as SetAgentsResponse)
                     : handleClose()
                 )
               )

--- a/specifyweb/frontend/js_src/lib/components/Security/User.tsx
+++ b/specifyweb/frontend/js_src/lib/components/Security/User.tsx
@@ -501,7 +501,7 @@ function UserView({
                       status === Http.BAD_REQUEST
                         ? setState({
                             type: 'SettingAgents',
-                            response: JSON.parse(data),
+                            response: JSON.parse(data) as SetAgentsResponse,
                           })
                         : Array.isArray(institutionPolicies) &&
                           changedInstitutionPolicies
@@ -519,9 +519,9 @@ function UserView({
                              * is the last admin
                              */
                             if (status === Http.BAD_REQUEST) {
-                              const parsed: {
+                              const parsed = JSON.parse(data) as {
                                 readonly NoAdminUsersException: IR<never>;
-                              } = JSON.parse(data);
+                              };
                               if (
                                 typeof parsed === 'object' &&
                                 'NoAdminUsersException' in parsed
@@ -532,7 +532,9 @@ function UserView({
                               else
                                 setState({
                                   type: 'SettingAgents',
-                                  response: JSON.parse(data),
+                                  response: JSON.parse(
+                                    data
+                                  ) as SetAgentsResponse,
                                 });
                             } else return true;
                             return undefined;

--- a/specifyweb/frontend/js_src/lib/components/Security/policyConverter.ts
+++ b/specifyweb/frontend/js_src/lib/components/Security/policyConverter.ts
@@ -167,12 +167,24 @@ export function compressPermissionQuery(
       filterArray(Object.values(actions)).map((item) => ({
         ...item,
         // Remove duplicate matching rules and policies
+        // eslint-disable-next-line @typescript-eslint/naming-convention
         matching_role_policies: f
           .unique(item.matching_role_policies.map(f.unary(JSON.stringify)))
-          .map(f.unary(JSON.parse)),
+          .map(
+            (string) =>
+              JSON.parse(
+                string
+              ) as PermissionsQueryItem['matching_role_policies'][number]
+          ),
+        // eslint-disable-next-line @typescript-eslint/naming-convention
         matching_user_policies: f
           .unique(item.matching_user_policies.map(f.unary(JSON.stringify)))
-          .map(f.unary(JSON.parse)),
+          .map(
+            (string) =>
+              JSON.parse(
+                string
+              ) as PermissionsQueryItem['matching_user_policies'][number]
+          ),
       }))
     ),
   ];

--- a/specifyweb/frontend/js_src/lib/components/WorkBench/DevShowPlan.tsx
+++ b/specifyweb/frontend/js_src/lib/components/WorkBench/DevShowPlan.tsx
@@ -48,7 +48,7 @@ export function DevShowPlan({
                   .then((status) =>
                     status === Http.NOT_FOUND
                       ? handleDeleted()
-                      : handleChanged(plan)
+                      : handleChanged(plan as UploadPlan)
                   )
                   .finally(handleClose)
               );

--- a/specifyweb/frontend/js_src/lib/components/WorkBench/DisambiguationLogic.tsx
+++ b/specifyweb/frontend/js_src/lib/components/WorkBench/DisambiguationLogic.tsx
@@ -15,6 +15,8 @@ import { DisambiguationDialog } from './Disambiguation';
 import { getSelectedLast } from './hotHelpers';
 import type { WbView } from './WbView';
 
+export type WbRowExtra = { readonly disambiguation?: IR<number> };
+
 /* eslint-disable functional/no-this-expression */
 export class Disambiguation {
   public constructor(private readonly wbView: WbView) {}
@@ -24,7 +26,7 @@ export class Disambiguation {
     const hiddenColumn = this.wbView.data[physicalRow][cols];
     const extra =
       typeof hiddenColumn === 'string' && hiddenColumn.length > 0
-        ? JSON.parse(hiddenColumn)
+        ? (JSON.parse(hiddenColumn) as WbRowExtra)
         : {};
     return extra.disambiguation ?? {};
   }
@@ -69,8 +71,11 @@ export class Disambiguation {
     if (this.wbView.hot === undefined) return;
     const cols = this.wbView.dataset.columns.length;
     const hidden = this.wbView.data[physicalRow][cols];
-    const extra = hidden ? JSON.parse(hidden) : {};
-    extra.disambiguation = changeFunction(extra.disambiguation || {});
+    const oldExtra = hidden ? (JSON.parse(hidden) as WbRowExtra) ?? {} : {};
+    const extra: WbRowExtra = {
+      ...oldExtra,
+      disambiguation: changeFunction(oldExtra.disambiguation ?? {}),
+    };
     const visualRow = this.wbView.hot.toVisualRow(physicalRow);
     const visualCol = this.wbView.hot.toVisualColumn(cols);
     this.wbView.hot.setDataAtCell(

--- a/specifyweb/frontend/js_src/lib/components/WorkBench/hooks.ts
+++ b/specifyweb/frontend/js_src/lib/components/WorkBench/hooks.ts
@@ -12,6 +12,7 @@ import { sortFunction } from '../../utils/utils';
 import { oneRem } from '../Atoms';
 import { schema } from '../DataModel/schema';
 import { hasPermission } from '../Permissions/helpers';
+import type { WbRowExtra } from './DisambiguationLogic';
 import { getHotPlugin } from './handsontable';
 import type { WbView } from './WbView';
 
@@ -577,7 +578,7 @@ export function getHotHooks(wbView: WbView) {
       const selection = wbView.hot?.getSelected() ?? [];
       const newSelection = f
         .unique(selection.map((row) => JSON.stringify(row)))
-        .map((row) => JSON.parse(row));
+        .map((row) => JSON.parse(row) as typeof selection[number]);
       if (newSelection.length !== selection.length) {
         wbView.hot?.deselectCell();
         wbView.hot?.selectCells(newSelection);
@@ -611,8 +612,8 @@ function afterUndoRedo(
   const physicalCol = wbView.hot.toPhysicalColumn(visualCol as number);
   if (physicalCol !== wbView.dataset.columns.length) return;
 
-  const newValue = JSON.parse(newData || '{}').disambiguation;
-  const oldValue = JSON.parse(oldData || '{}').disambiguation;
+  const newValue = (JSON.parse(newData || '{}') as WbRowExtra).disambiguation;
+  const oldValue = (JSON.parse(oldData || '{}') as WbRowExtra).disambiguation;
 
   /*
    * Disambiguation results are cleared when any cell in a row changes.

--- a/specifyweb/frontend/js_src/lib/declarations.d.ts
+++ b/specifyweb/frontend/js_src/lib/declarations.d.ts
@@ -76,6 +76,19 @@ declare global {
   interface PromiseConstructor {
     all<T>(values: Iterable<PromiseLike<T> | T>): Promise<RA<Awaited<T>>>;
   }
+
+  // Make JSON.parse() return type unknown instead of any
+  interface JSON {
+    parse(
+      text: string,
+      reviver?: (this: unknown, key: string, value: unknown) => unknown
+    ): unknown;
+  }
+
+  // Make (await fetch()).json() return type unknown instead of any
+  interface Body {
+    json(): Promise<unknown>;
+  }
 }
 
 // Make router state more type safe

--- a/specifyweb/frontend/js_src/lib/localization/utils/validateWeblate.ts
+++ b/specifyweb/frontend/js_src/lib/localization/utils/validateWeblate.ts
@@ -94,7 +94,7 @@ function getToken(): string {
 const doFetch = async (url: string): Promise<IR<unknown>> =>
   fetch(url, {
     headers: { Authorization: getToken() },
-  }).then(async (response) => response.json());
+  }).then(async (response) => response.json() as Promise<IR<unknown>>);
 const fetchComponents = async (
   url = componentsApiUrl
 ): Promise<RA<IR<unknown>>> =>

--- a/specifyweb/frontend/js_src/lib/utils/ajax/csrfToken.ts
+++ b/specifyweb/frontend/js_src/lib/utils/ajax/csrfToken.ts
@@ -15,7 +15,7 @@ import { readCookie } from './cookies';
 export function parseDjangoDump<T>(id: string): T | undefined {
   const value =
     globalThis.document?.getElementById(id)?.textContent ?? undefined;
-  return f.maybe(value, JSON.parse);
+  return f.maybe(value, JSON.parse) as T;
 }
 
 export const csrfToken =

--- a/specifyweb/frontend/js_src/lib/utils/ajax/response.ts
+++ b/specifyweb/frontend/js_src/lib/utils/ajax/response.ts
@@ -26,7 +26,11 @@ export function handleAjaxResponse<RESPONSE_TYPE = string>({
     if (response.ok || expectedErrors.includes(response.status)) {
       if (response.ok && accept === 'application/json') {
         try {
-          return { data: JSON.parse(text), response, status: response.status };
+          return {
+            data: JSON.parse(text) as RESPONSE_TYPE,
+            response,
+            status: response.status,
+          };
         } catch {
           throw {
             type: 'jsonParseFailure',

--- a/specifyweb/frontend/js_src/lib/utils/javaProperties.ts
+++ b/specifyweb/frontend/js_src/lib/utils/javaProperties.ts
@@ -18,7 +18,9 @@ const regexForJavaProperty = (key: string): RegExp =>
   new RegExp(`^${escapeRegExp(key)}(?:\\s*[:=]|\\s)\\s*(.*)$`, 'mu');
 
 const unescapeJavaProperty = (value: string): string =>
-  JSON.parse(`"${value.replaceAll('\\', '\\\\').replaceAll('"', '\\"')}"`);
+  JSON.parse(
+    `"${value.replaceAll('\\', '\\\\').replaceAll('"', '\\"')}"`
+  ) as string;
 
 export const exportsForTests = {
   regexForJavaProperty,


### PR DESCRIPTION
JSON.parse() returns `any` by default
This means, TypeScript checking is completely disabled for all the places where the return of JSON.parse() is used - this could be dangerous
Instead, this PR:
- Changes the return type of `JSON.parse()` to be `unknown`
- Which in turn, requires explicit type cast in places where `JSON.parse` is used. A type cast is still much safer than `any`, as at least the usages of this value are checked against what's described in the type
- For greater security, to actually ensure that the json string from the back-end matches a pre-defined schema (and thus remove the need for type assertion), a library like `zod` can be used, but that might be overkill for now

[Great talk that goes into this deeper](https://portal.gitnation.org/contents/the-lies-we-tell-ourselves-using-typescript)


### Checklist

- [x] Self-review the PR after opening it to make sure the changes look good
      and self-explanatory (or properly documented)

### Testing instructions

Type only changes. No code logic impact