### PR TITLE
Uniquely identify saveBlockers with keys

### DIFF
--- a/specifyweb/frontend/js_src/lib/components/AppResources/EditorComponents.tsx
+++ b/specifyweb/frontend/js_src/lib/components/AppResources/EditorComponents.tsx
@@ -23,7 +23,7 @@ import { LoadingContext } from '../Core/Contexts';
 import { getField } from '../DataModel/helpers';
 import type { SerializedResource } from '../DataModel/helperTypes';
 import type { SpecifyResource } from '../DataModel/legacyTypes';
-import { useSaveBlockers } from '../DataModel/saveBlockers';
+import { getFieldBlockerKey, useSaveBlockers } from '../DataModel/saveBlockers';
 import type { SpAppResource, SpViewSetObj } from '../DataModel/types';
 import { DeleteButton } from '../Forms/DeleteButton';
 import { Dialog } from '../Molecules/Dialog';
@@ -213,14 +213,13 @@ export function useCodeMirrorExtensions(
     () => getAppResourceExtension(resource),
     [resource]
   );
-  const [extensions, setExtensions] = React.useState<RA<Extension>>([]);
-  const [_blockers, setBlockers] = useSaveBlockers(
-    appResource,
-    React.useMemo(
-      () => getField(appResource.specifyTable, 'spAppResourceDatas'),
-      [appResource.specifyTable]
-    )
+  const field = React.useMemo(
+    () => getField(appResource.specifyTable, 'spAppResourceDatas'),
+    [appResource.specifyTable]
   );
+
+  const [extensions, setExtensions] = React.useState<RA<Extension>>([]);
+  const [_blockers, setBlockers] = useSaveBlockers(appResource, field);
 
   React.useEffect(() => {
     let isFirstLint = true;
@@ -234,7 +233,8 @@ export function useCodeMirrorExtensions(
           results.map(({ message, severity }) =>
             severity === 'error' ? message : undefined
           )
-        )
+        ),
+        getFieldBlockerKey(field, 'appResourceError')
       );
     }
 
@@ -255,7 +255,8 @@ export function useCodeMirrorExtensions(
       search(),
     ]);
 
