### PR TITLE
Add a key to panels to avoid data being carried away when cdt change

### DIFF
--- a/specifyweb/frontend/js_src/lib/components/FormCells/index.tsx
+++ b/specifyweb/frontend/js_src/lib/components/FormCells/index.tsx
@@ -282,9 +282,9 @@ const cellRenderers: {
       viewDefinition === undefined ? null : (
         <SpecifyForm
           display={display}
+          key={definitionIndex}
           resource={resource}
           viewDefinition={viewDefinition}
-          key={definitionIndex}
         />
       );
     return display === 'inline' ? <div className="mx-auto">{form}</div> : form;

--- a/specifyweb/frontend/js_src/lib/components/FormCells/index.tsx
+++ b/specifyweb/frontend/js_src/lib/components/FormCells/index.tsx
@@ -284,6 +284,7 @@ const cellRenderers: {
           display={display}
           resource={resource}
           viewDefinition={viewDefinition}
+          key={definitionIndex}
         />
       );
     return display === 'inline' ? <div className="mx-auto">{form}</div> : form;


### PR DESCRIPTION
Fixes #4497

### Checklist

- [x] Self-review the PR after opening it to make sure the changes look good
      and self-explanatory (or properly documented)
- [x] Add relevant issue to release milestone

### Testing instructions

Go to the geology database (https://geology-edge.test.specifysystems.org/)
Go to 'collectionobjectproperties' (Stratigraphies) and add a new record
Select 'Magnetostratigraphy' from the 'Stratigraphy' pick list
See 'Magnetic Polarity' is filled in by default with "Normal (northward-directed)"
Switch to 'Chemostratigraphy'
See that Geochecmical Ratio is empty
