### PR TITLE
Improve setting of default Tree Ranks

### DIFF
--- a/specifyweb/frontend/js_src/lib/components/PickLists/TreeLevelPickList.tsx
+++ b/specifyweb/frontend/js_src/lib/components/PickLists/TreeLevelPickList.tsx
@@ -99,10 +99,16 @@ export function TreeLevelComboBox(props: DefaultComboBoxProps): JSX.Element {
           )
           .then((items) => {
             if (destructorCalled) return undefined;
-            resource.set(
-              'definitionItem',
-              props.defaultValue ?? (items?.slice(-1)[0]?.value || '')
-            );
+            const definitionItem = resource.get('definitionItem');
+            if (
+              definitionItem === undefined ||
+              (items !== undefined &&
+                !items.map(({ value }) => value).includes(definitionItem))
+            )
+              resource.set(
+                'definitionItem',
+                props.defaultValue ?? (items?.slice(-1)[0]?.value || '')
+              );
             return void setItems(items);
           }),
       true

--- a/specifyweb/frontend/js_src/lib/components/PickLists/TreeLevelPickList.tsx
+++ b/specifyweb/frontend/js_src/lib/components/PickLists/TreeLevelPickList.tsx
@@ -99,16 +99,6 @@ export function TreeLevelComboBox(props: DefaultComboBoxProps): JSX.Element {
           )
           .then((items) => {
             if (destructorCalled) return undefined;
-            const definitionItem = resource.get('definitionItem');
-            if (
-              definitionItem === undefined ||
-              (items !== undefined &&
-                !items.map(({ value }) => value).includes(definitionItem))
-            )
-              resource.set(
-                'definitionItem',
-                props.defaultValue ?? (items?.slice(-1)[0]?.value || '')
-              );
             return void setItems(items);
           }),
       true


### PR DESCRIPTION
Fixes #4598 

For example the trees (specifically treedefitems) in the Taxon tree of Ichthyology discipline of `KUFish` are defined as the following:

<img width="859" alt="Screenshot 2024-03-14 at 10 33 38 PM" src="https://github.com/specify/specify7/assets/64045831/85a8347d-e703-404e-bda3-bdf560b7c75f">

A node at the `Family` level can have children of ranks of `Subfamily` or `Genus`. 
However, since `Genus` is enforced, this means that there _must_ be a rank at the `Genus` level in order to have taxon records at ranks lower than `Genus`.

In the example provided in https://github.com/specify/specify7/issues/4598#issuecomment-1998694168 (i.e., in KUFish), there are three possible ranks which children of `Genus` nodes can take: `Subgenus`, `Species`, `Subspecies`.

 The logic currently in `production` is to set the tree rank to be the lowest possible rank for a given parent. 
(In `KUFish`, the lowest possible rank for children of Genus nodes is Subspecies). 

This logic was not accounting for cases in which the record already had a rank. 

Now, the rank of a tree node is only set to the lowest possible rank given 
1. The value of the `definitionItem` field is undefined
OR
2. The value of the rank does not match that of the possible ranks for the tree record 

@specify/ux-testing 
There is a consideration in which the setting of the rank for a tree node may currently be an inconvenience. 
Is it more logical to consider populating the rank of a tree node to be the _highest_ possible rank rather than the lowest? 
For example, in `KUFish` currently when the `Add Child` button is pressed on a Genus Taxon record, the rank populated into the tree rank picklist will be Subspecies. Would it instead make more sense for this to be Subgenus? 

### Checklist

- [x] Self-review the PR after opening it to make sure the changes look good
      and self-explanatory (or properly documented)
- [x] Add relevant issue to release milestone

### Testing instructions

For any Tree (Taxon, Geography, Storage, Chronostrat, Lithostrat) 
- [ ] In the TreeViewer, ensure the correct rank populates into the rank picklist when editing/viewing a tree record
- [ ] When using the `Add Child` functionality, ensure the rank picklist remains blank but has the correct options available for ranks
