### PR TITLE
Remove unecessary skeleton loader from QueryListDialog

### DIFF
--- a/specifyweb/frontend/js_src/lib/components/Toolbar/Query.tsx
+++ b/specifyweb/frontend/js_src/lib/components/Toolbar/Query.tsx
@@ -31,6 +31,8 @@ import { QueryEditButton } from '../QueryBuilder/Edit';
 import { OverlayContext } from '../Router/Router';
 import { SafeOutlet } from '../Router/RouterUtils';
 import { QueryTablesWrapper } from './QueryTablesWrapper';
+import { DialogListSkeleton } from '../SkeletonLoaders/DialogList';
+import { f } from '../../utils/functools';
 
 export function QueriesOverlay(): JSX.Element {
   const handleClose = React.useContext(OverlayContext);
@@ -65,7 +67,20 @@ export function QueryListOutlet(): JSX.Element {
 const defaultChildren: Exclude<QueryListContextType['children'], undefined> = ({
   children,
   dialog,
-}): JSX.Element => dialog(children);
+}): JSX.Element => {
+  return children === undefined ? (
+    <Dialog
+      buttons={<Button.DialogClose>{commonText.cancel()}</Button.DialogClose>}
+      header={queryText.queries()}
+      icon={<span className="text-blue-500">{icons.documentSearch}</span>}
+      onClose={f.never()}
+    >
+      <DialogListSkeleton />
+    </Dialog>
+  ) : (
+    dialog(children)
+  );
+};
 
 export function QueryListDialog({
   newQueryUrl,

--- a/specifyweb/frontend/js_src/lib/components/Toolbar/Query.tsx
+++ b/specifyweb/frontend/js_src/lib/components/Toolbar/Query.tsx
@@ -8,6 +8,7 @@ import { useOutletContext } from 'react-router';
 import { useAsyncState } from '../../hooks/useAsyncState';
 import { commonText } from '../../localization/common';
 import { queryText } from '../../localization/query';
+import { f } from '../../utils/functools';
 import type { RA } from '../../utils/types';
 import { Button } from '../Atoms/Button';
 import { icons } from '../Atoms/Icons';
@@ -30,9 +31,8 @@ import { hasPermission, hasToolPermission } from '../Permissions/helpers';
 import { QueryEditButton } from '../QueryBuilder/Edit';
 import { OverlayContext } from '../Router/Router';
 import { SafeOutlet } from '../Router/RouterUtils';
-import { QueryTablesWrapper } from './QueryTablesWrapper';
 import { DialogListSkeleton } from '../SkeletonLoaders/DialogList';
-import { f } from '../../utils/functools';
+import { QueryTablesWrapper } from './QueryTablesWrapper';
 
 export function QueriesOverlay(): JSX.Element {
   const handleClose = React.useContext(OverlayContext);
@@ -67,8 +67,8 @@ export function QueryListOutlet(): JSX.Element {
 const defaultChildren: Exclude<QueryListContextType['children'], undefined> = ({
   children,
   dialog,
-}): JSX.Element => {
-  return children === undefined ? (
+}): JSX.Element =>
+  children === undefined ? (
     <Dialog
       buttons={<Button.DialogClose>{commonText.cancel()}</Button.DialogClose>}
       header={queryText.queries()}
@@ -80,7 +80,6 @@ const defaultChildren: Exclude<QueryListContextType['children'], undefined> = ({
   ) : (
     dialog(children)
   );
-};
 
 export function QueryListDialog({
   newQueryUrl,

--- a/specifyweb/frontend/js_src/lib/components/Toolbar/Query.tsx
+++ b/specifyweb/frontend/js_src/lib/components/Toolbar/Query.tsx
@@ -30,7 +30,6 @@ import { hasPermission, hasToolPermission } from '../Permissions/helpers';
 import { QueryEditButton } from '../QueryBuilder/Edit';
 import { OverlayContext } from '../Router/Router';
 import { SafeOutlet } from '../Router/RouterUtils';
-import { DialogListSkeleton } from '../SkeletonLoaders/DialogList';
 import { QueryTablesWrapper } from './QueryTablesWrapper';
 
 export function QueriesOverlay(): JSX.Element {
@@ -125,101 +124,90 @@ export function QueryListDialog({
 
   const isReadOnly = React.useContext(ReadOnlyContext);
 
-  return data === undefined ? (
-    <Dialog
-      buttons={<Button.DialogClose>{commonText.cancel()}</Button.DialogClose>}
-      header={queryText.queries()}
-      icon={<span className="text-blue-500">{icons.documentSearch}</span>}
-      onClose={handleClose}
-    >
-      <DialogListSkeleton />
-    </Dialog>
-  ) : (
-    children({
-      totalCount,
-      records: data?.records,
-      children: (
-        <>
-          <table className="grid-table grid-cols-[repeat(3,auto)_min-content] gap-2">
-            <thead>
-              <tr>
-                <th
-                  className="pl-[calc(theme(spacing.table-icon)_+_theme(spacing.2))]"
-                  scope="col"
+  return children({
+    totalCount,
+    records: data?.records,
+    children: (
+      <>
+        <table className="grid-table grid-cols-[repeat(3,auto)_min-content] gap-2">
+          <thead>
+            <tr>
+              <th
+                className="pl-[calc(theme(spacing.table-icon)_+_theme(spacing.2))]"
+                scope="col"
+              >
+                <Button.LikeLink onClick={(): void => handleSort('name')}>
+                  {getField(tables.SpQuery, 'name').label}
+                  <SortIndicator fieldName="name" sortConfig={sortConfig} />
+                </Button.LikeLink>
+              </th>
+              <th scope="col">
+                <Button.LikeLink
+                  onClick={(): void => handleSort('timestampCreated')}
                 >
-                  <Button.LikeLink onClick={(): void => handleSort('name')}>
-                    {getField(tables.SpQuery, 'name').label}
-                    <SortIndicator fieldName="name" sortConfig={sortConfig} />
-                  </Button.LikeLink>
-                </th>
-                <th scope="col">
-                  <Button.LikeLink
-                    onClick={(): void => handleSort('timestampCreated')}
-                  >
-                    {getField(tables.SpQuery, 'timestampCreated').label}
-                    <SortIndicator
-                      fieldName="timestampCreated"
-                      sortConfig={sortConfig}
-                    />
-                  </Button.LikeLink>
-                </th>
-                <th scope="col">
-                  <Button.LikeLink
-                    onClick={(): void => handleSort('timestampModified')}
-                  >
-                    {getField(tables.SpQuery, 'timestampModified').label}
-                    <SortIndicator
-                      fieldName="timestampModified"
-                      sortConfig={sortConfig}
-                    />
-                  </Button.LikeLink>
-                </th>
-                <td />
-              </tr>
-            </thead>
-            <tbody>
-              {data?.records.map((query) => (
-                <QueryList
-                  getQuerySelectCallback={getQuerySelectCallback}
-                  isReadOnly={isReadOnly}
-                  key={query.id}
-                  query={query}
-                />
-              ))}
-            </tbody>
-          </table>
-          <span className="-ml-2 flex-1" />
-          {data === undefined && loadingGif}
-          {paginator(data?.totalCount)}
-        </>
-      ),
-      dialog: (children) => (
-        <Dialog
-          buttons={
-            <>
-              <Button.DialogClose>{commonText.cancel()}</Button.DialogClose>
-              {(hasToolPermission('queryBuilder', 'create') ||
-                hasPermission('/querybuilder/query', 'execute')) && (
-                <Link.Info href={newQueryUrl}>{commonText.new()}</Link.Info>
-              )}
-            </>
-          }
-          header={
-            totalCount === undefined
-              ? queryText.queries()
-              : commonText.countLine({
-                  resource: queryText.queries(),
-                  count: totalCount,
-                })
-          }
-          icon={<span className="text-blue-500">{icons.documentSearch}</span>}
-          onClose={handleClose}
-        >
-          {children}
-        </Dialog>
-      ),
-    })
-  );
+                  {getField(tables.SpQuery, 'timestampCreated').label}
+                  <SortIndicator
+                    fieldName="timestampCreated"
+                    sortConfig={sortConfig}
+                  />
+                </Button.LikeLink>
+              </th>
+              <th scope="col">
+                <Button.LikeLink
+                  onClick={(): void => handleSort('timestampModified')}
+                >
+                  {getField(tables.SpQuery, 'timestampModified').label}
+                  <SortIndicator
+                    fieldName="timestampModified"
+                    sortConfig={sortConfig}
+                  />
+                </Button.LikeLink>
+              </th>
+              <td />
+            </tr>
+          </thead>
+          <tbody>
+            {data?.records.map((query) => (
+              <QueryList
+                getQuerySelectCallback={getQuerySelectCallback}
+                isReadOnly={isReadOnly}
+                key={query.id}
+                query={query}
+              />
+            ))}
+          </tbody>
+        </table>
+        <span className="-ml-2 flex-1" />
+        {data === undefined && loadingGif}
+        {paginator(data?.totalCount)}
+      </>
+    ),
+    dialog: (children) => (
+      <Dialog
+        buttons={
+          <>
+            <Button.DialogClose>{commonText.cancel()}</Button.DialogClose>
+            {(hasToolPermission('queryBuilder', 'create') ||
+              hasPermission('/querybuilder/query', 'execute')) && (
+              <Link.Info href={newQueryUrl}>{commonText.new()}</Link.Info>
+            )}
+          </>
+        }
+        header={
+          totalCount === undefined
+            ? queryText.queries()
+            : commonText.countLine({
+                resource: queryText.queries(),
+                count: totalCount,
+              })
+        }
+        icon={<span className="text-blue-500">{icons.documentSearch}</span>}
+        onClose={handleClose}
+      >
+        {children}
+      </Dialog>
+    ),
+  });
 }
 
 export function QueryList({


### PR DESCRIPTION
Fixes #4518

### Checklist

- [x] Self-review the PR after opening it to make sure the changes look good
      and self-explanatory (or properly documented)
- [x] Add relevant issue to release milestone

### Testing instructions

Go to the stats page
Go to add a new query (click Add) in the bottom right corner of a category
See that there isn't an extra queries dialog appear while the queries are loaded

NOTES: 
Since the refactoring of QueryListDialog component the skeleton loader is not necessary anymore. 