### PR TITLE
refactor(utils): optimize removeKey

### DIFF
--- a/specifyweb/frontend/js_src/lib/utils/__tests__/uniquifyName.test.ts
+++ b/specifyweb/frontend/js_src/lib/utils/__tests__/uniquifyName.test.ts
@@ -8,6 +8,7 @@ theories(getUniqueName, [
   // With length limit
   { in: ['abcdef', ['abcdef'], 6], out: 'ab' },
   { in: ['abcdef', ['abcdef', 'ab'], 6], out: 'ab (2)' },
+  { in: ['abcdef', ['abcdef', 'abcd'], 6, 'name'], out: 'abcd_2' },
   // With different format
   { in: ['abc', [], 6, 'name'], out: 'abc' },
   { in: ['abc', ['abc', 'ab'], 6, 'name'], out: 'abc_2' },

--- a/specifyweb/frontend/js_src/lib/utils/uniquifyName.ts
+++ b/specifyweb/frontend/js_src/lib/utils/uniquifyName.ts
@@ -7,7 +7,6 @@ import { escapeRegExp } from './utils';
 
 const format = {
   title: {
-    // FEATURE: allow users to customize this?
     prefix: ' (',
     suffix: ')',
   },
@@ -55,7 +54,13 @@ export function getUniqueName(
     newIndex === 1 && length === 0
       ? strippedName
       : `${strippedName}${uniquePart}`;
+
   return newName.length > maxLength
-    ? getUniqueName(name.slice(0, -1 * uniquePart.length), usedNames, maxLength)
+    ? getUniqueName(
+        name.slice(0, -1 * uniquePart.length),
+        usedNames,
+        maxLength,
+        type
+      )
     : localized(newName);
 }


### PR DESCRIPTION
Make `removeKey` significantly faster by optimizing the common case by removing the key from the object using destructing, rather than through iterating over each item.

### Checklist

- [x] Self-review the PR after opening it to make sure the changes look good
      and self-explanatory (or properly documented)
- [x] Add automated tests


### Testing instructions

This change is covered by the existing automated tests