### PR TITLE
Disable delete btn and add btn when read only in formatter comp

### DIFF
--- a/specifyweb/frontend/js_src/lib/components/Formatters/Definitions.tsx
+++ b/specifyweb/frontend/js_src/lib/components/Formatters/Definitions.tsx
@@ -151,8 +151,8 @@ function ConditionalFormatter({
               />
             </div>
             <span className="-ml-2" />
-            {trimmedFieldsLength > 0 && isExpanded ? (
-              <Button.Danger disabled={isReadOnly} onClick={handleDelete}>
+            {trimmedFieldsLength > 0 && isExpanded && !isReadOnly ? (
+              <Button.Danger onClick={handleDelete}>
                 {resourcesText.deleteDefinition()}
               </Button.Danger>
             ) : null}
@@ -173,9 +173,8 @@ function ConditionalFormatter({
           ) : null}
         </Label.Block>
       )}
-      {expandedNoCondition ? null : fields.length === 0 ? (
+      {expandedNoCondition || isReadOnly ? null : fields.length === 0 ? (
         <Button.Small
-          disabled={isReadOnly}
           onClick={(): void => {
             handleToggle();
             handleChanged(
@@ -215,21 +214,19 @@ function ConditionalFormatter({
             fields,
             (fields): void => handleChanged({ value, fields }, index),
           ]}
-          isReadOnly={isReadOnly}
           table={table}
         />
       ) : null}
       <span className="-ml-2 flex-1" />
-      <div className="inline-flex">
-        {trimmedFieldsLength === 1 || isExpanded ? null : (
+      {trimmedFieldsLength === 1 || isExpanded || isReadOnly ? null : (
+        <div className="inline-flex">
           <Button.Icon
-            disabled={isReadOnly}
             icon="trash"
             title={resourcesText.deleteDefinition()}
             onClick={handleDelete}
           />
-        )}
-      </div>
+        </div>
+      )}
       <div className="flex">
         {hasCondition && !isExpanded ? (
           <Button.Icon

--- a/specifyweb/frontend/js_src/lib/components/Formatters/Definitions.tsx
+++ b/specifyweb/frontend/js_src/lib/components/Formatters/Definitions.tsx
@@ -152,7 +152,7 @@ function ConditionalFormatter({
             </div>
             <span className="-ml-2" />
             {trimmedFieldsLength > 0 && isExpanded ? (
-              <Button.Danger onClick={handleDelete}>
+              <Button.Danger onClick={handleDelete} disabled={isReadOnly}>
                 {resourcesText.deleteDefinition()}
               </Button.Danger>
             ) : null}
@@ -193,6 +193,7 @@ function ConditionalFormatter({
               index
             );
           }}
+          disabled={isReadOnly}
         >
           {resourcesText.addField()}
         </Button.Small>
@@ -215,6 +216,7 @@ function ConditionalFormatter({
             (fields): void => handleChanged({ value, fields }, index),
           ]}
           table={table}
+          isReadOnly={isReadOnly}
         />
       ) : null}
       <span className="-ml-2 flex-1" />
@@ -224,6 +226,7 @@ function ConditionalFormatter({
             icon="trash"
             title={resourcesText.deleteDefinition()}
             onClick={handleDelete}
+            disabled={isReadOnly}
           />
         )}
       </div>

--- a/specifyweb/frontend/js_src/lib/components/Formatters/Definitions.tsx
+++ b/specifyweb/frontend/js_src/lib/components/Formatters/Definitions.tsx
@@ -152,7 +152,7 @@ function ConditionalFormatter({
             </div>
             <span className="-ml-2" />
             {trimmedFieldsLength > 0 && isExpanded ? (
-              <Button.Danger onClick={handleDelete} disabled={isReadOnly}>
+              <Button.Danger disabled={isReadOnly} onClick={handleDelete}>
                 {resourcesText.deleteDefinition()}
               </Button.Danger>
             ) : null}
@@ -175,6 +175,7 @@ function ConditionalFormatter({
       )}
       {expandedNoCondition ? null : fields.length === 0 ? (
         <Button.Small
+          disabled={isReadOnly}
           onClick={(): void => {
             handleToggle();
             handleChanged(
@@ -193,7 +194,6 @@ function ConditionalFormatter({
               index
             );
           }}
-          disabled={isReadOnly}
         >
           {resourcesText.addField()}
         </Button.Small>
@@ -215,18 +215,18 @@ function ConditionalFormatter({
             fields,
             (fields): void => handleChanged({ value, fields }, index),
           ]}
-          table={table}
           isReadOnly={isReadOnly}
+          table={table}
         />
       ) : null}
       <span className="-ml-2 flex-1" />
       <div className="inline-flex">
         {trimmedFieldsLength === 1 || isExpanded ? null : (
           <Button.Icon
+            disabled={isReadOnly}
             icon="trash"
             title={resourcesText.deleteDefinition()}
             onClick={handleDelete}
-            disabled={isReadOnly}
           />
         )}
       </div>

--- a/specifyweb/frontend/js_src/lib/components/Formatters/Element.tsx
+++ b/specifyweb/frontend/js_src/lib/components/Formatters/Element.tsx
@@ -73,14 +73,16 @@ export function XmlEditorShell<
     <Dialog
       buttons={
         <>
-          <Button.Danger
-            onClick={(): void => {
-              setItems(removeItem(items, index));
-              handleClose();
-            }}
-          >
-            {commonText.delete()}
-          </Button.Danger>
+          {isReadOnly ? null : (
+            <Button.Danger
+              onClick={(): void => {
+                setItems(removeItem(items, index));
+                handleClose();
+              }}
+            >
+              {commonText.delete()}
+            </Button.Danger>
+          )}
           <span className="-ml-2 flex-1" />
           <Submit.Secondary form={id('form')}>
             {commonText.close()}

--- a/specifyweb/frontend/js_src/lib/components/Formatters/Fields.tsx
+++ b/specifyweb/frontend/js_src/lib/components/Formatters/Fields.tsx
@@ -25,9 +25,11 @@ import type { Formatter } from './spec';
 export function Fields({
   table,
   fields: [fields, setFields],
+  isReadOnly,
 }: {
   readonly table: SpecifyTable;
   readonly fields: GetSet<Formatter['definition']['fields'][number]['fields']>;
+  readonly isReadOnly: boolean;
 }): JSX.Element {
   const [displayFormatter, setDisplayFormatter] = React.useState(false);
 
@@ -111,6 +113,7 @@ export function Fields({
               },
             ])
           }
+          disabled={isReadOnly}
         >
           {resourcesText.addField()}
         </Button.Secondary>
@@ -120,6 +123,7 @@ export function Fields({
             <Input.Checkbox
               checked={displayFormatter}
               onClick={(): void => setDisplayFormatter(!displayFormatter)}
+              disabled={isReadOnly}
             />
             {resourcesText.customizeFieldFormatters()}
           </Label.Inline>
@@ -190,6 +194,7 @@ function Field({
           title={commonText.remove()}
           variant={className.dangerButton}
           onClick={handleRemove}
+          disabled={isReadOnly}
         >
           {icons.trash}
         </Button.Small>
@@ -197,6 +202,7 @@ function Field({
           aria-label={queryText.moveUp()}
           title={queryText.moveUp()}
           onClick={moveFieldUp}
+          disabled={isReadOnly}
         >
           {icons.chevronUp}
         </Button.Small>
@@ -204,6 +210,7 @@ function Field({
           aria-label={queryText.moveDown()}
           title={queryText.moveDown()}
           onClick={moveFieldDown}
+          disabled={isReadOnly}
         >
           {icons.chevronDown}
         </Button.Small>

--- a/specifyweb/frontend/js_src/lib/components/Formatters/Fields.tsx
+++ b/specifyweb/frontend/js_src/lib/components/Formatters/Fields.tsx
@@ -101,6 +101,7 @@ export function Fields({
       )}
       <div className="flex gap-2">
         <Button.Secondary
+          disabled={isReadOnly}
           onClick={(): void =>
             setFields([
               ...fields,
@@ -113,7 +114,6 @@ export function Fields({
               },
             ])
           }
-          disabled={isReadOnly}
         >
           {resourcesText.addField()}
         </Button.Secondary>
@@ -122,8 +122,8 @@ export function Fields({
           <Label.Inline>
             <Input.Checkbox
               checked={displayFormatter}
-              onClick={(): void => setDisplayFormatter(!displayFormatter)}
               disabled={isReadOnly}
+              onClick={(): void => setDisplayFormatter(!displayFormatter)}
             />
             {resourcesText.customizeFieldFormatters()}
           </Label.Inline>
@@ -191,26 +191,26 @@ function Field({
       <td>
         <Button.Small
           aria-label={commonText.remove()}
+          disabled={isReadOnly}
           title={commonText.remove()}
           variant={className.dangerButton}
           onClick={handleRemove}
-          disabled={isReadOnly}
         >
           {icons.trash}
         </Button.Small>
         <Button.Small
           aria-label={queryText.moveUp()}
+          disabled={isReadOnly}
           title={queryText.moveUp()}
           onClick={moveFieldUp}
-          disabled={isReadOnly}
         >
           {icons.chevronUp}
         </Button.Small>
         <Button.Small
           aria-label={queryText.moveDown()}
+          disabled={isReadOnly}
           title={queryText.moveDown()}
           onClick={moveFieldDown}
-          disabled={isReadOnly}
         >
           {icons.chevronDown}
         </Button.Small>

--- a/specifyweb/frontend/js_src/lib/components/Formatters/Fields.tsx
+++ b/specifyweb/frontend/js_src/lib/components/Formatters/Fields.tsx
@@ -25,12 +25,12 @@ import type { Formatter } from './spec';
 export function Fields({
   table,
   fields: [fields, setFields],
-  isReadOnly,
 }: {
   readonly table: SpecifyTable;
   readonly fields: GetSet<Formatter['definition']['fields'][number]['fields']>;
-  readonly isReadOnly: boolean;
 }): JSX.Element {
+  const isReadOnly = React.useContext(ReadOnlyContext);
+
   const [displayFormatter, setDisplayFormatter] = React.useState(false);
 
   function moveField(index: number, direction: 'down' | 'up'): void {
@@ -99,36 +99,36 @@ export function Fields({
           </tbody>
         </table>
       )}
-      <div className="flex gap-2">
-        <Button.Secondary
-          disabled={isReadOnly}
-          onClick={(): void =>
-            setFields([
-              ...fields,
-              {
-                separator: localized(' '),
-                aggregator: undefined,
-                formatter: undefined,
-                fieldFormatter: undefined,
-                field: undefined,
-              },
-            ])
-          }
-        >
-          {resourcesText.addField()}
-        </Button.Secondary>
-        <span className="-ml-2 flex-1" />
-        {fields.length > 0 && (
-          <Label.Inline>
-            <Input.Checkbox
-              checked={displayFormatter}
-              disabled={isReadOnly}
-              onClick={(): void => setDisplayFormatter(!displayFormatter)}
-            />
-            {resourcesText.customizeFieldFormatters()}
-          </Label.Inline>
-        )}
-      </div>
+      {isReadOnly ? null : (
+        <div className="flex gap-2">
+          <Button.Secondary
+            onClick={(): void =>
+              setFields([
+                ...fields,
+                {
+                  separator: localized(' '),
+                  aggregator: undefined,
+                  formatter: undefined,
+                  fieldFormatter: undefined,
+                  field: undefined,
+                },
+              ])
+            }
+          >
+            {resourcesText.addField()}
+          </Button.Secondary>
+          <span className="-ml-2 flex-1" />
+          {fields.length > 0 && (
+            <Label.Inline>
+              <Input.Checkbox
+                checked={displayFormatter}
+                onClick={(): void => setDisplayFormatter(!displayFormatter)}
+              />
+              {resourcesText.customizeFieldFormatters()}
+            </Label.Inline>
+          )}
+        </div>
+      )}
     </>
   );
 }
@@ -188,33 +188,32 @@ function Field({
           <FieldFormatter field={[field, handleChange]} />
         </td>
       )}
-      <td>
-        <Button.Small
-          aria-label={commonText.remove()}
-          disabled={isReadOnly}
-          title={commonText.remove()}
-          variant={className.dangerButton}
-          onClick={handleRemove}
-        >
-          {icons.trash}
-        </Button.Small>
-        <Button.Small
-          aria-label={queryText.moveUp()}
-          disabled={isReadOnly}
-          title={queryText.moveUp()}
-          onClick={moveFieldUp}
-        >
-          {icons.chevronUp}
-        </Button.Small>
-        <Button.Small
-          aria-label={queryText.moveDown()}
-          disabled={isReadOnly}
-          title={queryText.moveDown()}
-          onClick={moveFieldDown}
-        >
-          {icons.chevronDown}
-        </Button.Small>
-      </td>
+      {isReadOnly ? null : (
+        <td>
+          <Button.Small
+            aria-label={commonText.remove()}
+            title={commonText.remove()}
+            variant={className.dangerButton}
+            onClick={handleRemove}
+          >
+            {icons.trash}
+          </Button.Small>
+          <Button.Small
+            aria-label={queryText.moveUp()}
+            title={queryText.moveUp()}
+            onClick={moveFieldUp}
+          >
+            {icons.chevronUp}
+          </Button.Small>
+          <Button.Small
+            aria-label={queryText.moveDown()}
+            title={queryText.moveDown()}
+            onClick={moveFieldDown}
+          >
+            {icons.chevronDown}
+          </Button.Small>
+        </td>
+      )}
     </tr>
   );
 }

--- a/specifyweb/frontend/js_src/lib/components/Formatters/Fields.tsx
+++ b/specifyweb/frontend/js_src/lib/components/Formatters/Fields.tsx
@@ -188,32 +188,34 @@ function Field({
           <FieldFormatter field={[field, handleChange]} />
         </td>
       )}
-      {isReadOnly ? null : (
-        <td>
-          <Button.Small
-            aria-label={commonText.remove()}
-            title={commonText.remove()}
-            variant={className.dangerButton}
-            onClick={handleRemove}
-          >
-            {icons.trash}
-          </Button.Small>
-          <Button.Small
-            aria-label={queryText.moveUp()}
-            title={queryText.moveUp()}
-            onClick={moveFieldUp}
-          >
-            {icons.chevronUp}
-          </Button.Small>
-          <Button.Small
-            aria-label={queryText.moveDown()}
-            title={queryText.moveDown()}
-            onClick={moveFieldDown}
-          >
-            {icons.chevronDown}
-          </Button.Small>
-        </td>
-      )}
+      <td>
+        {isReadOnly ? null : (
+          <>
+            <Button.Small
+              aria-label={commonText.remove()}
+              title={commonText.remove()}
+              variant={className.dangerButton}
+              onClick={handleRemove}
+            >
+              {icons.trash}
+            </Button.Small>
+            <Button.Small
+              aria-label={queryText.moveUp()}
+              title={queryText.moveUp()}
+              onClick={moveFieldUp}
+            >
+              {icons.chevronUp}
+            </Button.Small>
+            <Button.Small
+              aria-label={queryText.moveDown()}
+              title={queryText.moveDown()}
+              onClick={moveFieldDown}
+            >
+              {icons.chevronDown}
+            </Button.Small>
+          </>
+        )}
+      </td>
     </tr>
   );
 }


### PR DESCRIPTION
Fixes #4610

### Checklist

- [x] Self-review the PR after opening it to make sure the changes look good
      and self-explanatory (or properly documented)
- [x] Add relevant issue to release milestone

### Testing instructions

Log in as grant on the umherb_1_10_24 test panel database
Go to https://umherb11024-edge.test.specifysystems.org/specify/overlay/resources/app-resource/92/formatter/Determination/22
Click on the Edit pencils next the Determination table format 
==> Verify that the content of the dialog is read only and that you cannot delete anything, reorder or add new field
