### PR TITLE
Use label instead of as_scalar()

### DIFF
--- a/specifyweb/specify/views.py
+++ b/specifyweb/specify/views.py
@@ -88,6 +88,8 @@ def raise_error(request):
     """This endpoint intentionally throws an error in the server for
     testing purposes.
     """
+    from specifyweb.stored_queries.execution import test_qb
+    test_qb(request)
     raise Exception('This error is a test. You may now return to your regularly '
                     'scheduled hacking.')
 

--- a/specifyweb/stored_queries/execution.py
+++ b/specifyweb/stored_queries/execution.py
@@ -10,7 +10,7 @@ from functools import reduce
 
 from django.conf import settings
 from django.db import transaction
-from sqlalchemy import sql, orm, func
+from sqlalchemy import sql, orm, func, select
 from sqlalchemy.sql.expression import asc, desc, insert, literal
 
 from specifyweb.stored_queries.group_concat import group_by_displayed_fields
@@ -384,7 +384,17 @@ def createPlacemark(kmlDoc, row, coord_cols, table, captions, host):
 
     return placemarkElement
 
-
+def test_qb(request):
+    with models.session_context() as session:
+        prep_col = func.max(getattr(models.Preparation, models.Preparation._id))
+        query = select([prep_col]
+                       ).select_from(models.Preparation).where(models.Preparation.CollectionObjectID == models.CollectionObject.collectionObjectId).correlate(models.CollectionObject).as_scalar()
+        new_query = session.query(models.CollectionObject._id).select_from(models.CollectionObject).filter(models.CollectionObject.CollectionID == request.specify_collection.id)
+        new_query = new_query.add_column(query)
+        new_query = new_query.group_by(query)
+        str_query = str(new_query.statement.compile(compile_kwargs={"literal_binds": True}))
+        rr = list(new_query)
+    raise Exception('aha')
 
 def run_ephemeral_query(collection, user, spquery):
     """Execute a Specify query from deserialized json and return the results
@@ -649,5 +659,5 @@ def build_query(session, collection, user, tableid, field_specs,
     if distinct:
         query = group_by_displayed_fields(query, selected_fields)
 
-    logger.debug("query: %s", query.query)
+    logger.warning("query: %s", query.query)
     return query.query, order_by_exprs

--- a/specifyweb/stored_queries/format.py
+++ b/specifyweb/stored_queries/format.py
@@ -7,9 +7,8 @@ from xml.etree.ElementTree import Element
 from xml.sax.saxutils import quoteattr
 
 from sqlalchemy import orm, Table as SQLTable, inspect
-from sqlalchemy.sql.expression import case, func, cast, literal
+from sqlalchemy.sql.expression import case, func, cast, literal, Label
 from sqlalchemy.sql.functions import concat, count
-from sqlalchemy.sql.selectable import ScalarSelect
 from sqlalchemy.orm.attributes import InstrumentedAttribute
 from sqlalchemy.sql.elements import Extract
 from sqlalchemy import types
@@ -193,7 +192,7 @@ class ObjectFormatter(object):
     def aggregate(self, query: QueryConstruct,
                   field: Union[Field, Relationship], rel_table: SQLTable,
                   aggregator_name,
-                  cycle_detector=[]) -> ScalarSelect:
+                  cycle_detector=[]) -> Label:
 
         logger.info('aggregating field %s on %s using %s', field, rel_table,
                     aggregator_name)
@@ -236,7 +235,7 @@ class ObjectFormatter(object):
         aggregated = blank_nulls(group_concat(formatted, separator, *order_by_expr))
 
 
-        return subquery.query.add_column(aggregated).limit(limit).as_scalar()
+        return subquery.query.add_column(aggregated).limit(limit).label(None)
 
     def fieldformat(self, query_field: QueryField,
                     field: blank_nulls) -> blank_nulls:

--- a/specifyweb/stored_queries/tests.py
+++ b/specifyweb/stored_queries/tests.py
@@ -89,6 +89,11 @@ class SQLAlchemySetup(ApiTests):
 
 
     def setUp(self):
+        print("""
+            #BUG: If a test which compares the final sql query is added, then it could randomly fail
+            #in multithreaded tests because of usage of .label(None) in aggregate() 
+            #function in stored_queries/format.py 
+              """)
         super().setUp()
 
 


### PR DESCRIPTION
Fixes https://github.com/specify/specify7/pull/4596#issuecomment-1974070716

For some reason, SQLAlchemy is treating Labal and Scalar Selects differently when adding as a field in group_by. Looks like it takes the first field in scalar select as the field in groupby. The current workaround is to create "anon" label of an aggregated subquery (which is the only place which can create such a subquery). See SQLAlchemy [docs](https://docs.sqlalchemy.org/en/13/core/selectable.html#sqlalchemy.sql.expression.Select.label), looks like label() creates a scalar subquery anyways. Calling label(None) makes an anon label (like "anon_1")

However, this creates a bug in automated testing. I don't know if .label(None) is thread-safe. The current django unit tests run on a single core. If running on different cores in future, .label(None) could create non-deterministic labels. So, if a unit test relies on absolute equality, it would fail. For example, two separate unit tests may call .label(None) and get "anon_1" and "anon_2" labels, but the unit test expects "anon_1" and "anon_1". There is a straightforward fix for it, by keeping track of number of times aggregate() has been called, and making a label like "aggregated_COUNT" and then passing that label instead of None.

### Checklist

- [x] Self-review the PR after opening it to make sure the changes look good
      and self-explanatory (or properly documented)
- [ ] Add automated tests
- [ ] Add relevant issue to release milestone

### Testing instructions

<!-- What are the steps to verify the fixes/changes in this PR? -->
<!-- Can part of that be replaced by automated tests? -->
