### PR TITLE
feat(FormTable): reduce layout shifts

### DIFF
--- a/specifyweb/frontend/js_src/lib/components/Molecules/FilePicker.tsx
+++ b/specifyweb/frontend/js_src/lib/components/Molecules/FilePicker.tsx
@@ -134,6 +134,7 @@ export const downloadFile = async (
   new Promise((resolve) => {
     let fileDownloaded = false;
     const iframe = document.createElement('iframe');
+    iframe.classList.add('absolute', 'hidden');
     iframe.addEventListener('load', () => {
       if (iframe.contentWindow === null || fileDownloaded) return;
       const element = iframe.contentWindow.document.createElement('a');


### PR DESCRIPTION
Fixes #4545

See how removing the needless layout shift reduces the possibility for accidental misclick as described in #4545:

https://github.com/specify/specify7/assets/40512816/090b7b1c-dbc1-4518-bea5-917817d2bcce

(especially bad in cases when accidental misclick causes the record to be deleted)

@grantfitzsimmons what do you think about this feature? ship it or not?
also, should we hide the form table header when all records are expanded? (right now it is hidden only when there are 0 resources or when there is 1 resource and that resource is expanded)