### PR TITLE
Add logic to mute outside dialog clicks for the first 300ms

### DIFF
--- a/specifyweb/frontend/js_src/lib/components/Forms/Save.tsx
+++ b/specifyweb/frontend/js_src/lib/components/Forms/Save.tsx
@@ -83,6 +83,7 @@ export function SaveButton<SCHEMA extends AnySchema = AnySchema>({
 
   const blockers = useAllSaveBlockers(resource, filterBlockers);
   const saveBlocked = blockers.length > 0;
+  console.log(blockers);
 
   const [isSaving, setIsSaving] = React.useState(false);
   const [shownBlocker, setShownBlocker] = React.useState<

--- a/specifyweb/frontend/js_src/lib/components/Molecules/Dialog.tsx
+++ b/specifyweb/frontend/js_src/lib/components/Molecules/Dialog.tsx
@@ -365,7 +365,7 @@ export function Dialog({
   React.useEffect(() => {
     const timer = setTimeout(() => {
       allowCloseRef.current = true;
-    }, 1000);
+    }, 300);
 
     return () => {
       clearTimeout(timer);

--- a/specifyweb/frontend/js_src/lib/components/Molecules/Dialog.tsx
+++ b/specifyweb/frontend/js_src/lib/components/Molecules/Dialog.tsx
@@ -375,31 +375,29 @@ export function Dialog({
   const overlayElement: Props['overlayElement'] = (
     props: React.ComponentPropsWithRef<'div'>,
     contentElement: React.ReactElement
-  ) => {
-    return (
-      <div
-        {...props}
-        onMouseDown={
-          closeOnOutsideClick
-            ? (event): void => {
-                // Outside click detection
-                if (
-                  allowCloseRef.current &&
-                  modal &&
-                  typeof handleClose === 'function' &&
-                  event.target === event.currentTarget
-                ) {
-                  event.preventDefault();
-                  handleClose();
-                } else props?.onMouseDown?.(event);
-              }
-            : undefined
-        }
-      >
-        {contentElement}
-      </div>
-    );
-  };
+  ) => (
+    <div
+      {...props}
+      onMouseDown={
+        closeOnOutsideClick
+          ? (event): void => {
+              // Outside click detection
+              if (
+                allowCloseRef.current &&
+                modal &&
+                typeof handleClose === 'function' &&
+                event.target === event.currentTarget
+              ) {
+                event.preventDefault();
+                handleClose();
+              } else props?.onMouseDown?.(event);
+            }
+          : undefined
+      }
+    >
+      {contentElement}
+    </div>
+  );
 
   const transitionDuration = useTransitionDuration();
   const highContrast = useHighContrast();


### PR DESCRIPTION
Fixes #4711

- [x] Self-review the PR after opening it to make sure the changes look good
      and self-explanatory (or properly documented)
- [x] Add relevant issue to release milestone

### Testing instructions

- Go to any Loan with preparations (https://umherb11024-edge.test.specifysystems.org/specify/view/loan/2414/)
- Click on Return Loan at the bottom of the form
- Click Select All
- Click Deselect All

- [ ] See that dialog has the correct size 
- [ ] Verify that you cannot click outside the dialog to close it during the first 300ms 
- [ ] Verify other dialogs across Sp 
