### PR TITLE
Fix page size selector taking up a disproportionate amount of space

### DIFF
--- a/specifyweb/frontend/js_src/lib/components/Molecules/Paginator.tsx
+++ b/specifyweb/frontend/js_src/lib/components/Molecules/Paginator.tsx
@@ -48,7 +48,7 @@ export function usePaginator(
           )}
           <div className="flex flex-1 justify-end">
             <Select
-              className={pageSize === infinity ? 'w-auto' : 'w-16'}
+              className={pageSize === infinity ? '!w-auto' : '!w-16'}
               value={pageSize}
               onValueChange={(rawNewPageSize): void => {
                 const newPageSize = Number.parseInt(rawNewPageSize);


### PR DESCRIPTION
Since we should use these flags sparingly, I'd like to hear from a dev if removing `w-full` from the `select` style in `Form.tsx` would be a better long-term solution

Fixes #4623

Left is this branch, right is the current `edge` behavior:

https://github.com/specify/specify7/assets/37256050/00ecc7e3-1275-449d-b7c7-01c61191bbf1

### Checklist

- [X] Self-review the PR after opening it to make sure the changes look good
      and self-explanatory (or properly documented)
- [X] Add relevant issue to release milestone

### Testing instructions
1. Verify that the page size list takes up an appropriate amount of room in the
   - [ ] Record set dialog
   - [ ] Queries dialog 
2. Make sure the paginator appears correctly in
   - [ ] Browse in forms
   - [ ] Record sets
