### PR TITLE
Set tree rank for new tree records after very short delay

### DIFF
--- a/specifyweb/frontend/js_src/lib/components/PickLists/TreeLevelPickList.tsx
+++ b/specifyweb/frontend/js_src/lib/components/PickLists/TreeLevelPickList.tsx
@@ -120,9 +120,13 @@ export function TreeLevelComboBox(props: DefaultComboBoxProps): JSX.Element {
           .then((items) => {
             if (destructorCalled) return undefined;
             if (typeof resource.get('definitionItem') !== 'string')
-              resource.set(
-                'definitionItem',
-                props.defaultValue ?? items?.slice(-1)[0]?.value ?? ''
+              setTimeout(
+                () =>
+                  resource.set(
+                    'definitionItem',
+                    props.defaultValue ?? items?.slice(-1)[0]?.value ?? ''
+                  ),
+                1
               );
             return void setItems(items);
           }),


### PR DESCRIPTION
Fixes #4666

> With regards to the other issue mentioned, here is what I have found in the code.
> 
> The issue is not with the field value on the resource object. Which is being set from
> 
> https://github.com/specify/specify7/blob/967d0d28c342e8d9d365f878053f0b82c90ed7b2/specifyweb/frontend/js_src/lib/components/PickLists/TreeLevelPickList.tsx#L123-L125
> 
> The underlying issue is with regards to parseResults in the useResourceValue hook. In this case `parseResults` returns `{isValid: false, value: <treeDefItemUrl>, reason: ''}`
> 
> https://github.com/specify/specify7/blob/967d0d28c342e8d9d365f878053f0b82c90ed7b2/specifyweb/frontend/js_src/lib/hooks/useResourceValue.tsx#L116-L121
> 
> The problem is that the value is never being set on the HTML input element itself. Because of this, the [valueMissing](https://developer.mozilla.org/en-US/docs/Web/API/ValidityState/valueMissing) attribute on the input's validity element remains `true` and thus `hasNativeErrors` returns true.
> 
> https://github.com/specify/specify7/blob/967d0d28c342e8d9d365f878053f0b82c90ed7b2/specifyweb/frontend/js_src/lib/utils/parser/parse.ts#L41-L45

https://github.com/specify/specify7/issues/4666#issuecomment-2021058501

### Checklist

- [x] Self-review the PR after opening it to make sure the changes look good
      and self-explanatory (or properly documented)
- [x] Add relevant issue to release milestone

### Testing instructions

- [ ] On a new Tree Data Entry form, ensure the rank populates correctly into the Tree Rank picklist (both the correct rank and no saveBlockers are set) when a parent is added 
- [ ] When using the `Add Child` button in the Tree Viewer, ensure the rank populates correctly into the Tree Rank picklist (both the correct rank and no saveBlockers are set)

Additionally, make sure the functionality from #4665 is kept: 

For any Tree (Taxon, Geography, Storage, Chronostrat, Lithostrat) 
- [ ] In the TreeViewer, ensure the correct rank populates into the rank picklist when editing/viewing a tree record
- [ ] When using the `Add Child` functionality, ensure the rank picklist is not blank and has the correct options available for ranks
- [ ] The rank picklist for all trees should now be disbaled (readonly) when the tree record does not have a parent
- [ ] When viewing the root node for the tree, ensure the rank pisklist contains the correct rank 
