### PR TITLE
Add headings to conditional table when collapsed

### DIFF
--- a/specifyweb/frontend/js_src/lib/components/Formatters/Definitions.tsx
+++ b/specifyweb/frontend/js_src/lib/components/Formatters/Definitions.tsx
@@ -12,6 +12,7 @@ import { ReadOnlyContext } from '../Core/Contexts';
 import type { SpecifyTable } from '../DataModel/specifyTable';
 import { Fields } from './Fields';
 import type { Formatter } from './spec';
+import { commonText } from '../../localization/common';
 
 export function Definitions({
   item: [formatter, setFormatter],
@@ -125,53 +126,60 @@ function ConditionalFormatter({
   return (
     <div
       className={`flex
-        ${isExpanded || !hasCondition ? 'flex-col' : 'items-center'}
+        ${isExpanded || !hasCondition ? 'flex-col' : ''}
         ${isExpanded ? 'gap-2' : ''}
       `}
       key={index}
     >
       {hasCondition && (
-        <Label.Block>
-          {isExpanded ? resourcesText.conditionFieldValue() : null}
-          <div className="flex items-center gap-2 pr-2">
-            <div className="h-full flex-1">
-              <Input.Text
-                className="h-full"
-                isReadOnly={isReadOnly}
-                value={value ?? ''}
-                onValueChange={(value): void =>
-                  handleChanged(
-                    {
-                      value: value.length === 0 ? undefined : value,
-                      fields,
-                    },
-                    index
-                  )
-                }
-              />
-            </div>
-            <span className="-ml-2" />
-            {trimmedFieldsLength > 0 && isExpanded && !isReadOnly ? (
-              <Button.Danger onClick={handleDelete}>
-                {resourcesText.deleteDefinition()}
-              </Button.Danger>
-            ) : null}
-            {hasCondition && isExpanded ? (
-              <Button.Icon
-                icon="chevronUp"
-                title={resourcesText.collapseConditionalField()}
-                onClick={handleToggle}
-              />
-            ) : null}
-          </div>
-          {isExpanded ? (
-            <span>
-              {index === 0
-                ? resourcesText.elseConditionDescription()
-                : resourcesText.conditionDescription()}
+        <div className={`${isExpanded ? '' : 'gap-2 p-2'} flex flex-col`}>
+          {!isExpanded && index === 0 ? (
+            <span className="font-bold">
+              {resourcesText.conditionalFieldValue()}
             </span>
           ) : null}
-        </Label.Block>
+          <Label.Block>
+            {isExpanded ? resourcesText.conditionFieldValue() : null}
+            <div className="flex items-center gap-2 pr-2">
+              <div className="h-full flex-1">
+                <Input.Text
+                  className="h-full"
+                  isReadOnly={isReadOnly}
+                  value={value ?? ''}
+                  onValueChange={(value): void =>
+                    handleChanged(
+                      {
+                        value: value.length === 0 ? undefined : value,
+                        fields,
+                      },
+                      index
+                    )
+                  }
+                />
+              </div>
+              <span className="-ml-2" />
+              {trimmedFieldsLength > 0 && isExpanded && !isReadOnly ? (
+                <Button.Danger onClick={handleDelete}>
+                  {resourcesText.deleteDefinition()}
+                </Button.Danger>
+              ) : null}
+              {hasCondition && isExpanded ? (
+                <Button.Icon
+                  icon="chevronUp"
+                  title={resourcesText.collapseConditionalField()}
+                  onClick={handleToggle}
+                />
+              ) : null}
+            </div>
+            {isExpanded ? (
+              <span>
+                {index === 0
+                  ? resourcesText.elseConditionDescription()
+                  : resourcesText.conditionDescription()}
+              </span>
+            ) : null}
+          </Label.Block>
+        </div>
       )}
       {expandedNoCondition || isReadOnly ? null : fields.length === 0 ? (
         <Button.Small
@@ -197,7 +205,10 @@ function ConditionalFormatter({
           {resourcesText.addField()}
         </Button.Small>
       ) : (
-        <div className="flex flex-wrap whitespace-pre-wrap p-2">
+        <div className="flex flex-col flex-wrap whitespace-pre-wrap p-2">
+          {index === 0 && (
+            <span className="font-bold">{resourcesText.formatPreview()}</span>
+          )}
           {fields
             .map(
               (field) =>
@@ -218,23 +229,30 @@ function ConditionalFormatter({
         />
       ) : null}
       <span className="-ml-2 flex-1" />
-      {trimmedFieldsLength === 1 || isExpanded || isReadOnly ? null : (
-        <div className="inline-flex">
-          <Button.Icon
-            icon="trash"
-            title={resourcesText.deleteDefinition()}
-            onClick={handleDelete}
-          />
-        </div>
-      )}
-      <div className="flex">
-        {hasCondition && !isExpanded ? (
-          <Button.Icon
-            icon="chevronDown"
-            title={resourcesText.expandConditionalField()}
-            onClick={handleToggle}
-          />
+      <div className="flex flex-col p-2">
+        {!isExpanded && index === 0 ? (
+          <span className="font-bold">{commonText.expand()}</span>
         ) : null}
+        <div className="flex justify-end">
+          {trimmedFieldsLength === 1 || isExpanded || isReadOnly ? null : (
+            <div className="inline-flex">
+              <Button.Icon
+                icon="trash"
+                title={resourcesText.deleteDefinition()}
+                onClick={handleDelete}
+              />
+            </div>
+          )}
+          <div className="flex p-2">
+            {hasCondition && !isExpanded ? (
+              <Button.Icon
+                icon="chevronDown"
+                title={resourcesText.expandConditionalField()}
+                onClick={handleToggle}
+              />
+            ) : null}
+          </div>
+        </div>
       </div>
     </div>
   );

--- a/specifyweb/frontend/js_src/lib/components/Formatters/Definitions.tsx
+++ b/specifyweb/frontend/js_src/lib/components/Formatters/Definitions.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import type { LocalizedString } from 'typesafe-i18n';
 
 import { useBooleanState } from '../../hooks/useBooleanState';
+import { commonText } from '../../localization/common';
 import { resourcesText } from '../../localization/resources';
 import type { GetSet } from '../../utils/types';
 import { localized } from '../../utils/types';
@@ -12,7 +13,6 @@ import { ReadOnlyContext } from '../Core/Contexts';
 import type { SpecifyTable } from '../DataModel/specifyTable';
 import { Fields } from './Fields';
 import type { Formatter } from './spec';
-import { commonText } from '../../localization/common';
 
 export function Definitions({
   item: [formatter, setFormatter],

--- a/specifyweb/frontend/js_src/lib/components/WorkBench/DevShowPlan.tsx
+++ b/specifyweb/frontend/js_src/lib/components/WorkBench/DevShowPlan.tsx
@@ -8,8 +8,8 @@ import { Button } from '../Atoms/Button';
 import { LoadingContext } from '../Core/Contexts';
 import { AutoGrowTextArea } from '../Molecules/AutoGrowTextArea';
 import { Dialog } from '../Molecules/Dialog';
-import type { UploadPlan } from '../WbPlanView/uploadPlanParser';
 import { downloadFile } from '../Molecules/FilePicker';
+import type { UploadPlan } from '../WbPlanView/uploadPlanParser';
 
 /**
  * Show upload plan as JSON. Available in Development only

--- a/specifyweb/frontend/js_src/lib/localization/resources.ts
+++ b/specifyweb/frontend/js_src/lib/localization/resources.ts
@@ -781,4 +781,10 @@ export const resourcesText = createDictionary({
     'ru-ru': 'Свернуть условное поле',
     'uk-ua': 'Згорнути умовне поле',
   },
+  conditionalFieldValue: {
+    'en-us': 'Conditional Field Value',
+  },
+  formatPreview: {
+    'en-us': 'Format Preview',
+  },
 } as const);


### PR DESCRIPTION
Fixes #4627

### Checklist

- [x] Self-review the PR after opening it to make sure the changes look good
      and self-explanatory (or properly documented)
- [x] Add relevant issue to release milestone

### Testing instructions

- go in app resources 
- choose records formatters 
- choose a table that has formatters

- [ ] verify that there is 3 headers when the conditional is collapsed 
- [ ] verify that the headers are removed when expanding 
