### PR TITLE
Display query header inline when distinct selected

### DIFF
--- a/specifyweb/frontend/js_src/lib/components/QueryBuilder/Results.tsx
+++ b/specifyweb/frontend/js_src/lib/components/QueryBuilder/Results.tsx
@@ -279,7 +279,7 @@ export function QueryResults(props: QueryResultsProps): JSX.Element {
         role="table"
         style={{
           gridTemplateColumns: [
-            ...new Array(metaColumns).fill('min-content'),
+            ...Array.from({ length: metaColumns }).fill('min-content'),
             ...Array.from({ length: visibleFieldSpecs.length }).fill('auto'),
           ].join(' '),
         }}

--- a/specifyweb/frontend/js_src/lib/components/QueryBuilder/Results.tsx
+++ b/specifyweb/frontend/js_src/lib/components/QueryBuilder/Results.tsx
@@ -274,7 +274,12 @@ export function QueryResults(props: QueryResultsProps): JSX.Element {
           overflow-auto rounded
           ${tableClassName}
           ${showResults ? 'border-b border-gray-500' : ''}
-       `}
+          ${
+            hasIdField
+              ? 'grid-cols-[min-content_min-content_repeat(var(--columns),auto)]'
+              : 'grid-cols-[repeat(var(--columns),auto)]'
+          }
+        `}
         ref={scrollerRef}
         role="table"
         style={

--- a/specifyweb/frontend/js_src/lib/components/QueryBuilder/Results.tsx
+++ b/specifyweb/frontend/js_src/lib/components/QueryBuilder/Results.tsx
@@ -181,6 +181,7 @@ export function QueryResults(props: QueryResultsProps): JSX.Element {
     'appearance',
     'showLineNumber'
   );
+  const metaColumns = (showLineNumber ? 1 : 0) + (hasIdField ? 2 : 0);
 
   return (
     <Container.Base className="w-full !bg-[color:var(--form-background)]">
@@ -273,20 +274,15 @@ export function QueryResults(props: QueryResultsProps): JSX.Element {
           overflow-auto rounded
           ${tableClassName}
           ${showResults ? 'border-b border-gray-500' : ''}
-          ${
-            hasIdField
-              ? 'grid-cols-[min-content_min-content_repeat(var(--columns),auto)]'
-              : 'grid-cols-[repeat(var(--columns),auto)]'
-          }
         `}
         ref={scrollerRef}
         role="table"
-        style={
-          {
-            '--columns': visibleFieldSpecs.length,
-            '--meta-columns': (showLineNumber ? 1 : 0) + (hasIdField ? 2 : 0),
-          } as React.CSSProperties
-        }
+        style={{
+          gridTemplateColumns: [
+            ...Array(metaColumns).fill('min-content'),
+            ...Array(visibleFieldSpecs.length).fill('auto'),
+          ].join(' '),
+        }}
         onScroll={showResults && !canFetchMore ? undefined : handleScroll}
       >
         {showResults && visibleFieldSpecs.length > 0 ? (

--- a/specifyweb/frontend/js_src/lib/components/QueryBuilder/Results.tsx
+++ b/specifyweb/frontend/js_src/lib/components/QueryBuilder/Results.tsx
@@ -279,8 +279,8 @@ export function QueryResults(props: QueryResultsProps): JSX.Element {
         role="table"
         style={{
           gridTemplateColumns: [
-            ...Array(metaColumns).fill('min-content'),
-            ...Array(visibleFieldSpecs.length).fill('auto'),
+            ...new Array(metaColumns).fill('min-content'),
+            ...Array.from({ length: visibleFieldSpecs.length }).fill('auto'),
           ].join(' '),
         }}
         onScroll={showResults && !canFetchMore ? undefined : handleScroll}

--- a/specifyweb/frontend/js_src/lib/components/QueryBuilder/Results.tsx
+++ b/specifyweb/frontend/js_src/lib/components/QueryBuilder/Results.tsx
@@ -270,7 +270,6 @@ export function QueryResults(props: QueryResultsProps): JSX.Element {
         // REFACTOR: turn this into a reusable table component
         className={`
           grid-table auto-rows-min
-          grid-cols-[repeat(var(--meta-columns),min-content)_repeat(var(--columns),auto)]
           overflow-auto rounded
           ${tableClassName}
           ${showResults ? 'border-b border-gray-500' : ''}


### PR DESCRIPTION
Fixes #4514

### Checklist

- [x] Self-review the PR after opening it to make sure the changes look good
      and self-explanatory (or properly documented)
- [x] Add relevant issue to release milestone

### Testing instructions

run a query with "Distinct" selected, verify headers in the results table are in line
run a query with "Distinct" not selected, verify headers in the results table are in line

![Screenshot 2024-02-13 at 8 09 27 AM](https://github.com/specify/specify7/assets/108160931/3dc9f3c4-2c20-412a-aeb7-fdf9356ffcdd)

