### PR TITLE
Expand collector subform when adding new

### DIFF
--- a/specifyweb/frontend/js_src/lib/components/FormSliders/IntegratedRecordSelector.tsx
+++ b/specifyweb/frontend/js_src/lib/components/FormSliders/IntegratedRecordSelector.tsx
@@ -240,7 +240,8 @@ export function IntegratedRecordSelector({
                 preHeaderButtons={collapsibleButton}
                 sortField={sortField}
                 viewName={viewName}
-                onAdd={(): void => {
+                onAdd={(resources): void => {
+                  if (!isInteraction) collection.add(resources);
                   if (typeof handleAdd === 'function') handleAdd();
                 }}
                 onClose={handleClose}

--- a/specifyweb/frontend/js_src/lib/components/FormSliders/IntegratedRecordSelector.tsx
+++ b/specifyweb/frontend/js_src/lib/components/FormSliders/IntegratedRecordSelector.tsx
@@ -115,6 +115,7 @@ export function IntegratedRecordSelector({
       <RecordSelectorFromCollection
         collection={collection}
         defaultIndex={isToOne ? 0 : index}
+        formType={formType}
         isCollapsed={isCollapsed}
         isInteraction={isInteraction}
         relationship={relationship}
@@ -130,7 +131,6 @@ export function IntegratedRecordSelector({
           handleExpand();
           if (typeof urlParameter === 'string') setIndex(index.toString());
         }}
-        formType={formType}
         {...rest}
       >
         {({

--- a/specifyweb/frontend/js_src/lib/components/FormSliders/IntegratedRecordSelector.tsx
+++ b/specifyweb/frontend/js_src/lib/components/FormSliders/IntegratedRecordSelector.tsx
@@ -130,6 +130,7 @@ export function IntegratedRecordSelector({
           handleExpand();
           if (typeof urlParameter === 'string') setIndex(index.toString());
         }}
+        formType={formType}
         {...rest}
       >
         {({

--- a/specifyweb/frontend/js_src/lib/components/FormSliders/IntegratedRecordSelector.tsx
+++ b/specifyweb/frontend/js_src/lib/components/FormSliders/IntegratedRecordSelector.tsx
@@ -115,12 +115,11 @@ export function IntegratedRecordSelector({
       <RecordSelectorFromCollection
         collection={collection}
         defaultIndex={isToOne ? 0 : index}
-        formType={formType}
-        isCollapsed={isCollapsed}
-        isInteraction={isInteraction}
         relationship={relationship}
         onAdd={(resource) => {
           if (isInteraction) handleOpenDialog();
+          if (!isInteraction && formType !== 'formTable')
+            collection.add(resource);
           handleAdding(resource);
         }}
         onDelete={(...args): void => {

--- a/specifyweb/frontend/js_src/lib/components/FormSliders/RecordSelectorFromCollection.tsx
+++ b/specifyweb/frontend/js_src/lib/components/FormSliders/RecordSelectorFromCollection.tsx
@@ -103,7 +103,6 @@ export function RecordSelectorFromCollection<SCHEMA extends AnySchema>({
       const resources = isToOne ? rawResources.slice(0, 1) : rawResources;
       if (isDependent && isToOne)
         collection.related?.placeInSameHierarchy(resources[0]);
-      if (!isInteraction) collection.add(resources);
       handleAdd?.(resources);
       const lastIndex = Math.max(0, collection.models.length - 1);
       setIndex(lastIndex);

--- a/specifyweb/frontend/js_src/lib/components/FormSliders/RecordSelectorFromCollection.tsx
+++ b/specifyweb/frontend/js_src/lib/components/FormSliders/RecordSelectorFromCollection.tsx
@@ -29,6 +29,7 @@ export function RecordSelectorFromCollection<SCHEMA extends AnySchema>({
   children,
   defaultIndex = 0,
   isInteraction,
+  formType,
   ...rest
 }: Omit<
   RecordSelectorProps<SCHEMA>,
@@ -46,6 +47,7 @@ export function RecordSelectorFromCollection<SCHEMA extends AnySchema>({
     readonly defaultIndex?: number;
     readonly children: (state: RecordSelectorState<SCHEMA>) => JSX.Element;
     readonly isInteraction?: boolean;
+    readonly formType: string;
   }): JSX.Element | null {
   const getRecords = React.useCallback(
     (): RA<SpecifyResource<SCHEMA> | undefined> =>
@@ -103,6 +105,7 @@ export function RecordSelectorFromCollection<SCHEMA extends AnySchema>({
       const resources = isToOne ? rawResources.slice(0, 1) : rawResources;
       if (isDependent && isToOne)
         collection.related?.placeInSameHierarchy(resources[0]);
+      if (!isInteraction && formType !== 'formTable') collection.add(resources);
       handleAdd?.(resources);
       const lastIndex = Math.max(0, collection.models.length - 1);
       setIndex(lastIndex);

--- a/specifyweb/frontend/js_src/lib/components/FormSliders/RecordSelectorFromCollection.tsx
+++ b/specifyweb/frontend/js_src/lib/components/FormSliders/RecordSelectorFromCollection.tsx
@@ -28,8 +28,6 @@ export function RecordSelectorFromCollection<SCHEMA extends AnySchema>({
   onSlide: handleSlide,
   children,
   defaultIndex = 0,
-  isInteraction,
-  formType,
   ...rest
 }: Omit<
   RecordSelectorProps<SCHEMA>,
@@ -46,8 +44,6 @@ export function RecordSelectorFromCollection<SCHEMA extends AnySchema>({
     readonly relationship: Relationship;
     readonly defaultIndex?: number;
     readonly children: (state: RecordSelectorState<SCHEMA>) => JSX.Element;
-    readonly isInteraction?: boolean;
-    readonly formType: string;
   }): JSX.Element | null {
   const getRecords = React.useCallback(
     (): RA<SpecifyResource<SCHEMA> | undefined> =>
@@ -105,7 +101,6 @@ export function RecordSelectorFromCollection<SCHEMA extends AnySchema>({
       const resources = isToOne ? rawResources.slice(0, 1) : rawResources;
       if (isDependent && isToOne)
         collection.related?.placeInSameHierarchy(resources[0]);
-      if (!isInteraction && formType !== 'formTable') collection.add(resources);
       handleAdd?.(resources);
       const lastIndex = Math.max(0, collection.models.length - 1);
       setIndex(lastIndex);


### PR DESCRIPTION
Fixes #4578

### Checklist

- [x] Self-review the PR after opening it to make sure the changes look good
      and self-explanatory (or properly documented)
- [x] Add relevant issue to release milestone

### Testing instructions

- Go to collecting event form
- Click on the collectors subform
- See that it is expanded 

Also test: 
add new prep in gift or loan
add other types of records in subview


Notes: 
with the code changes during the refactoring of IntegratedRecordSelector.tsx between 9.3 and 9.4 we had collection.add() being called twice for resources in formTable. 