### PR TITLE
Add class name to display date precision

### DIFF
--- a/specifyweb/frontend/js_src/lib/components/FormPlugins/DateInput.tsx
+++ b/specifyweb/frontend/js_src/lib/components/FormPlugins/DateInput.tsx
@@ -88,7 +88,7 @@ export function DateInput({
   return (
     <>
       <Input.Generic
-        className="w-[unset] grow"
+        className="!w-[unset] grow"
         forwardRef={validationRef}
         id={id}
         isReadOnly={isReadOnly}

--- a/specifyweb/frontend/js_src/lib/components/FormPlugins/DateInput.tsx
+++ b/specifyweb/frontend/js_src/lib/components/FormPlugins/DateInput.tsx
@@ -88,11 +88,6 @@ export function DateInput({
   return (
     <>
       <Input.Generic
-        className={
-          precision === 'full' && dateType === 'text'
-            ? '!w-full'
-            : '!w-[unset] grow'
-        }
         forwardRef={validationRef}
         id={id}
         isReadOnly={isReadOnly}
@@ -144,6 +139,7 @@ export function DateInput({
           (precision === 'month-year' && !monthSupported)) ? (
           <Button.Icon
             aria-label={formsText.today()}
+            className="print:hidden"
             icon="calendar"
             title={formsText.todayButtonDescription()}
             onClick={(): void => setMoment(dayjs())}

--- a/specifyweb/frontend/js_src/lib/components/FormPlugins/DateInput.tsx
+++ b/specifyweb/frontend/js_src/lib/components/FormPlugins/DateInput.tsx
@@ -89,7 +89,9 @@ export function DateInput({
     <>
       <Input.Generic
         className={
-          precision === 'full' && dateType === 'text' ? '!w-full' : 'grow'
+          precision === 'full' && dateType === 'text'
+            ? '!w-full'
+            : '!w-[unset] grow'
         }
         forwardRef={validationRef}
         id={id}

--- a/specifyweb/frontend/js_src/lib/components/FormPlugins/DateInput.tsx
+++ b/specifyweb/frontend/js_src/lib/components/FormPlugins/DateInput.tsx
@@ -88,7 +88,7 @@ export function DateInput({
   return (
     <>
       <Input.Generic
-        className="grow"
+        className="w-[unset] grow"
         forwardRef={validationRef}
         id={id}
         isReadOnly={isReadOnly}

--- a/specifyweb/frontend/js_src/lib/components/FormPlugins/DateInput.tsx
+++ b/specifyweb/frontend/js_src/lib/components/FormPlugins/DateInput.tsx
@@ -88,7 +88,9 @@ export function DateInput({
   return (
     <>
       <Input.Generic
-        className="!w-[unset] grow"
+        className={
+          precision === 'full' && dateType === 'text' ? '!w-full' : 'grow'
+        }
         forwardRef={validationRef}
         id={id}
         isReadOnly={isReadOnly}

--- a/specifyweb/frontend/js_src/lib/components/FormPlugins/DateInput.tsx
+++ b/specifyweb/frontend/js_src/lib/components/FormPlugins/DateInput.tsx
@@ -88,7 +88,7 @@ export function DateInput({
   return (
     <>
       <Input.Generic
-        className="!w-[unset] grow"
+        className="grow"
         forwardRef={validationRef}
         id={id}
         isReadOnly={isReadOnly}

--- a/specifyweb/frontend/js_src/lib/components/FormPlugins/DatePrecisionPicker.tsx
+++ b/specifyweb/frontend/js_src/lib/components/FormPlugins/DatePrecisionPicker.tsx
@@ -27,7 +27,7 @@ export function DatePrecisionPicker({
     <label className="shrink-[3]">
       <span className="sr-only">{formsText.datePrecision()}</span>
       <Select
-        className="!w-auto print:hidden"
+        className="!w-auto !min-w-[unset] print:hidden "
         disabled={isReadOnly}
         forwardRef={precisionValidationRef}
         value={precision}

--- a/specifyweb/frontend/js_src/lib/components/FormPlugins/DatePrecisionPicker.tsx
+++ b/specifyweb/frontend/js_src/lib/components/FormPlugins/DatePrecisionPicker.tsx
@@ -24,10 +24,9 @@ export function DatePrecisionPicker({
 }): JSX.Element {
   const isReadOnly = React.useContext(ReadOnlyContext);
   return (
-    <label className="shrink-[3]">
+    <label className="print:hidden">
       <span className="sr-only">{formsText.datePrecision()}</span>
       <Select
-        className="!w-auto !min-w-[unset] print:hidden "
         disabled={isReadOnly}
         forwardRef={precisionValidationRef}
         value={precision}

--- a/specifyweb/frontend/js_src/lib/components/FormPlugins/DatePrecisionPicker.tsx
+++ b/specifyweb/frontend/js_src/lib/components/FormPlugins/DatePrecisionPicker.tsx
@@ -27,7 +27,7 @@ export function DatePrecisionPicker({
     <label className="shrink-[3]">
       <span className="sr-only">{formsText.datePrecision()}</span>
       <Select
-        className="!w-auto !min-w-[unset] print:hidden"
+        className="!w-auto print:hidden"
         disabled={isReadOnly}
         forwardRef={precisionValidationRef}
         value={precision}

--- a/specifyweb/frontend/js_src/lib/components/FormPlugins/DatePrecisionPicker.tsx
+++ b/specifyweb/frontend/js_src/lib/components/FormPlugins/DatePrecisionPicker.tsx
@@ -27,7 +27,7 @@ export function DatePrecisionPicker({
     <label className="shrink-[3]">
       <span className="sr-only">{formsText.datePrecision()}</span>
       <Select
-        className="!min-w-[unset] print:hidden"
+        className="!w-auto !min-w-[unset] print:hidden"
         disabled={isReadOnly}
         forwardRef={precisionValidationRef}
         value={precision}

--- a/specifyweb/frontend/js_src/lib/components/FormPlugins/PartialDateUi.tsx
+++ b/specifyweb/frontend/js_src/lib/components/FormPlugins/PartialDateUi.tsx
@@ -49,18 +49,20 @@ export function PartialDateUi({
     React.useContext(ReadOnlyContext) || resource === undefined;
 
   return (
-    <div className="flex w-full gap-1">
+    <div className="grid w-full grid-cols-[fit-content(40%)_1fr] gap-1">
       {!isReadOnly && canChangePrecision ? (
         <DatePrecisionPicker moment={moment} {...precisionProps} />
       ) : undefined}
       <ReadOnlyContext.Provider value={isReadOnly || resource === undefined}>
-        <DateInput
-          id={id}
-          isRequired={isRequired}
-          moment={moment}
-          parser={parser}
-          precision={precision}
-        />
+        <div className="flex">
+          <DateInput
+            id={id}
+            isRequired={isRequired}
+            moment={moment}
+            parser={parser}
+            precision={precision}
+          />
+        </div>
       </ReadOnlyContext.Provider>
     </div>
   );

--- a/specifyweb/frontend/js_src/lib/components/FormPlugins/__tests__/__snapshots__/PartialDateUi.test.tsx.snap
+++ b/specifyweb/frontend/js_src/lib/components/FormPlugins/__tests__/__snapshots__/PartialDateUi.test.tsx.snap
@@ -14,7 +14,7 @@ exports[`PartialDateUi renders without errors 1`] = `
         Date Precision
       </span>
       <select
-        class="not-touched w-full pr-5 bg-right cursor-pointer !min-w-[unset] print:hidden"
+        class="not-touched w-full pr-5 bg-right cursor-pointer !w-auto !min-w-[unset] print:hidden"
       >
         <option
           value="full"

--- a/specifyweb/frontend/js_src/lib/components/FormPlugins/__tests__/__snapshots__/PartialDateUi.test.tsx.snap
+++ b/specifyweb/frontend/js_src/lib/components/FormPlugins/__tests__/__snapshots__/PartialDateUi.test.tsx.snap
@@ -14,7 +14,7 @@ exports[`PartialDateUi renders without errors 1`] = `
         Date Precision
       </span>
       <select
-        class="not-touched w-full pr-5 bg-right cursor-pointer !w-auto print:hidden"
+        class="not-touched w-full pr-5 bg-right cursor-pointer !w-auto !min-w-[unset] print:hidden"
       >
         <option
           value="full"
@@ -34,7 +34,7 @@ exports[`PartialDateUi renders without errors 1`] = `
       </select>
     </label>
     <input
-      class="not-touched w-full !w-[unset] grow"
+      class="not-touched w-full grow"
       max="9999-12-31"
       placeholder="MM/DD/YYYY"
       type="date"
@@ -50,7 +50,7 @@ exports[`PartialDateUi renders without errors 2`] = `
     class="flex w-full gap-1"
   >
     <input
-      class="not-touched w-full !w-[unset] grow"
+      class="not-touched w-full grow"
       placeholder="MM/YYYY"
       type="month"
       value=""
@@ -65,7 +65,7 @@ exports[`PartialDateUi renders without errors 3`] = `
     class="flex w-full gap-1"
   >
     <input
-      class="not-touched w-full !w-[unset] grow"
+      class="not-touched w-full grow"
       max="9999"
       min="1"
       placeholder="YYYY"

--- a/specifyweb/frontend/js_src/lib/components/FormPlugins/__tests__/__snapshots__/PartialDateUi.test.tsx.snap
+++ b/specifyweb/frontend/js_src/lib/components/FormPlugins/__tests__/__snapshots__/PartialDateUi.test.tsx.snap
@@ -34,7 +34,7 @@ exports[`PartialDateUi renders without errors 1`] = `
       </select>
     </label>
     <input
-      class="not-touched w-full w-[unset] grow"
+      class="not-touched w-full !w-[unset] grow"
       max="9999-12-31"
       placeholder="MM/DD/YYYY"
       type="date"
@@ -50,7 +50,7 @@ exports[`PartialDateUi renders without errors 2`] = `
     class="flex w-full gap-1"
   >
     <input
-      class="not-touched w-full w-[unset] grow"
+      class="not-touched w-full !w-[unset] grow"
       placeholder="MM/YYYY"
       type="month"
       value=""
@@ -65,7 +65,7 @@ exports[`PartialDateUi renders without errors 3`] = `
     class="flex w-full gap-1"
   >
     <input
-      class="not-touched w-full w-[unset] grow"
+      class="not-touched w-full !w-[unset] grow"
       max="9999"
       min="1"
       placeholder="YYYY"

--- a/specifyweb/frontend/js_src/lib/components/FormPlugins/__tests__/__snapshots__/PartialDateUi.test.tsx.snap
+++ b/specifyweb/frontend/js_src/lib/components/FormPlugins/__tests__/__snapshots__/PartialDateUi.test.tsx.snap
@@ -3,10 +3,10 @@
 exports[`PartialDateUi renders without errors 1`] = `
 <DocumentFragment>
   <div
-    class="flex w-full gap-1"
+    class="grid w-full grid-cols-[fit-content(40%)_1fr] gap-1"
   >
     <label
-      class="shrink-[3]"
+      class="print:hidden"
     >
       <span
         class="sr-only"
@@ -14,7 +14,7 @@ exports[`PartialDateUi renders without errors 1`] = `
         Date Precision
       </span>
       <select
-        class="not-touched w-full pr-5 bg-right cursor-pointer !w-auto !min-w-[unset] print:hidden"
+        class="not-touched w-full pr-5 bg-right cursor-pointer"
       >
         <option
           value="full"
@@ -33,13 +33,17 @@ exports[`PartialDateUi renders without errors 1`] = `
         </option>
       </select>
     </label>
-    <input
-      class="not-touched w-full !w-[unset] grow"
-      max="9999-12-31"
-      placeholder="MM/DD/YYYY"
-      type="date"
-      value=""
-    />
+    <div
+      class="flex"
+    >
+      <input
+        class="not-touched w-full"
+        max="9999-12-31"
+        placeholder="MM/DD/YYYY"
+        type="date"
+        value=""
+      />
+    </div>
   </div>
 </DocumentFragment>
 `;
@@ -47,14 +51,18 @@ exports[`PartialDateUi renders without errors 1`] = `
 exports[`PartialDateUi renders without errors 2`] = `
 <DocumentFragment>
   <div
-    class="flex w-full gap-1"
+    class="grid w-full grid-cols-[fit-content(40%)_1fr] gap-1"
   >
-    <input
-      class="not-touched w-full !w-[unset] grow"
-      placeholder="MM/YYYY"
-      type="month"
-      value=""
-    />
+    <div
+      class="flex"
+    >
+      <input
+        class="not-touched w-full"
+        placeholder="MM/YYYY"
+        type="month"
+        value=""
+      />
+    </div>
   </div>
 </DocumentFragment>
 `;
@@ -62,17 +70,21 @@ exports[`PartialDateUi renders without errors 2`] = `
 exports[`PartialDateUi renders without errors 3`] = `
 <DocumentFragment>
   <div
-    class="flex w-full gap-1"
+    class="grid w-full grid-cols-[fit-content(40%)_1fr] gap-1"
   >
-    <input
-      class="not-touched w-full !w-[unset] grow"
-      max="9999"
-      min="1"
-      placeholder="YYYY"
-      step="1"
-      type="number"
-      value=""
-    />
+    <div
+      class="flex"
+    >
+      <input
+        class="not-touched w-full"
+        max="9999"
+        min="1"
+        placeholder="YYYY"
+        step="1"
+        type="number"
+        value=""
+      />
+    </div>
   </div>
 </DocumentFragment>
 `;

--- a/specifyweb/frontend/js_src/lib/components/FormPlugins/__tests__/__snapshots__/PartialDateUi.test.tsx.snap
+++ b/specifyweb/frontend/js_src/lib/components/FormPlugins/__tests__/__snapshots__/PartialDateUi.test.tsx.snap
@@ -34,7 +34,7 @@ exports[`PartialDateUi renders without errors 1`] = `
       </select>
     </label>
     <input
-      class="not-touched w-full grow"
+      class="not-touched w-full w-[unset] grow"
       max="9999-12-31"
       placeholder="MM/DD/YYYY"
       type="date"
@@ -50,7 +50,7 @@ exports[`PartialDateUi renders without errors 2`] = `
     class="flex w-full gap-1"
   >
     <input
-      class="not-touched w-full grow"
+      class="not-touched w-full w-[unset] grow"
       placeholder="MM/YYYY"
       type="month"
       value=""
@@ -65,7 +65,7 @@ exports[`PartialDateUi renders without errors 3`] = `
     class="flex w-full gap-1"
   >
     <input
-      class="not-touched w-full grow"
+      class="not-touched w-full w-[unset] grow"
       max="9999"
       min="1"
       placeholder="YYYY"

--- a/specifyweb/frontend/js_src/lib/components/FormPlugins/__tests__/__snapshots__/PartialDateUi.test.tsx.snap
+++ b/specifyweb/frontend/js_src/lib/components/FormPlugins/__tests__/__snapshots__/PartialDateUi.test.tsx.snap
@@ -14,7 +14,7 @@ exports[`PartialDateUi renders without errors 1`] = `
         Date Precision
       </span>
       <select
-        class="not-touched w-full pr-5 bg-right cursor-pointer !w-auto !min-w-[unset] print:hidden"
+        class="not-touched w-full pr-5 bg-right cursor-pointer !w-auto print:hidden"
       >
         <option
           value="full"


### PR DESCRIPTION
Fixes #4643
Fixes #4642 
### Checklist

- [x] Self-review the PR after opening it to make sure the changes look good
      and self-explanatory (or properly documented)
- [x] Add relevant issue to release milestone

### Testing instructions

- Go to Preferences -> Uncheck "Use accessible month picker" 
- Go to any form with a Date and the option for "Month / Year" 
- Select different type of date precision

- [ ] verify all date precisions are visible 

Notes: 
Class name lost in https://github.com/specify/specify7/pull/4276
