### PR TITLE
Use correct views for every type of subview

### DIFF
--- a/specifyweb/frontend/js_src/lib/components/FormCells/FormTable.tsx
+++ b/specifyweb/frontend/js_src/lib/components/FormCells/FormTable.tsx
@@ -154,14 +154,14 @@ export function FormTable<SCHEMA extends AnySchema>({
   const isReadOnly = React.useContext(ReadOnlyContext);
   const isInSearchDialog = React.useContext(SearchDialogContext);
   const mode = propsToFormMode(isReadOnly, isInSearchDialog);
-  const viewDefinition = useViewDefinition({
+  const collapsedViewDefinition = useViewDefinition({
     table: relationship.relatedTable,
     viewName,
     fallbackViewName: relationship.relatedTable.view,
     formType: 'formTable',
     mode,
   });
-  const fullViewDefinition = useViewDefinition({
+  const expandedViewDefinition = useViewDefinition({
     table: relationship.relatedTable,
     viewName,
     fallbackViewName: relationship.relatedTable.view,
@@ -199,7 +199,7 @@ export function FormTable<SCHEMA extends AnySchema>({
   const [maxHeight] = userPreferences.use('form', 'formTable', 'maxHeight');
 
   const children =
-    viewDefinition === undefined ? (
+    collapsedViewDefinition === undefined ? (
       commonText.loading()
     ) : resources.length === 0 ? (
       <p>{formsText.noData()}</p>
@@ -213,12 +213,12 @@ export function FormTable<SCHEMA extends AnySchema>({
           role="table"
           style={{
             gridTemplateColumns: `min-content ${columnDefinitionsToCss(
-              viewDefinition.columns,
+              collapsedViewDefinition.columns,
               flexibleSubGridColumnWidth
             )} min-content`,
             maxHeight: `${maxHeight}px`,
           }}
-          viewDefinition={viewDefinition}
+          viewDefinition={collapsedViewDefinition}
           onScroll={handleScroll}
         >
           <div
@@ -232,7 +232,7 @@ export function FormTable<SCHEMA extends AnySchema>({
             <div className={cellClassName} role="columnheader">
               <span className="sr-only">{commonText.expand()}</span>
             </div>
-            {viewDefinition.rows[0].map((cell, index) => {
+            {collapsedViewDefinition.rows[0].map((cell, index) => {
               const { text, title } = cellToLabel(
                 relationship.relatedTable,
                 cell
@@ -301,7 +301,7 @@ export function FormTable<SCHEMA extends AnySchema>({
                       </div>
                       <DataEntry.Cell
                         align="left"
-                        colSpan={viewDefinition.columns.length}
+                        colSpan={collapsedViewDefinition.columns.length}
                         role="cell"
                         tabIndex={-1}
                         verticalAlign="stretch"
@@ -310,7 +310,7 @@ export function FormTable<SCHEMA extends AnySchema>({
                         <SpecifyForm
                           display="inline"
                           resource={resource}
-                          viewDefinition={fullViewDefinition}
+                          viewDefinition={expandedViewDefinition}
                         />
                       </DataEntry.Cell>
                     </>
@@ -332,19 +332,22 @@ export function FormTable<SCHEMA extends AnySchema>({
                         </Button.Small>
                       </div>
                       <ReadOnlyContext.Provider
-                        value={isReadOnly || viewDefinition.mode === 'view'}
+                        value={
+                          isReadOnly || collapsedViewDefinition.mode === 'view'
+                        }
                       >
                         <SearchDialogContext.Provider
                           value={
-                            isInSearchDialog || viewDefinition.mode === 'search'
+                            isInSearchDialog ||
+                            collapsedViewDefinition.mode === 'search'
                           }
                         >
-                          {viewDefinition.name === attachmentView ? (
+                          {collapsedViewDefinition.name === attachmentView ? (
                             <div className="flex gap-8" role="cell">
                               <Attachment resource={resource} />
                             </div>
                           ) : (
-                            viewDefinition.rows[0].map(
+                            collapsedViewDefinition.rows[0].map(
                               (
                                 {
                                   colSpan,
@@ -420,7 +423,7 @@ export function FormTable<SCHEMA extends AnySchema>({
                       <FormMeta
                         className="flex-1"
                         resource={resource}
-                        viewDescription={fullViewDefinition}
+                        viewDescription={expandedViewDefinition}
                       />
                     )}
                   </div>

--- a/specifyweb/frontend/js_src/lib/components/FormCells/FormTable.tsx
+++ b/specifyweb/frontend/js_src/lib/components/FormCells/FormTable.tsx
@@ -163,8 +163,8 @@ export function FormTable<SCHEMA extends AnySchema>({
   });
   const fullViewDefinition = useViewDefinition({
     table: relationship.relatedTable,
-    viewName: relationship.relatedTable.view,
-    fallbackViewName: viewName,
+    viewName,
+    fallbackViewName: relationship.relatedTable.view,
     formType: 'form',
     mode,
   });


### PR DESCRIPTION
Fixes #4737 

See https://github.com/specify/specify7/issues/4737#issuecomment-2038639953

### Checklist

- [x] Self-review the PR after opening it to make sure the changes look good
      and self-explanatory (or properly documented)
- [ ] Add automated tests
- [x] Add relevant issue to release milestone

### Testing instructions
For any relationship which is `to-many` (can be rendered as a SubView in both form and table modes. e.g, on CollectionObject: `preparations`, `determinations`, `dnaSequences`,  etc.)
- [ ] Create a new view definition for the Related Table of the relationship (Preparation, Determination, ...) 
- [ ] Modify the view definition to make it distinct from the default view of the table
- [ ] On the form for the `one` side of the `to-many` relationship, ensure the `viewname` attribute matches that of the newly created view/viewdef and the `defaulttype` attribute is set to `table`
- [ ] On the DataEntry form of the `one` side of the relationship, ensure the correct view definition is used for the subview in all of the following cases:
  - [ ]  The collapsed view of a row in `table` mode
  - [ ] The expanded view of a row in `table` mode
  - [ ] Subform/Form mode

(For a concrete example see https://github.com/specify/specify7/issues/4737#issue-2225602012)
