### PR TITLE
Fix issue for doubled resolved quantity in loan return

### DIFF
--- a/specifyweb/frontend/js_src/lib/components/Interactions/LoanReturn.tsx
+++ b/specifyweb/frontend/js_src/lib/components/Interactions/LoanReturn.tsx
@@ -228,8 +228,8 @@ function PreparationReturn({
               const loanReturn = new tables.LoanReturnPreparation.Resource();
               loanReturn.set('loanPreparation', preparation.url());
               loanReturn.set('remarks', remarks);
-              loanReturn.set('quantityResolved', returns);
               loanReturn.set('quantityReturned', returns);
+              loanReturn.set('quantityResolved', returns);
               loanReturn.set(
                 'receivedBy',
                 loanReturnPreparation.current.get('receivedBy')

--- a/specifyweb/frontend/js_src/lib/components/Interactions/LoanReturn.tsx
+++ b/specifyweb/frontend/js_src/lib/components/Interactions/LoanReturn.tsx
@@ -229,7 +229,7 @@ function PreparationReturn({
               loanReturn.set('loanPreparation', preparation.url());
               loanReturn.set('remarks', remarks);
               loanReturn.set('quantityReturned', returns);
-              loanReturn.set('quantityResolved', returns);
+              loanReturn.set('quantityResolved', resolve);
               loanReturn.set(
                 'receivedBy',
                 loanReturnPreparation.current.get('receivedBy')


### PR DESCRIPTION
Fixes #4505
Fixes #4551 too ?
### Checklist

- [x] Self-review the PR after opening it to make sure the changes look good
      and self-explanatory (or properly documented)
- [x] Add relevant issue to release milestone

### Testing instructions

Create a record set with count preparations
Create a loan using that record set
Save loan
Return loan
Check record set count
