### PR TITLE
Hide header title and trash icon when no table

### DIFF
--- a/specifyweb/frontend/js_src/lib/components/Formatters/Definitions.tsx
+++ b/specifyweb/frontend/js_src/lib/components/Formatters/Definitions.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import type { LocalizedString } from 'typesafe-i18n';
 
 import { useBooleanState } from '../../hooks/useBooleanState';
-import { commonText } from '../../localization/common';
 import { resourcesText } from '../../localization/resources';
 import type { GetSet } from '../../utils/types';
 import { localized } from '../../utils/types';
@@ -13,6 +12,7 @@ import { ReadOnlyContext } from '../Core/Contexts';
 import type { SpecifyTable } from '../DataModel/specifyTable';
 import { Fields } from './Fields';
 import type { Formatter } from './spec';
+import { commonText } from '../../localization/common';
 
 export function Definitions({
   item: [formatter, setFormatter],
@@ -129,7 +129,11 @@ function ConditionalFormatter({
         ${isExpanded || !hasCondition ? 'flex-col' : ''}
         ${isExpanded ? 'gap-2' : ''}
         ${
-          fields.length === 0 && hasCondition && trimmedFieldsLength > 0
+          fields.length === 0 &&
+          hasCondition &&
+          trimmedFieldsLength > 0 &&
+          !isExpanded &&
+          index !== 0
             ? 'items-center'
             : ''
         }
@@ -187,28 +191,31 @@ function ConditionalFormatter({
         </div>
       )}
       {expandedNoCondition || isReadOnly ? null : fields.length === 0 ? (
-        <Button.Small
-          onClick={(): void => {
-            handleToggle();
-            handleChanged(
-              {
-                value,
-                fields: [
-                  {
-                    separator: localized(' '),
-                    aggregator: undefined,
-                    formatter: undefined,
-                    fieldFormatter: undefined,
-                    field: undefined,
-                  },
-                ],
-              },
-              index
-            );
-          }}
-        >
-          {resourcesText.addField()}
-        </Button.Small>
+        <div className="flex flex-col p-2">
+          <span className="flex-1" />
+          <Button.Small
+            onClick={(): void => {
+              handleToggle();
+              handleChanged(
+                {
+                  value,
+                  fields: [
+                    {
+                      separator: localized(' '),
+                      aggregator: undefined,
+                      formatter: undefined,
+                      fieldFormatter: undefined,
+                      field: undefined,
+                    },
+                  ],
+                },
+                index
+              );
+            }}
+          >
+            {resourcesText.addField()}
+          </Button.Small>
+        </div>
       ) : (
         <div className="flex flex-col flex-wrap whitespace-pre-wrap p-2">
           {index === 0 && (
@@ -234,11 +241,11 @@ function ConditionalFormatter({
         />
       ) : null}
       <span className="-ml-2 flex-1" />
-      <div className="flex flex-col p-2">
+      <div className="flex flex-col">
         {!isExpanded && hasCondition && index === 0 ? (
           <span className="font-bold">{commonText.expand()}</span>
         ) : null}
-        <div className="flex justify-end">
+        <div className="flex">
           {trimmedFieldsLength === 1 ||
           isExpanded ||
           isReadOnly ||

--- a/specifyweb/frontend/js_src/lib/components/Formatters/Definitions.tsx
+++ b/specifyweb/frontend/js_src/lib/components/Formatters/Definitions.tsx
@@ -128,6 +128,11 @@ function ConditionalFormatter({
       className={`flex
         ${isExpanded || !hasCondition ? 'flex-col' : ''}
         ${isExpanded ? 'gap-2' : ''}
+        ${
+          fields.length === 0 && hasCondition && trimmedFieldsLength > 0
+            ? 'items-center'
+            : ''
+        }
       `}
       key={index}
     >
@@ -237,7 +242,7 @@ function ConditionalFormatter({
           {trimmedFieldsLength === 1 ||
           isExpanded ||
           isReadOnly ||
-          !hasCondition ? null : (
+          fields.length === 0 ? null : (
             <div className="inline-flex">
               <Button.Icon
                 icon="trash"

--- a/specifyweb/frontend/js_src/lib/components/Formatters/Definitions.tsx
+++ b/specifyweb/frontend/js_src/lib/components/Formatters/Definitions.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import type { LocalizedString } from 'typesafe-i18n';
 
 import { useBooleanState } from '../../hooks/useBooleanState';
+import { commonText } from '../../localization/common';
 import { resourcesText } from '../../localization/resources';
 import type { GetSet } from '../../utils/types';
 import { localized } from '../../utils/types';
@@ -12,7 +13,6 @@ import { ReadOnlyContext } from '../Core/Contexts';
 import type { SpecifyTable } from '../DataModel/specifyTable';
 import { Fields } from './Fields';
 import type { Formatter } from './spec';
-import { commonText } from '../../localization/common';
 
 export function Definitions({
   item: [formatter, setFormatter],

--- a/specifyweb/frontend/js_src/lib/components/Formatters/Definitions.tsx
+++ b/specifyweb/frontend/js_src/lib/components/Formatters/Definitions.tsx
@@ -230,11 +230,14 @@ function ConditionalFormatter({
       ) : null}
       <span className="-ml-2 flex-1" />
       <div className="flex flex-col p-2">
-        {!isExpanded && index === 0 ? (
+        {!isExpanded && hasCondition && index === 0 ? (
           <span className="font-bold">{commonText.expand()}</span>
         ) : null}
         <div className="flex justify-end">
-          {trimmedFieldsLength === 1 || isExpanded || isReadOnly ? null : (
+          {trimmedFieldsLength === 1 ||
+          isExpanded ||
+          isReadOnly ||
+          !hasCondition ? null : (
             <div className="inline-flex">
               <Button.Icon
                 icon="trash"


### PR DESCRIPTION
Fixes #4647

### Checklist

- [x] Self-review the PR after opening it to make sure the changes look good
      and self-explanatory (or properly documented)
- [x] Add relevant issue to release milestone

### Testing instructions

- go in app resources
- choose record formatter 

- [ ] verify that the titles and trash icon are correct when condition 
- [ ] verify that the titles and trash icon are correct when no condition 
- [ ] verify that the titles and trash icon are correct when condition and no expansion 
- [ ] verify that the titles and trash icon are correct when condition and expansion 
- [ ] verify that there is no titles and no trash icon when creating a new formatter before clicking for the first time the add button 
