### PR TITLE
Set domainFilter to false to avoid Hierarchy exception

### DIFF
--- a/specifyweb/frontend/js_src/lib/components/Formatters/Preview.tsx
+++ b/specifyweb/frontend/js_src/lib/components/Formatters/Preview.tsx
@@ -36,7 +36,7 @@ export function useResourcePreview(table: SpecifyTable): {
           table.name,
           {
             limit: defaultPreviewSize,
-            domainFilter: true,
+            domainFilter: false, // set to true after scoping reimplementation
           },
           {
             orderBy: [

--- a/specifyweb/frontend/js_src/lib/components/Formatters/Preview.tsx
+++ b/specifyweb/frontend/js_src/lib/components/Formatters/Preview.tsx
@@ -36,7 +36,7 @@ export function useResourcePreview(table: SpecifyTable): {
           table.name,
           {
             limit: defaultPreviewSize,
-            domainFilter: false, // set to true after scoping reimplementation
+            domainFilter: false, // REFACTOR: set to true after scoping reimplementation
           },
           {
             orderBy: [


### PR DESCRIPTION
Fixes #3564

This is a temporary fix to stay on schedule for releasing the xml editor.  Fixing the filter_by_col function on the back-end needs to be done.  The #4498 PR is an attempt at that, but at this time needs more work.  As discussed on the issue page, setting the domain filter to false will avoid the Hierarchy exception from being thrown for tables without direct collection table relations.

Look at the #3564 issue for testing instructions.
