### PR TITLE
fix(Workbench): set cell metadata even for off-screen cells

### DIFF
--- a/specifyweb/frontend/js_src/lib/components/WorkBench/CellMeta.ts
+++ b/specifyweb/frontend/js_src/lib/components/WorkBench/CellMeta.ts
@@ -269,8 +269,13 @@ export class WbCellMeta {
     const visualCol =
       initialVisualCol ?? this.wbView.hot.toVisualColumn(physicalCol);
     const cell = initialCell ?? this.wbView.hot.getCell(visualRow, visualCol);
-    if (typeof cell === 'object' && cell !== null)
-      this.runMetaUpdateEffects(cell, key, value, visualRow, visualCol);
+    this.runMetaUpdateEffects(
+      cell ?? undefined,
+      key,
+      value,
+      visualRow,
+      visualCol
+    );
 
     return true;
   }


### PR DESCRIPTION
Fixes #4450

### Explanation of the cause

Here is what's happening:
- When validation results come in, they are parsed and the cell metadata is set (i.e what cells are new, and what have validation errors)
- Then, the visual changes (red color and popup) are applied only to cells that are rendered. See - https://github.com/specify/specify7/blob/04cb026b2652c7d5a3935f8468f001279c38a13a/specifyweb/frontend/js_src/lib/components/WorkBench/CellMeta.ts#L271 - this method returns null if cell is outside the rendered range (the Handsontable library is smart - it only renders cells that are within visible range, and a bit more for a safety boundary)

The bug was created during a refactor of this file to TypeScript
See this code change:

before:
https://github.com/specify/specify7/blob/9a3b5428e7adb04a6308b4c0f2334513ba6a73e5/specifyweb/frontend/js_src/lib/components/WorkBench/wbView.js#L1487-L1488

after:
https://github.com/specify/specify7/blob/04cb026b2652c7d5a3935f8468f001279c38a13a/specifyweb/frontend/js_src/lib/components/WorkBench/CellMeta.ts#L272-L273

The check for the cell being an object was added so as not to call runMetaUpdateEffects needlessly for cells that are not on the screen
runMetaUpdateEffects is responsible for updating the visuals of a cell to match the new metadata
When refactoring the code, I forgot that runMetaUpdateEffects doesn't only change the visuals for physical cell in the dom:
https://github.com/specify/specify7/blob/04cb026b2652c7d5a3935f8468f001279c38a13a/specifyweb/frontend/js_src/lib/components/WorkBench/CellMeta.ts#L202-L209

but, it also tells Handsontable to add the issue comments:
https://github.com/specify/specify7/blob/04cb026b2652c7d5a3935f8468f001279c38a13a/specifyweb/frontend/js_src/lib/components/WorkBench/CellMeta.ts#L213-L229

and unlike the DOM element changes, the issue comments should be added even if the cell is not rendered, as they are stored in a handsontable's internal data structure and are used by it to display the comments.

For reference, this is a function that Handsontable calls after it renders a cell:
https://github.com/specify/specify7/blob/04cb026b2652c7d5a3935f8468f001279c38a13a/specifyweb/frontend/js_src/lib/components/WorkBench/hooks.ts#L33-L73

This is where we add the blue/brown/orange colors to a cell.
Notice that we don't add the issues/red color in here because that is taken care of by Handsontable when we set the issue comments

cc @CarolineDenis 


### Checklist

- [x] Self-review the PR after opening it to make sure the changes look good
      and self-explanatory (or properly documented)
- [ ] Add automated tests
- [x] Add relevant issue to release milestone

### Testing instructions

Makes sure is fixed #4450 (test that errors display for cells even at rows that are below the screen - i.e row 50-60)