### PR TITLE
Allow dialog to reduce size once skeleton disappears in att gallery

### DIFF
--- a/specifyweb/frontend/js_src/lib/components/Attachments/RecordSetAttachment.tsx
+++ b/specifyweb/frontend/js_src/lib/components/Attachments/RecordSetAttachment.tsx
@@ -92,7 +92,7 @@ export function RecordSetAttachments<SCHEMA extends AnySchema>({
     'scale'
   );
 
-  const isComplete = fetchedCount.current === records.length
+  const isComplete = fetchedCount.current === records.length;
 
   return (
     <>
@@ -110,9 +110,7 @@ export function RecordSetAttachments<SCHEMA extends AnySchema>({
           className={{
             container: dialogClassNames.wideContainer,
           }}
-          dimensionsKey={
-            isComplete ? undefined : false
-          }
+          dimensionsKey={isComplete ? undefined : false}
           header={
             attachmentsRef.current?.attachments === undefined
               ? attachmentsText.attachments()

--- a/specifyweb/frontend/js_src/lib/components/Attachments/RecordSetAttachment.tsx
+++ b/specifyweb/frontend/js_src/lib/components/Attachments/RecordSetAttachment.tsx
@@ -92,6 +92,8 @@ export function RecordSetAttachments<SCHEMA extends AnySchema>({
     'scale'
   );
 
+  const isComplete = fetchedCount.current === records.length
+
   return (
     <>
       <Button.Icon
@@ -109,7 +111,7 @@ export function RecordSetAttachments<SCHEMA extends AnySchema>({
             container: dialogClassNames.wideContainer,
           }}
           dimensionsKey={
-            fetchedCount.current === records.length ? undefined : false
+            isComplete ? undefined : false
           }
           header={
             attachmentsRef.current?.attachments === undefined
@@ -141,7 +143,7 @@ export function RecordSetAttachments<SCHEMA extends AnySchema>({
           ) : (
             <AttachmentGallery
               attachments={attachmentsRef?.current?.attachments ?? []}
-              isComplete={fetchedCount.current === records.length}
+              isComplete={isComplete}
               scale={scale}
               onChange={(attachment, index): void =>
                 void attachments?.related[index].set(`attachment`, attachment)

--- a/specifyweb/frontend/js_src/lib/components/Attachments/RecordSetAttachment.tsx
+++ b/specifyweb/frontend/js_src/lib/components/Attachments/RecordSetAttachment.tsx
@@ -117,6 +117,9 @@ export function RecordSetAttachments<SCHEMA extends AnySchema>({
                 })
           }
           onClose={handleHideAttachments}
+          dimensionsKey={
+            fetchedCount.current === records.length ? undefined : false
+          }
         >
           {halt ? (
             haltValue === records.length ? (

--- a/specifyweb/frontend/js_src/lib/components/Attachments/RecordSetAttachment.tsx
+++ b/specifyweb/frontend/js_src/lib/components/Attachments/RecordSetAttachment.tsx
@@ -108,6 +108,9 @@ export function RecordSetAttachments<SCHEMA extends AnySchema>({
           className={{
             container: dialogClassNames.wideContainer,
           }}
+          dimensionsKey={
+            fetchedCount.current === records.length ? undefined : false
+          }
           header={
             attachmentsRef.current?.attachments === undefined
               ? attachmentsText.attachments()
@@ -117,9 +120,6 @@ export function RecordSetAttachments<SCHEMA extends AnySchema>({
                 })
           }
           onClose={handleHideAttachments}
-          dimensionsKey={
-            fetchedCount.current === records.length ? undefined : false
-          }
         >
           {halt ? (
             haltValue === records.length ? (


### PR DESCRIPTION
Fixes #4549

### Checklist

- [x] Self-review the PR after opening it to make sure the changes look good
      and self-explanatory (or properly documented)
- [x] Add relevant issue to release milestone

### Testing instructions

Go to a record set without any attachments
Click on attachment gallery
See the skeleton
See the skeleton disappear 
See the dialog shrinks 
