### PR TITLE
Recompute delete blockers on parent when changes made to children

### DIFF
--- a/specifyweb/frontend/js_src/lib/components/DataModel/businessRules.ts
+++ b/specifyweb/frontend/js_src/lib/components/DataModel/businessRules.ts
@@ -12,7 +12,7 @@ import { businessRuleDefs } from './businessRuleDefs';
 import { backboneFieldSeparator, djangoLookupSeparator } from './helpers';
 import type { AnySchema, AnyTree, CommonFields } from './helperTypes';
 import type { SpecifyResource } from './legacyTypes';
-import { setSaveBlockers } from './saveBlockers';
+import { propagateBlockerEvents, setSaveBlockers } from './saveBlockers';
 import { specialFields } from './serializers';
 import type { LiteralField, Relationship } from './specifyField';
 import type { Collection, SpecifyTable } from './specifyTable';
@@ -51,6 +51,7 @@ export class BusinessRuleManager<SCHEMA extends AnySchema> {
     this.resource.on('change', this.changed, this);
     this.resource.on('add', this.added, this);
     this.resource.on('remove', this.removed, this);
+    this.resource.on('destroy', () => propagateBlockerEvents(this.resource));
   }
 
   public async checkField(
@@ -140,6 +141,8 @@ export class BusinessRuleManager<SCHEMA extends AnySchema> {
     resource: SpecifyResource<SCHEMA>,
     collection: Collection<SCHEMA>
   ): void {
+    // TODO: optimize because it will recalculate everything
+    propagateBlockerEvents(this.resource);
     this.addPromise(
       this.invokeRule('onRemoved', undefined, [resource, collection])
     );

--- a/specifyweb/frontend/js_src/lib/components/DataModel/saveBlockers.tsx
+++ b/specifyweb/frontend/js_src/lib/components/DataModel/saveBlockers.tsx
@@ -47,6 +47,17 @@ export type BlockerWithResource = {
   readonly message: string;
 };
 
+export const propagateBlockerEvents = (
+  resource: SpecifyResource<AnySchema>
+) => {
+  if (resource.parent) blockerEvents.trigger('change', resource.parent);
+  if (
+    resource.collection?.related !== undefined &&
+    resource.collection.related !== resource.parent
+  )
+    blockerEvents.trigger('change', resource.collection.related);
+};
+
 export function useSaveBlockers(
   resource: SpecifyResource<AnySchema> | undefined,
   field: LiteralField | Relationship | undefined


### PR DESCRIPTION
Fixes #4536

### Checklist

- [x] Self-review the PR after opening it to make sure the changes look good
      and self-explanatory (or properly documented)
- [x] Add relevant issue to release milestone

### Testing instructions

Add Preparation without specifying a prep type - this creates a validation error
Remove the preparation from the form - thus, the field with error no longer exists, and should not prevent save anymore
Verify that save button is enabled 
