### PR TITLE
Hide pagination range selector when no queries

### DIFF
--- a/specifyweb/frontend/js_src/lib/components/Toolbar/Query.tsx
+++ b/specifyweb/frontend/js_src/lib/components/Toolbar/Query.tsx
@@ -198,7 +198,9 @@ export function QueryListDialog({
         </table>
         <span className="-ml-2 flex-1" />
         {data === undefined && loadingGif}
-        {paginator(data?.totalCount)}
+        {data !== undefined && data?.records.length > 0
+          ? paginator(data?.totalCount)
+          : null}
       </>
     ),
     dialog: (children) => (


### PR DESCRIPTION
Fixes #4616

### Checklist

- [ ] Self-review the PR after opening it to make sure the changes look good
      and self-explanatory (or properly documented)
- [ ] Add relevant issue to release milestone

### Testing instructions

- Log into a user who does not have any queries (for example, csiro on umherb_1_10_24 on the test panel)

- Click "Queries" in the navigation menu

- [ ] See that paginator is not present as well as no slider
- [ ] See that paginator is present as well as slider for users that have queries 
