### PR TITLE
Keep new unique name when cloning resource

### DIFF
--- a/specifyweb/frontend/js_src/lib/components/AppResources/EditorWrapper.tsx
+++ b/specifyweb/frontend/js_src/lib/components/AppResources/EditorWrapper.tsx
@@ -95,14 +95,14 @@ export function Wrapper({
       directory={directory}
       initialData={initialData === false ? undefined : initialData}
       resource={record}
-      onClone={(_clonedResource, clone): void =>
+      onClone={(clonedResource, clone): void =>
         navigate(
           formatUrl(`${baseHref}/new/`, {
             directoryKey: findAppResourceDirectoryKey(
               resourcesTree,
               directory.id
             ),
-            name: record.name,
+            name: clonedResource.name,
             mimeType: 'mimeType' in record ? record.mimeType : undefined,
             clone,
           })


### PR DESCRIPTION
Fixes #4517

### Checklist

- [x] Self-review the PR after opening it to make sure the changes look good
      and self-explanatory (or properly documented)
- [x] Add relevant issue to release milestone

### Testing instructions

Clone a record
See that the cloned record has a unique name (with a (number))
Save and see the new resource still has the right name
