### PR TITLE
Remove duplicate ru syntax error

### DIFF
--- a/specifyweb/frontend/js_src/lib/localization/common.ts
+++ b/specifyweb/frontend/js_src/lib/localization/common.ts
@@ -247,7 +247,7 @@ export const commonText = createDictionary({
     'de-ch': 'Start',
   },
   end: {
-    commment: 'Noun',
+    comment: 'Noun',
     'en-us': 'End',
     'ru-ru': 'Конец',
     'es-es': 'Fin',

--- a/specifyweb/frontend/js_src/lib/localization/common.ts
+++ b/specifyweb/frontend/js_src/lib/localization/common.ts
@@ -625,7 +625,7 @@ export const commonText = createDictionary({
   countLine: {
     comment: 'Example usage: Record Sets (1,234)',
     'en-us': '{resource:string} ({count:number|formatted})',
-    'ru-ru': 'ru-ru': '{resource:string} ({count:number|formatted})',
+    'ru-ru': '{resource:string} ({count:number|formatted})',
     'es-es': '{resource:string} ({count:number|formatted})',
     'fr-fr': '{resource:string} ({count:number|formatted})',
     'uk-ua': '{resource:string} ({count:number|formatted})',


### PR DESCRIPTION

Fixes front-end build by fixing the syntax error in localization/common.ts file.