### PR TITLE
Account for localization.isrequired with field.isRequired

### DIFF
--- a/specifyweb/frontend/js_src/lib/components/DataModel/businessRules.ts
+++ b/specifyweb/frontend/js_src/lib/components/DataModel/businessRules.ts
@@ -342,7 +342,7 @@ export class BusinessRuleManager<SCHEMA extends AnySchema> {
             return true;
           if (
             field !== undefined &&
-            !(field.isRequired || field.localization.isrequired) &&
+            !field.isRequired &&
             (value === undefined || value === null)
           ) {
             return false;

--- a/specifyweb/frontend/js_src/lib/components/DataModel/specifyField.ts
+++ b/specifyweb/frontend/js_src/lib/components/DataModel/specifyField.ts
@@ -131,18 +131,18 @@ export abstract class FieldBase {
     this.isReadOnly =
       globalFieldOverride === 'readOnly' || fieldDefinition.readOnly === true;
 
+    this.localization =
+      this.table.localization.items[this.name.toLowerCase()] ?? {};
+
     this.isRequired =
       globalFieldOverride === 'required'
         ? true
         : globalFieldOverride === 'optional'
         ? false
-        : fieldDefinition.required;
+        : fieldDefinition.required || (this.localization?.isrequired ?? false);
     this.type = fieldDefinition.type;
     this.length = fieldDefinition.length;
     this.databaseColumn = fieldDefinition.column;
-
-    this.localization =
-      this.table.localization.items[this.name.toLowerCase()] ?? {};
 
     this.label =
       typeof this.localization.name === 'string' &&


### PR DESCRIPTION
Fixes #4720

> Currently the `field.localization.isrequired` is not present in `field.isRequired`. The `fieldDefinition` only contains information from the `specify_datamodel.xml` (https://files.specifysoftware.org/schema/version/2.10/), and does not contain any information on the splocalecontaineritem which represents the disclipline's configuration for the field.
> 
> Consider the two CollectionObject fields `uniqueIdentifier` and `totalValue`. In the currently logged in discipline, `totalValue` is marked as required and `uniqueIdentifier` is not required.
> 
> The following code is added to the constructor of `FieldBase`
> 
> ```ts
> if (
>       table.name === 'CollectionObject' &&
>       ['totalvalue', 'uniqueidentifier'].includes(
>         fieldDefinition.name.toLowerCase()
>       )
>     )
>       console.log(
>         table.name,
>         fieldDefinition.name,
>         table.localization.items[fieldDefinition.name.toLowerCase()]
>           ?.isrequired,
>         fieldDefinition.required,
>         this.isRequired
>       );
> ```
> 
> which outputs:
> 
> <img alt="Screenshot 2024-04-01 at 9 22 48 AM" width="454" src="https://private-user-images.githubusercontent.com/64045831/318461799-d2c633f7-fc9e-4325-adc8-fb4c16018d1a.png?jwt=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3MTIwNTc4NTUsIm5iZiI6MTcxMjA1NzU1NSwicGF0aCI6Ii82NDA0NTgzMS8zMTg0NjE3OTktZDJjNjMzZjctZmM5ZS00MzI1LWFkYzgtZmI0YzE2MDE4ZDFhLnBuZz9YLUFtei1BbGdvcml0aG09QVdTNC1ITUFDLVNIQTI1NiZYLUFtei1DcmVkZW50aWFsPUFLSUFWQ09EWUxTQTUzUFFLNFpBJTJGMjAyNDA0MDIlMkZ1cy1lYXN0LTElMkZzMyUyRmF3czRfcmVxdWVzdCZYLUFtei1EYXRlPTIwMjQwNDAyVDExMzIzNVomWC1BbXotRXhwaXJlcz0zMDAmWC1BbXotU2lnbmF0dXJlPTZiMWM3MDVlOTY2ZjY3MWQ4NjMzZTFlMjAwZjFlNzFjZGQyM2EzNzc4M2EyZTQ1YmIwMGU1ZjJjZjE0M2Y3NzQmWC1BbXotU2lnbmVkSGVhZGVycz1ob3N0JmFjdG9yX2lkPTAma2V5X2lkPTAmcmVwb19pZD0wIn0.8N60hlhoNBBgLiJqG8RgB81_iV0VBWucCgFMjqHDom0">
> I agree it would make sense to include the `field.localization.isrequired` with the `field.isRequired`.

https://github.com/specify/specify7/pull/4703#discussion_r1546387723

### Checklist

- [x] Self-review the PR after opening it to make sure the changes look good
      and self-explanatory (or properly documented)
- [ ] Add automated tests
- [ ] Add relevant issue to release milestone

### Testing instructions

