### PR TITLE
Unset auto width for forms when not in subForm to avoid shifts

### DIFF
--- a/specifyweb/frontend/js_src/lib/components/Forms/ResourceView.tsx
+++ b/specifyweb/frontend/js_src/lib/components/Forms/ResourceView.tsx
@@ -310,7 +310,7 @@ export function ResourceView<SCHEMA extends AnySchema>({
       </DataEntry.SubForm>
     ) : (
       <Container.FullGray>
-        <Container.Center className="!w-auto">
+        <Container.Center>
           <DataEntry.Header>
             <AppTitle title={customTitle ?? formatted} />
             <DataEntry.Title>{customTitle ?? jsxFormatted}</DataEntry.Title>


### PR DESCRIPTION
Fixes #4738

### Checklist

- [ ] Self-review the PR after opening it to make sure the changes look good
      and self-explanatory (or properly documented)
- [ ] Add relevant issue to release milestone

### Testing instructions

- Go to data entry
- Click on taxon
- Input a parent of taxon
- Delete what you selected and reenter a new taxon

- [ ] See there is no form shift
- [ ] test other places with forms, other data entry forms, app resources, record sets, interactions. Verify width is ok 
