### PR TITLE
Add support for explicitly choose a formatter in QB

### DIFF
--- a/specifyweb/frontend/js_src/lib/components/QueryBuilder/Formatter.tsx
+++ b/specifyweb/frontend/js_src/lib/components/QueryBuilder/Formatter.tsx
@@ -55,12 +55,12 @@ export function QueryFieldFormatter({
   ) : availableFormatters.length > 1 ? (
     <>
       <Button.Icon
-        className={
+        className={`${
           availableFormatters.find((selected) => selected.name === formatter)
             ?.isDefault
             ? ''
-            : 'bg-yellow-250 dark:bg-yellow-900'
-        }
+            : 'bg-yellow-250 dark:bg-yellow-900 '
+        } border border-gray-500 p-0.5`}
         icon="cog"
         title={queryText.chooseFormatter()}
         onClick={() => toggleFormatterSelect(!formatterSelectIsOpen)}

--- a/specifyweb/frontend/js_src/lib/components/QueryBuilder/Formatter.tsx
+++ b/specifyweb/frontend/js_src/lib/components/QueryBuilder/Formatter.tsx
@@ -75,7 +75,6 @@ export function QueryFieldFormatter({
             value={formatter}
             onValueChange={(value) => {
               handleChange?.(value);
-              toggleFormatterSelect(!formatterSelectIsOpen);
             }}
           >
             <option />

--- a/specifyweb/frontend/js_src/lib/components/QueryBuilder/Formatter.tsx
+++ b/specifyweb/frontend/js_src/lib/components/QueryBuilder/Formatter.tsx
@@ -73,9 +73,7 @@ export function QueryFieldFormatter({
           <Select
             disabled={handleChange === undefined}
             value={formatter}
-            onValueChange={(value) => {
-              handleChange?.(value);
-            }}
+            onValueChange={handleChange}
           >
             <option />
             {availableFormatters.map(({ name, title }, index) => (

--- a/specifyweb/frontend/js_src/lib/components/QueryBuilder/Formatter.tsx
+++ b/specifyweb/frontend/js_src/lib/components/QueryBuilder/Formatter.tsx
@@ -57,8 +57,8 @@ export function QueryFieldFormatter({
       <Button.Icon
         className={`${
           availableFormatters.find((selected) => selected.name === formatter)
-            ?.isDefault
-            ? ''
+            ?.isDefault || formatter === undefined
+            ? 'bg-white dark:bg-neutral-600'
             : 'bg-yellow-250 dark:bg-yellow-900 '
         } border border-gray-500 p-0.5`}
         icon="cog"

--- a/specifyweb/frontend/js_src/lib/components/QueryBuilder/Formatter.tsx
+++ b/specifyweb/frontend/js_src/lib/components/QueryBuilder/Formatter.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import { usePromise } from '../../hooks/useAsyncState';
+import { useId } from '../../hooks/useId';
 import { commonText } from '../../localization/common';
 import { queryText } from '../../localization/query';
 import { Button } from '../Atoms/Button';
@@ -8,7 +9,6 @@ import { Select } from '../Atoms/Form';
 import { icons } from '../Atoms/Icons';
 import type { Tables } from '../DataModel/types';
 import { fetchFormatters } from '../Formatters/formatters';
-import { useId } from '../../hooks/useId';
 
 export function QueryFieldFormatter({
   type,
@@ -59,6 +59,7 @@ export function QueryFieldFormatter({
   ) : availableFormatters.length > 1 ? (
     <>
       <Button.Small
+        aria-controls={id('list')}
         aria-label={queryText.chooseFormatter()}
         className={`${
           availableFormatters.find((selected) => selected.name === formatter)
@@ -68,18 +69,17 @@ export function QueryFieldFormatter({
         }`}
         title={queryText.chooseFormatter()}
         onClick={() => setFormatterSelect(!formatterSelectIsOpen)}
-        aria-controls={id('list')}
       >
         {icons.cog}
       </Button.Small>
       {formatterSelectIsOpen && (
         <div>
           <Select
+            aria-label={queryText.chooseFormatter()}
             disabled={handleChange === undefined}
+            id="list"
             value={formatter}
             onValueChange={handleChange}
-            aria-label={queryText.chooseFormatter()}
-            id={'list'}
           >
             <option />
             {availableFormatters.map(({ name, title }, index) => (

--- a/specifyweb/frontend/js_src/lib/components/QueryBuilder/Formatter.tsx
+++ b/specifyweb/frontend/js_src/lib/components/QueryBuilder/Formatter.tsx
@@ -10,6 +10,7 @@ import { icons } from '../Atoms/Icons';
 import type { Tables } from '../DataModel/types';
 import { fetchFormatters } from '../Formatters/formatters';
 import { customSelectElementBackground } from '../WbPlanView/CustomSelectElement';
+import { resourcesText } from '../../localization/resources';
 
 export function QueryFieldFormatter({
   type,
@@ -86,9 +87,9 @@ export function QueryFieldFormatter({
             onValueChange={handleChange}
           >
             <option />
-            {availableFormatters.map(({ name, title }, index) => (
+            {availableFormatters.map(({ name, title, isDefault }, index) => (
               <option key={index} value={name}>
-                {title}
+                {title} {isDefault ? resourcesText.defaultInline() : ''}
               </option>
             ))}
           </Select>

--- a/specifyweb/frontend/js_src/lib/components/QueryBuilder/Formatter.tsx
+++ b/specifyweb/frontend/js_src/lib/components/QueryBuilder/Formatter.tsx
@@ -7,6 +7,7 @@ import { Button } from '../Atoms/Button';
 import { Select } from '../Atoms/Form';
 import type { Tables } from '../DataModel/types';
 import { fetchFormatters } from '../Formatters/formatters';
+import { icons } from '../Atoms/Icons';
 
 export function QueryFieldFormatter({
   type,
@@ -54,17 +55,19 @@ export function QueryFieldFormatter({
     ) : null
   ) : availableFormatters.length > 1 ? (
     <>
-      <Button.Icon
+      <Button.Small
+        aria-label={queryText.chooseFormatter()}
         className={`${
           availableFormatters.find((selected) => selected.name === formatter)
             ?.isDefault || formatter === undefined
             ? 'bg-white dark:bg-neutral-600'
             : 'bg-yellow-250 dark:bg-yellow-900 '
-        } border border-gray-500 p-0.5`}
-        icon="cog"
+        }`}
         title={queryText.chooseFormatter()}
         onClick={() => toggleFormatterSelect(!formatterSelectIsOpen)}
-      />
+      >
+        {icons.cog}
+      </Button.Small>
       {formatterSelectIsOpen && (
         <div>
           <Select

--- a/specifyweb/frontend/js_src/lib/components/QueryBuilder/Formatter.tsx
+++ b/specifyweb/frontend/js_src/lib/components/QueryBuilder/Formatter.tsx
@@ -9,6 +9,7 @@ import { Select } from '../Atoms/Form';
 import { icons } from '../Atoms/Icons';
 import type { Tables } from '../DataModel/types';
 import { fetchFormatters } from '../Formatters/formatters';
+import { customSelectElementBackground } from '../WbPlanView/CustomSelectElement';
 
 export function QueryFieldFormatter({
   type,
@@ -50,7 +51,7 @@ export function QueryFieldFormatter({
 
   const [formatterSelectIsOpen, setFormatterSelect] = React.useState(false);
 
-  const id = useId('formatters');
+  const id = useId('formatters-selection');
 
   return availableFormatters === undefined ? (
     typeof formatter === 'string' ? (
@@ -63,7 +64,9 @@ export function QueryFieldFormatter({
         aria-label={queryText.chooseFormatter()}
         className={`${
           availableFormatters.find((selected) => selected.name === formatter)
-            ?.isDefault || formatter === undefined
+            ?.isDefault ||
+          formatter === undefined ||
+          formatter === ''
             ? 'bg-white dark:bg-neutral-600'
             : 'bg-yellow-250 dark:bg-yellow-900 '
         }`}
@@ -77,9 +80,10 @@ export function QueryFieldFormatter({
           <Select
             aria-label={queryText.chooseFormatter()}
             disabled={handleChange === undefined}
-            id="list"
+            id={id('list')}
             value={formatter}
             onValueChange={handleChange}
+            className={`${customSelectElementBackground}`}
           >
             <option />
             {availableFormatters.map(({ name, title }, index) => (

--- a/specifyweb/frontend/js_src/lib/components/QueryBuilder/Formatter.tsx
+++ b/specifyweb/frontend/js_src/lib/components/QueryBuilder/Formatter.tsx
@@ -8,6 +8,7 @@ import { Select } from '../Atoms/Form';
 import { icons } from '../Atoms/Icons';
 import type { Tables } from '../DataModel/types';
 import { fetchFormatters } from '../Formatters/formatters';
+import { useId } from '../../hooks/useId';
 
 export function QueryFieldFormatter({
   type,
@@ -47,7 +48,9 @@ export function QueryFieldFormatter({
     [type, formatters, tableName]
   );
 
-  const [formatterSelectIsOpen, toggleFormatterSelect] = React.useState(false);
+  const [formatterSelectIsOpen, setFormatterSelect] = React.useState(false);
+
+  const id = useId('formatters');
 
   return availableFormatters === undefined ? (
     typeof formatter === 'string' ? (
@@ -64,7 +67,8 @@ export function QueryFieldFormatter({
             : 'bg-yellow-250 dark:bg-yellow-900 '
         }`}
         title={queryText.chooseFormatter()}
-        onClick={() => toggleFormatterSelect(!formatterSelectIsOpen)}
+        onClick={() => setFormatterSelect(!formatterSelectIsOpen)}
+        aria-controls={id('list')}
       >
         {icons.cog}
       </Button.Small>
@@ -74,6 +78,8 @@ export function QueryFieldFormatter({
             disabled={handleChange === undefined}
             value={formatter}
             onValueChange={handleChange}
+            aria-label={queryText.chooseFormatter()}
+            id={'list'}
           >
             <option />
             {availableFormatters.map(({ name, title }, index) => (

--- a/specifyweb/frontend/js_src/lib/components/QueryBuilder/Formatter.tsx
+++ b/specifyweb/frontend/js_src/lib/components/QueryBuilder/Formatter.tsx
@@ -4,13 +4,13 @@ import { usePromise } from '../../hooks/useAsyncState';
 import { useId } from '../../hooks/useId';
 import { commonText } from '../../localization/common';
 import { queryText } from '../../localization/query';
+import { resourcesText } from '../../localization/resources';
 import { Button } from '../Atoms/Button';
 import { Select } from '../Atoms/Form';
 import { icons } from '../Atoms/Icons';
 import type { Tables } from '../DataModel/types';
 import { fetchFormatters } from '../Formatters/formatters';
 import { customSelectElementBackground } from '../WbPlanView/CustomSelectElement';
-import { resourcesText } from '../../localization/resources';
 
 export function QueryFieldFormatter({
   type,

--- a/specifyweb/frontend/js_src/lib/components/QueryBuilder/Formatter.tsx
+++ b/specifyweb/frontend/js_src/lib/components/QueryBuilder/Formatter.tsx
@@ -5,7 +5,8 @@ import { commonText } from '../../localization/common';
 import { Select } from '../Atoms/Form';
 import type { Tables } from '../DataModel/types';
 import { fetchFormatters } from '../Formatters/formatters';
-import { mappingElementDivider } from '../WbPlanView/LineComponents';
+import { Button } from '../Atoms/Button';
+import { queryText } from '../../localization/query';
 
 export function QueryFieldFormatter({
   type,
@@ -23,42 +24,67 @@ export function QueryFieldFormatter({
     () =>
       // Some code duplication, but required by TypeScript
       (type === 'formatter'
-        ? formatters?.formatters.map(({ table, name, title }) => ({
+        ? formatters?.formatters.map(({ table, name, title, isDefault }) => ({
             table,
             name,
             title,
+            isDefault,
           }))
-        : formatters?.aggregators.map(({ table, name, title }) => ({
+        : formatters?.aggregators.map(({ table, name, title, isDefault }) => ({
             table,
             name,
             title,
+            isDefault,
           }))
       )
         ?.filter(({ table }) => table?.name === tableName)
-        .map(({ name, title = name }) => ({ name, title })),
+        .map(({ name, title = name, isDefault }) => ({
+          name,
+          title,
+          isDefault,
+        })),
     [type, formatters, tableName]
   );
+
+  const [formatterSelectIsOpen, toggleFormatterSelect] = React.useState(false);
+
   return availableFormatters === undefined ? (
     typeof formatter === 'string' ? (
       <>{commonText.loading()}</>
     ) : null
   ) : availableFormatters.length > 1 ? (
     <>
-      {mappingElementDivider}
-      <div>
-        <Select
-          disabled={handleChange === undefined}
-          value={formatter}
-          onValueChange={handleChange}
-        >
-          <option />
-          {availableFormatters.map(({ name, title }, index) => (
-            <option key={index} value={name}>
-              {title}
-            </option>
-          ))}
-        </Select>
-      </div>
+      <Button.Icon
+        icon="cog"
+        title={queryText.chooseFormatter()}
+        onClick={() => toggleFormatterSelect(!formatterSelectIsOpen)}
+        className={
+          formatter &&
+          availableFormatters.find((selected) => selected.name === formatter)
+            ?.isDefault
+            ? ''
+            : 'bg-yellow-250 dark:bg-yellow-900'
+        }
+      />
+      {formatterSelectIsOpen && (
+        <div>
+          <Select
+            disabled={handleChange === undefined}
+            value={formatter}
+            onValueChange={(value) => {
+              handleChange?.(value);
+              toggleFormatterSelect(!formatterSelectIsOpen);
+            }}
+          >
+            <option />
+            {availableFormatters.map(({ name, title }, index) => (
+              <option key={index} value={name}>
+                {title}
+              </option>
+            ))}
+          </Select>
+        </div>
+      )}
     </>
   ) : null;
 }

--- a/specifyweb/frontend/js_src/lib/components/QueryBuilder/Formatter.tsx
+++ b/specifyweb/frontend/js_src/lib/components/QueryBuilder/Formatter.tsx
@@ -79,11 +79,11 @@ export function QueryFieldFormatter({
         <div>
           <Select
             aria-label={queryText.chooseFormatter()}
+            className={`${customSelectElementBackground}`}
             disabled={handleChange === undefined}
             id={id('list')}
             value={formatter}
             onValueChange={handleChange}
-            className={`${customSelectElementBackground}`}
           >
             <option />
             {availableFormatters.map(({ name, title }, index) => (

--- a/specifyweb/frontend/js_src/lib/components/QueryBuilder/Formatter.tsx
+++ b/specifyweb/frontend/js_src/lib/components/QueryBuilder/Formatter.tsx
@@ -5,9 +5,9 @@ import { commonText } from '../../localization/common';
 import { queryText } from '../../localization/query';
 import { Button } from '../Atoms/Button';
 import { Select } from '../Atoms/Form';
+import { icons } from '../Atoms/Icons';
 import type { Tables } from '../DataModel/types';
 import { fetchFormatters } from '../Formatters/formatters';
-import { icons } from '../Atoms/Icons';
 
 export function QueryFieldFormatter({
   type,

--- a/specifyweb/frontend/js_src/lib/components/QueryBuilder/Formatter.tsx
+++ b/specifyweb/frontend/js_src/lib/components/QueryBuilder/Formatter.tsx
@@ -2,11 +2,11 @@ import React from 'react';
 
 import { usePromise } from '../../hooks/useAsyncState';
 import { commonText } from '../../localization/common';
+import { queryText } from '../../localization/query';
+import { Button } from '../Atoms/Button';
 import { Select } from '../Atoms/Form';
 import type { Tables } from '../DataModel/types';
 import { fetchFormatters } from '../Formatters/formatters';
-import { Button } from '../Atoms/Button';
-import { queryText } from '../../localization/query';
 
 export function QueryFieldFormatter({
   type,
@@ -55,15 +55,15 @@ export function QueryFieldFormatter({
   ) : availableFormatters.length > 1 ? (
     <>
       <Button.Icon
-        icon="cog"
-        title={queryText.chooseFormatter()}
-        onClick={() => toggleFormatterSelect(!formatterSelectIsOpen)}
         className={
           availableFormatters.find((selected) => selected.name === formatter)
             ?.isDefault
             ? ''
             : 'bg-yellow-250 dark:bg-yellow-900'
         }
+        icon="cog"
+        title={queryText.chooseFormatter()}
+        onClick={() => toggleFormatterSelect(!formatterSelectIsOpen)}
       />
       {formatterSelectIsOpen && (
         <div>

--- a/specifyweb/frontend/js_src/lib/components/QueryBuilder/Formatter.tsx
+++ b/specifyweb/frontend/js_src/lib/components/QueryBuilder/Formatter.tsx
@@ -59,7 +59,6 @@ export function QueryFieldFormatter({
         title={queryText.chooseFormatter()}
         onClick={() => toggleFormatterSelect(!formatterSelectIsOpen)}
         className={
-          formatter &&
           availableFormatters.find((selected) => selected.name === formatter)
             ?.isDefault
             ? ''

--- a/specifyweb/frontend/js_src/lib/components/QueryBuilder/Line.tsx
+++ b/specifyweb/frontend/js_src/lib/components/QueryBuilder/Line.tsx
@@ -49,6 +49,7 @@ import type { DatePart } from './fieldSpec';
 import { QueryFieldSpec } from './fieldSpec';
 import type { QueryField } from './helpers';
 import { QueryLineTools } from './QueryLineTools';
+import { QueryFieldFormatter } from './Formatter';
 
 // REFACTOR: split this component into smaller components
 export function QueryLine({
@@ -372,6 +373,27 @@ export function QueryLine({
                 mappingElementDivider
               )
             )}
+            {(fieldMeta.fieldType === 'formatter' ||
+              fieldMeta.fieldType === 'aggregator') &&
+            typeof fieldMeta.tableName === 'string' ? (
+              <>
+                {mappingElementDivider}
+                <QueryFieldFormatter
+                  formatter={field.dataObjFormatter}
+                  tableName={fieldMeta.tableName}
+                  type={fieldMeta.fieldType}
+                  onChange={
+                    handleChange === undefined
+                      ? undefined
+                      : (dataObjectFormatter): void =>
+                          handleChange({
+                            ...field,
+                            dataObjFormatter: dataObjectFormatter,
+                          })
+                  }
+                />
+              </>
+            ) : undefined}
           </div>
           {filtersVisible ? (
             <div

--- a/specifyweb/frontend/js_src/lib/components/QueryBuilder/Line.tsx
+++ b/specifyweb/frontend/js_src/lib/components/QueryBuilder/Line.tsx
@@ -377,7 +377,6 @@ export function QueryLine({
               fieldMeta.fieldType === 'aggregator') &&
             typeof fieldMeta.tableName === 'string' ? (
               <>
-                {mappingElementDivider}
                 <QueryFieldFormatter
                   formatter={field.dataObjFormatter}
                   tableName={fieldMeta.tableName}

--- a/specifyweb/frontend/js_src/lib/components/QueryBuilder/Line.tsx
+++ b/specifyweb/frontend/js_src/lib/components/QueryBuilder/Line.tsx
@@ -29,6 +29,7 @@ import {
   formattedEntry,
   mappingPathToString,
   parsePartialField,
+  relationshipIsToMany,
   valueIsPartialField,
 } from '../WbPlanView/mappingHelpers';
 import { generateMappingPathPreview } from '../WbPlanView/mappingPreview';
@@ -166,7 +167,7 @@ export function QueryLine({
         canOpenMap = fieldName === 'latitude1' || fieldName === 'longitude1';
       } else if (isMapped)
         fieldType =
-          isFormatted && mappingPath.at(-1) === '#1'
+          dataModelField?.isRelationship && relationshipIsToMany(dataModelField)
             ? 'aggregator'
             : 'formatter';
 

--- a/specifyweb/frontend/js_src/lib/components/QueryBuilder/Line.tsx
+++ b/specifyweb/frontend/js_src/lib/components/QueryBuilder/Line.tsx
@@ -167,7 +167,7 @@ export function QueryLine({
         canOpenMap = fieldName === 'latitude1' || fieldName === 'longitude1';
       } else if (isMapped)
         fieldType =
-          dataModelField?.isRelationship && relationshipIsToMany(dataModelField)
+          isFormatted && mappingPath.at(-1) === '#1'
             ? 'aggregator'
             : 'formatter';
 

--- a/specifyweb/frontend/js_src/lib/components/QueryBuilder/Line.tsx
+++ b/specifyweb/frontend/js_src/lib/components/QueryBuilder/Line.tsx
@@ -376,22 +376,20 @@ export function QueryLine({
             {(fieldMeta.fieldType === 'formatter' ||
               fieldMeta.fieldType === 'aggregator') &&
             typeof fieldMeta.tableName === 'string' ? (
-              <>
-                <QueryFieldFormatter
-                  formatter={field.dataObjFormatter}
-                  tableName={fieldMeta.tableName}
-                  type={fieldMeta.fieldType}
-                  onChange={
-                    handleChange === undefined
-                      ? undefined
-                      : (dataObjectFormatter): void =>
-                          handleChange({
-                            ...field,
-                            dataObjFormatter: dataObjectFormatter,
-                          })
-                  }
-                />
-              </>
+              <QueryFieldFormatter
+                formatter={field.dataObjFormatter}
+                tableName={fieldMeta.tableName}
+                type={fieldMeta.fieldType}
+                onChange={
+                  handleChange === undefined
+                    ? undefined
+                    : (dataObjectFormatter): void =>
+                        handleChange({
+                          ...field,
+                          dataObjFormatter: dataObjectFormatter,
+                        })
+                }
+              />
             ) : undefined}
           </div>
           {filtersVisible ? (

--- a/specifyweb/frontend/js_src/lib/components/QueryBuilder/Line.tsx
+++ b/specifyweb/frontend/js_src/lib/components/QueryBuilder/Line.tsx
@@ -47,9 +47,9 @@ import {
 } from './FieldFilter';
 import type { DatePart } from './fieldSpec';
 import { QueryFieldSpec } from './fieldSpec';
+import { QueryFieldFormatter } from './Formatter';
 import type { QueryField } from './helpers';
 import { QueryLineTools } from './QueryLineTools';
-import { QueryFieldFormatter } from './Formatter';
 
 // REFACTOR: split this component into smaller components
 export function QueryLine({

--- a/specifyweb/frontend/js_src/lib/components/QueryBuilder/Line.tsx
+++ b/specifyweb/frontend/js_src/lib/components/QueryBuilder/Line.tsx
@@ -29,7 +29,6 @@ import {
   formattedEntry,
   mappingPathToString,
   parsePartialField,
-  relationshipIsToMany,
   valueIsPartialField,
 } from '../WbPlanView/mappingHelpers';
 import { generateMappingPathPreview } from '../WbPlanView/mappingPreview';

--- a/specifyweb/frontend/js_src/lib/localization/query.ts
+++ b/specifyweb/frontend/js_src/lib/localization/query.ts
@@ -883,4 +883,7 @@ export const queryText = createDictionary({
     'ru-ru': 'Просмотр записей',
     'uk-ua': 'Переглянути записи',
   },
+  chooseFormatter: {
+    'en-us': 'Choose fromatter',
+  },
 } as const);

--- a/specifyweb/frontend/js_src/lib/localization/query.ts
+++ b/specifyweb/frontend/js_src/lib/localization/query.ts
@@ -884,6 +884,6 @@ export const queryText = createDictionary({
     'uk-ua': 'Переглянути записи',
   },
   chooseFormatter: {
-    'en-us': 'Choose fromatter',
+    'en-us': 'Choose formatter',
   },
 } as const);


### PR DESCRIPTION
Fixes #1959

Notes: 
Code was lost during a merge. Feature added in https://github.com/specify/specify7/commit/d52aee94a01d126b2ef83f0dea1f690bb59f6ee1

### Checklist

- [x] Self-review the PR after opening it to make sure the changes look good
      and self-explanatory (or properly documented)
- [x] Add relevant issue to release milestone

### Testing instructions

- Navigate to the Query Builder (QB).
- Select a table that you know has one or several formatters (To check, go to app resources, navigate to Record Formatter, choose the table, and verify the list of formatter names available).
- Choose "formatted."

- [ ] Verify that in the query line, after selecting the "formatted" field box, a drop-down appears with a list of formatter choices (corresponding to the list in app resources).
- [ ] Verify that changing the formatter changes the way the field is displayed in the results table.