### PR TITLE
Enable select all in loan prep return dialog after deselect all

### DIFF
--- a/specifyweb/frontend/js_src/lib/components/Interactions/LoanReturn.tsx
+++ b/specifyweb/frontend/js_src/lib/components/Interactions/LoanReturn.tsx
@@ -180,10 +180,9 @@ function PreparationReturn({
             onClick={(): void =>
               setState(
                 state.map((preparation) => ({
+                  ...preparation,
                   resolve: 0,
                   returns: 0,
-                  unresolved: preparation.unresolved ?? 0,
-                  remarks: preparation.remarks,
                 }))
               )
             }

--- a/specifyweb/frontend/js_src/lib/components/Interactions/LoanReturn.tsx
+++ b/specifyweb/frontend/js_src/lib/components/Interactions/LoanReturn.tsx
@@ -179,11 +179,11 @@ function PreparationReturn({
             title={commonText.clearAll()}
             onClick={(): void =>
               setState(
-                state.map(({ remarks }) => ({
+                state.map((preparation) => ({
                   resolve: 0,
                   returns: 0,
-                  unresolved: 0,
-                  remarks,
+                  unresolved: preparation.unresolved ?? 0,
+                  remarks: preparation.remarks,
                 }))
               )
             }


### PR DESCRIPTION
Fixes #4710

### Checklist

- [x] Self-review the PR after opening it to make sure the changes look good
      and self-explanatory (or properly documented)
- [x] Add relevant issue to release milestone

### Testing instructions

Go to any Loan with preparations
Click on Return Loan at the bottom of the form
Click Select All
Click Deselect All
Click Select All

- [ ] Verify Select All is enabled after clicking deselect all 