-    return (): void => setBlockers([]);
+    return (): void =>
+      setBlockers([], getFieldBlockerKey(field, 'appResourceError'));
   }, [
     appResource,
     mode,

--- a/specifyweb/frontend/js_src/lib/components/DataModel/saveBlockers.tsx
+++ b/specifyweb/frontend/js_src/lib/components/DataModel/saveBlockers.tsx
@@ -7,7 +7,7 @@ import React from 'react';
 
 import { eventListener } from '../../utils/events';
 import { f } from '../../utils/functools';
-import type { GetOrSet, GetSet, IR, RA } from '../../utils/types';
+import type { GetOrSet, RA } from '../../utils/types';
 import { filterArray } from '../../utils/types';
 import { removeItem } from '../../utils/utils';
 import { softError } from '../Errors/assert';
@@ -21,14 +21,6 @@ import type { Collection } from './specifyTable';
 const saveBlockers = new WeakMap<
   SpecifyResource<AnySchema>,
   ResourceBlockers
->();
-
-type FieldValue = number | string | string | null | undefined;
-type FieldsWithValue = IR<FieldValue>;
-
-const previouslySetBlockers = new WeakMap<
-  SpecifyResource<AnySchema>,
-  FieldsWithValue
 >();
 
 type ResourceBlockers = {
@@ -46,6 +38,7 @@ const blockerEvents = eventListener<{
 }>();
 
 type Blocker = {
+  readonly key: string;
   readonly field: LiteralField | Relationship;
   readonly message: string;
 };
@@ -54,6 +47,11 @@ export type BlockerWithResource = {
   readonly resources: RA<SpecifyResource<AnySchema>>;
   readonly message: string;
 };
+
+export const getFieldBlockerKey = (
+  field: LiteralField | Relationship,
+  blockerKey: string
+): string => `${blockerKey}-${field.name}`;
 
 export const propagateBlockerEvents = (
   resource: SpecifyResource<AnySchema>
@@ -69,7 +67,7 @@ export const propagateBlockerEvents = (
 export function useSaveBlockers(
   resource: SpecifyResource<AnySchema> | undefined,
   field: LiteralField | Relationship | undefined
-): GetOrSet<RA<string>> {
+): readonly [RA<string>, (value: RA<string>, blockerKey: string) => void] {
   const [blockers, setBlockers] = React.useState<RA<string>>([]);
 
   React.useEffect(
@@ -93,7 +91,7 @@ export function useSaveBlockers(
   return [
     blockers,
     React.useCallback(
-      (errors) => {
+      (errors, blockerKey) => {
         if (resource === undefined || field === undefined) {
           softFail(
             new Error('Unable to set blockers on undefined resource or field'),
@@ -103,7 +101,7 @@ export function useSaveBlockers(
               field,
             }
           );
-        } else setSaveBlockers(resource, field, errors);
+        } else setSaveBlockers(resource, field, errors, blockerKey);
       },
       [resource, field]
     ),
@@ -113,41 +111,25 @@ export function useSaveBlockers(
 export function setSaveBlockers(
   resource: SpecifyResource<AnySchema>,
   field: LiteralField | Relationship,
-  errors: Parameters<GetOrSet<RA<string>>[1]>[0]
+  errors: Parameters<GetOrSet<RA<string>>[1]>[0],
+  blockerKey: string
 ): void {
   const resolvedErrors =
     typeof errors === 'function'
-      ? errors(getFieldBlockers(resource, field))
+      ? errors(getFieldBlockers(resource, field, blockerKey))
       : errors;
-  const blockers = f.unique(resolvedErrors).map((error) => ({
+  const blockers: RA<Blocker> = f.unique(resolvedErrors).map((error) => ({
     field,
     message: error,
+    key: blockerKey,
   }));
   const resourceBlockers = getResourceBlockers(resource)!;
   const newBlockers = [
-    ...resourceBlockers.blockers.filter((blocker) => blocker.field !== field),
+    ...resourceBlockers.blockers.filter(
+      (blocker) => blocker.key !== blockerKey
+    ),
     ...blockers,
   ];
-
-  const fieldValue = resource.get(field.name);
-  const [previouslySet, setPreviouslySetBlocker] = getSetPreviouslySetBlocker(
-    resource,
-    field
-  );
-
-  /**
-   * If a consumer of this function attempts to reset the saveBlockers but the
-   * current value of the field matches the field value which was previously
-   * set, then the case should be ignored to not override any existing blockers
-   */
-  const skipResettingBlockers =
-    newBlockers.length === 0 &&
-    fieldValue === previouslySet &&
-    (!field.isRelationship ||
-      (field.isRelationship && field.type.endsWith('to-one')));
-
-  if (skipResettingBlockers) return;
-  setPreviouslySetBlocker(fieldValue);
 
   saveBlockers.set(resource, {
     ...resourceBlockers,
@@ -158,34 +140,17 @@ export function setSaveBlockers(
 
 export function getFieldBlockers(
   resource: SpecifyResource<AnySchema>,
-  field: LiteralField | Relationship
+  field: LiteralField | Relationship,
+  blockerKey?: string
 ): RA<string> {
   const blockers = getResourceBlockers(resource).blockers;
   return blockers
-    .filter((blocker) => blocker.field === field)
+    .filter((blocker) =>
+      blockerKey === undefined
+        ? blocker.field === field
+        : blocker.field === field && blocker.key === blockerKey
+    )
     .map(({ message }) => message);
-}
-
-function getSetPreviouslySetBlocker(
-  resource: SpecifyResource<AnySchema>,
-  field: LiteralField | Relationship
-): GetSet<FieldValue> {
-  const fieldAndValue = {
-    [field.name]: resource.get(field.name),
-  };
-  if (!previouslySetBlockers.has(resource))
-    previouslySetBlockers.set(resource, fieldAndValue);
-
-  function setPreviouslySetBlocker(value: FieldValue): void {
-    previouslySetBlockers.set(resource, {
-      ...previouslySetBlockers.get(resource),
-      [field.name]: value,
-    });
-  }
-  return [
-    previouslySetBlockers.get(resource)![field.name],
-    setPreviouslySetBlocker,
-  ];
 }
 
 function getResourceBlockers(

--- a/specifyweb/frontend/js_src/lib/hooks/useResourceValue.tsx
+++ b/specifyweb/frontend/js_src/lib/hooks/useResourceValue.tsx
@@ -4,7 +4,10 @@ import { className } from '../components/Atoms/className';
 import type { AnySchema } from '../components/DataModel/helperTypes';
 import type { SpecifyResource } from '../components/DataModel/legacyTypes';
 import { resourceOn } from '../components/DataModel/resource';
-import { useSaveBlockers } from '../components/DataModel/saveBlockers';
+import {
+  getFieldBlockerKey,
+  useSaveBlockers,
+} from '../components/DataModel/saveBlockers';
 import type {
   LiteralField,
   Relationship,
@@ -132,8 +135,13 @@ export function useResourceValue<
       );
       if (field === undefined) return;
 
-      if (parseResults.isValid) setBlockers([]);
-      else setBlockers([parseResults.reason]);
+      if (parseResults.isValid)
+        setBlockers([], getFieldBlockerKey(field, 'parseResult'));
+      else
+        setBlockers(
+          [parseResults.reason],
+          getFieldBlockerKey(field, 'parseResult')
+        );
 
       ignoreChangeRef.current = true;
       /*


### PR DESCRIPTION
Fixes #4638 

See https://github.com/specify/specify7/issues/4638#issuecomment-1991752196

### Checklist

- [x] Self-review the PR after opening it to make sure the changes look good
      and self-explanatory (or properly documented)
- [ ] Add automated tests
- [x] Add relevant issue to release milestone

### Testing instructions

For any table: 
- [ ] Create or find a uniqueness with 1 or more uniqueness fields
- [ ] For the same table, create a uniqueness rule with at least two fields (with at least one field differing from the previous rule) with the same scope as the previous rule
- [ ] On the DataEntry form for the table, invalidate both rules
- [ ] Change the field value for a rule so that one uniqueness rule becomes valid while the other remains invalid
- [ ] Ensure the saveBlocker for the invalid rule (and any other saveBlockers on the form) is still set

For an example, see https://github.com/specify/specify7/issues/4638#issuecomment-1991752196