### PR TITLE
Preserves aliased table

### DIFF
--- a/specifyweb/stored_queries/format.py
+++ b/specifyweb/stored_queries/format.py
@@ -119,6 +119,10 @@ class ObjectFormatter(object):
         formatter = fieldNodeAttrib.get('formatter', None)
         aggregator = fieldNodeAttrib.get('aggregator', None)
         next_table_name = formatter_field_spec.table.name
+
+        # preserve sql table alias
+        formatter_field_spec = formatter_field_spec._replace(root_sql_table=orm_table)
+
         if formatter_field_spec.is_relationship():
             if previous_tables is not None and next_table_name in [table_name for table_name, _ in previous_tables]:
                 return (query, literal(

--- a/specifyweb/stored_queries/format.py
+++ b/specifyweb/stored_queries/format.py
@@ -125,9 +125,8 @@ class ObjectFormatter(object):
 
         if formatter_field_spec.is_relationship():
             if previous_tables is not None and next_table_name in [table_name for table_name, _ in previous_tables]:
-                return (query, literal(
-                    _text(f"<Cycle Detected.>: {'->'.join([*[str(_) for _ in previous_tables], next_table_name])}")),
-                        formatter_field_spec)
+                return query, literal(_text('')), formatter_field_spec
+
             new_query, new_expr, _, __ = formatter_field_spec.add_spec_to_query(
                 query,
                 formatter,

--- a/specifyweb/stored_queries/tests.py
+++ b/specifyweb/stored_queries/tests.py
@@ -88,15 +88,6 @@ class SQLAlchemySetup(ApiTests):
 
 
 
-    def setUp(self):
-        print("""
-            #BUG: If a test which compares the final sql query is added, then it could randomly fail
-            #in multithreaded tests because of usage of .label(None) in aggregate() 
-            #function in stored_queries/format.py 
-              """)
-        super().setUp()
-
-
 class SQLAlchemySetupTest(SQLAlchemySetup):
 
     def test_collection_object_count(self):

--- a/specifyweb/stored_queries/tests.py
+++ b/specifyweb/stored_queries/tests.py
@@ -358,7 +358,9 @@ class FormatterAggregatorTests(SQLAlchemySetup):
           >
             <switch single="true">
               <fields>
+                <field>role</field>
                 <field>accession</field>
+                <field>accession.accessionnumber</field>
               </fields>
             </switch>
           </format>
@@ -379,11 +381,11 @@ class FormatterAggregatorTests(SQLAlchemySetup):
         """
         object_formatter = self.get_formatter(formatter_def)
         accession_1 = spmodels.Accession.objects.create(
-            accessionnumber='a',
+            accessionnumber='Some_number',
             division=self.division)
         accession_agent_1 = spmodels.Accessionagent.objects.create(
             agent=self.agent,
-            role='role',
+            role='roleA',
             accession=accession_1,
         )
         with FormatterAggregatorTests.test_session_context() as session:
@@ -396,7 +398,7 @@ class FormatterAggregatorTests(SQLAlchemySetup):
             query = query.query.add_column(expr)
             self.assertCountEqual(list(query),
                                   [(
-                                   "<Cycle Detected.>: ('Accession', 'formatting')->('AccessionAgent', 'aggregating')->('AccessionAgent', 'formatting')->Accession",)]
+                                   "roleASome_number",)]
                                   )
 
     def test_relationships_in_switch_fields(self):


### PR DESCRIPTION
Fixes #4687 

Backend does have logic for detecting and handling cyclical formatter and aggregator formatters. The actual problem was unrelated to that cycle.

The problem is that if you make a query like CollectionObject -> Accession -> (Accession formatted), and if Accession's formatter is aggregation of accession agents, then a subquery needs to be made. This subquery incorrectly didn't consider the outer accession (made from the join of CollectionObject -> Accession). So, the _entire_ accession table join accession agent was being used. 

Testing instructions: 
https://github.com/specify/specify7/issues/4687#issue-2206620927