### PR TITLE
fix(FormEditor): allow for multiple form definitions

### DIFF
--- a/specifyweb/frontend/js_src/lib/components/FormEditor/__tests__/viewSpec.test.ts
+++ b/specifyweb/frontend/js_src/lib/components/FormEditor/__tests__/viewSpec.test.ts
@@ -89,32 +89,35 @@ test('Can edit form definition', () => {
     formDefinitionSpec(tables.Accession)
   );
   const parsed = serializer(simpleXmlNode);
+  const parsedRows = parsed.definitions[0];
   const updated = deserializer({
     ...parsed,
     columnDefinitions: [
       parsed.columnDefinitions[0],
       ...parsed.columnDefinitions,
     ],
-    rows: {
-      ...parsed.rows,
-      rows: [
-        parsed.rows.rows[0],
-        [
-          ...parsed.rows.rows[0],
-          {
-            ...parsed.rows.rows[0][1],
-            definition:
-              parsed.rows.rows[0][1].definition.type === 'Label'
-                ? {
-                    ...parsed.rows.rows[0][1].definition,
-                    label: localized('New Label'),
-                  }
-                : error('Expected a label cell at this position'),
-          },
+    definitions: [
+      {
+        ...parsedRows,
+        rows: [
+          parsedRows.rows[0],
+          [
+            ...parsedRows.rows[0],
+            {
+              ...parsedRows.rows[0][1],
+              definition:
+                parsedRows.rows[0][1].definition.type === 'Label'
+                  ? {
+                      ...parsedRows.rows[0][1].definition,
+                      label: localized('New Label'),
+                    }
+                  : error('Expected a label cell at this position'),
+            },
+          ],
+          ...parsedRows.rows,
         ],
-        ...parsed.rows.rows,
-      ],
-    },
+      },
+    ],
   });
   const updatedXml = formatXmlForTests(updateXml(updated));
   expect(updatedXml).toMatchSnapshot();

--- a/specifyweb/frontend/js_src/lib/components/FormEditor/viewSpec.ts
+++ b/specifyweb/frontend/js_src/lib/components/FormEditor/viewSpec.ts
@@ -35,15 +35,15 @@ export const formDefinitionSpec = (table: SpecifyTable | undefined) =>
       syncers.xmlChild('enableRules', 'optional'),
       syncers.maybe(syncers.object(legacyBusinessRulesSpec()))
     ),
-    rows: rows(table),
+    definitions: definitions(table),
   });
 
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
-const rows = (table: SpecifyTable | undefined) =>
+const definitions = (table: SpecifyTable | undefined) =>
   pipe(
-    syncers.xmlChild('rows'),
-    syncers.fallback<SimpleXmlNode>(createSimpleXmlNode),
-    syncers.object(rowsSpec(table))
+    syncers.xmlChildren('rows'),
+    syncers.fallback<RA<SimpleXmlNode>>(() => [createSimpleXmlNode()]),
+    syncers.map(syncers.object(rowsSpec(table)))
   );
 
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
@@ -502,7 +502,7 @@ const panelSpec = (
 const veryUnsafeRows = (
   table: SpecifyTable | undefined
 ): Syncer<SimpleXmlNode, SimpleXmlNode> =>
-  rows(table) as unknown as Syncer<SimpleXmlNode, SimpleXmlNode>;
+  definitions(table) as unknown as Syncer<SimpleXmlNode, SimpleXmlNode>;
 
 const commandTables = {
   generateLabelBtn: undefined,


### PR DESCRIPTION
Update viewSpec to say that multiple form definitions are allowed to support conditional form definitions.

Fixes #4661



### Checklist

- [x] Self-review the PR after opening it to make sure the changes look good
      and self-explanatory (or properly documented)
- [x] Add automated tests
- [x] Add relevant issue to release milestone

### Testing instructions

- [ ] Should be able to create conditional form definitions without errors in XML editor
- [ ] Conditional form definitions should work on forms (display correct conditional form)
- [ ] [Conditional forms documentation](https://github.com/specify/specify7/wiki/Form-System#conditional-rendering) is clear and understandable