### PR TITLE
Display view button only when specified

### DIFF
--- a/specifyweb/frontend/js_src/lib/components/QueryComboBox/index.tsx
+++ b/specifyweb/frontend/js_src/lib/components/QueryComboBox/index.tsx
@@ -508,7 +508,11 @@ export function QueryComboBox({
                 }
               />
             )}
-            {hasViewButton ? viewButton : undefined}
+            {hasViewButton &&
+            formatted?.resource !== undefined &&
+            hasTablePermission(formatted.resource.specifyTable.name, 'create')
+              ? viewButton
+              : undefined}
           </>
         )}
       </span>

--- a/specifyweb/frontend/js_src/lib/components/QueryComboBox/index.tsx
+++ b/specifyweb/frontend/js_src/lib/components/QueryComboBox/index.tsx
@@ -509,8 +509,7 @@ export function QueryComboBox({
               />
             )}
             {hasViewButton &&
-            formatted?.resource !== undefined &&
-            hasTablePermission(formatted.resource.specifyTable.name, 'create')
+            hasTablePermission(relatedTable.name, 'create')
               ? viewButton
               : undefined}
           </>

--- a/specifyweb/frontend/js_src/lib/components/QueryComboBox/index.tsx
+++ b/specifyweb/frontend/js_src/lib/components/QueryComboBox/index.tsx
@@ -508,14 +508,7 @@ export function QueryComboBox({
                 }
               />
             )}
-            {formatted?.resource === undefined ||
-            (hasViewButton &&
-              hasTablePermission(
-                formatted.resource.specifyTable.name,
-                'create'
-              ))
-              ? viewButton
-              : undefined}
+            {hasViewButton ? viewButton : undefined}
           </>
         )}
       </span>

--- a/specifyweb/frontend/js_src/lib/components/QueryComboBox/index.tsx
+++ b/specifyweb/frontend/js_src/lib/components/QueryComboBox/index.tsx
@@ -508,8 +508,7 @@ export function QueryComboBox({
                 }
               />
             )}
-            {hasViewButton &&
-            hasTablePermission(relatedTable.name, 'create')
+            {hasViewButton && hasTablePermission(relatedTable.name, 'create')
               ? viewButton
               : undefined}
           </>


### PR DESCRIPTION
Fixes #4521

### Checklist

- [x] Self-review the PR after opening it to make sure the changes look good
      and self-explanatory (or properly documented)
- [x] Add relevant issue to release milestone

### Testing instructions

Go to the Collection Object form
See eyes next to query combo boxes when specified in form def
See eyes icons not present when not specified in form def
Test some qcbx with "viewBtn=true" in the "initialize" part of the form def, some with "viewBtn=false" and some with nothing at all 
