### PR TITLE
Unset width for bulkSelect in prep dialog

### DIFF
--- a/specifyweb/frontend/js_src/lib/components/Interactions/PrepDialog.tsx
+++ b/specifyweb/frontend/js_src/lib/components/Interactions/PrepDialog.tsx
@@ -136,7 +136,7 @@ export function PrepDialog({
         {commonText.bulkSelect()}
         <Input.Integer
           aria-label={interactionsText.selectedAmount()}
-          className="w-[unset]"
+          className="!w-[unset]"
           max={maxPrep}
           min={0}
           title={interactionsText.selectedAmount()}


### PR DESCRIPTION
Fixes #4722

### Checklist

- [x] Self-review the PR after opening it to make sure the changes look good
      and self-explanatory (or properly documented)
- [x] Add relevant issue to release milestone

### Testing instructions

- Click on interaction
- Choose a RC 

- [ ]  See that Bulk Select is not taking full width
