### PR TITLE
Allow to add sortField attribute to initialize cells

### DIFF
--- a/specifyweb/frontend/js_src/lib/components/FormEditor/viewSpec.ts
+++ b/specifyweb/frontend/js_src/lib/components/FormEditor/viewSpec.ts
@@ -405,9 +405,16 @@ const subViewSpec = (
       syncers.maybe(
         syncer(
           (raw: string) => {
+            const cellName = _cell.rest.node.attributes.name;
+            const cellRelationship = table?.fields
+              .filter((field) => field.isRelationship)
+              .find((table) => table.name === cellName) as
+              | Relationship
+              | undefined;
+            const cellRelatedTableName = cellRelationship?.relatedTable.name;
             const parsed = toLargeSortConfig(raw);
             const fieldNames = syncers
-              .field(table?.name)
+              .field(cellRelatedTableName)
               .serializer(parsed.fieldNames.join('.'));
             return fieldNames === undefined
               ? undefined


### PR DESCRIPTION
Fixes #4741

### Checklist

- [ ] Self-review the PR after opening it to make sure the changes look good
      and self-explanatory (or properly documented)
- [ ] Add relevant issue to release milestone

### Testing instructions

- go to app resource 
- open a table (i.e collection object)
- in a subview, add initialize="sortField=NAME OF FIELD" in the cell
i.e: 
```xml
<row>
   <cell type="subview" viewname="Determination" id="6" name="determinations" defaulttype="table" colspan="13" rows="5" initialize="sortField=isCurrent"/>
</row>
```

- [ ] verify that there is no errors and it sorts the field 