### PR TITLE
Disable check boxes when read only

### DIFF
--- a/specifyweb/frontend/js_src/lib/components/Atoms/Form.tsx
+++ b/specifyweb/frontend/js_src/lib/components/Atoms/Form.tsx
@@ -155,7 +155,6 @@ export const Input = {
         props.onChange?.(event);
       },
       readOnly: isReadOnly,
-      disabled: isReadOnly,
     })
   ),
   Text: wrap<

--- a/specifyweb/frontend/js_src/lib/components/Atoms/Form.tsx
+++ b/specifyweb/frontend/js_src/lib/components/Atoms/Form.tsx
@@ -155,6 +155,7 @@ export const Input = {
         props.onChange?.(event);
       },
       readOnly: isReadOnly,
+      disabled: isReadOnly,
     })
   ),
   Text: wrap<

--- a/specifyweb/frontend/js_src/lib/components/Atoms/Form.tsx
+++ b/specifyweb/frontend/js_src/lib/components/Atoms/Form.tsx
@@ -136,6 +136,7 @@ export const Input = {
     'input',
     {
       readonly onValueChange?: (isChecked: boolean) => void;
+      readonly onClick?: 'Use onValueChange instead';
       readonly readOnly?: 'Use isReadOnly instead';
       readonly isReadOnly?: boolean;
       readonly type?: 'If you need to specify type, use Input.Generic';

--- a/specifyweb/frontend/js_src/lib/components/Formatters/Element.tsx
+++ b/specifyweb/frontend/js_src/lib/components/Formatters/Element.tsx
@@ -142,7 +142,7 @@ export function FormatterWrapper(): JSX.Element {
             <Input.Checkbox
               checked={getSet[0].isDefault}
               isReadOnly={isReadOnly}
-              onClick={(): void =>
+              onChange={(): void =>
                 setItems(
                   // Ensure there is only one default
                   items.map((otherItem, itemIndex) =>

--- a/specifyweb/frontend/js_src/lib/components/Formatters/Fields.tsx
+++ b/specifyweb/frontend/js_src/lib/components/Formatters/Fields.tsx
@@ -122,7 +122,9 @@ export function Fields({
             <Label.Inline>
               <Input.Checkbox
                 checked={displayFormatter}
-                onClick={(): void => setDisplayFormatter(!displayFormatter)}
+                onValueChange={(): void =>
+                  setDisplayFormatter(!displayFormatter)
+                }
               />
               {resourcesText.customizeFieldFormatters()}
             </Label.Inline>

--- a/specifyweb/frontend/js_src/lib/components/Formatters/Formatter.tsx
+++ b/specifyweb/frontend/js_src/lib/components/Formatters/Formatter.tsx
@@ -72,7 +72,7 @@ function ConditionalMapping({
             formatter.definition.conditionField !== undefined
           }
           isReadOnly={isReadOnly}
-          onClick={setConditionField}
+          onChange={setConditionField}
         />
         {resourcesText.conditionalFormatter()}
       </Label.Inline>


### PR DESCRIPTION
Fixes #4700

### Checklist

- [x] Self-review the PR after opening it to make sure the changes look good
      and self-explanatory (or properly documented)
- [x] Add relevant issue to release milestone

### Testing instructions
- Connect as a read only user
- Go to App Resources => Record Formatters => Choose Table that has conditional formatter
- Click on a formatter

- [ ] Verify the 2 check boxes (Default and Conditional Format) are disabled 

- proceed with the same steps with another table 

