### PR TITLE
Enable select all/deselect all when typing in bulk, handle NaN

### DIFF
--- a/specifyweb/frontend/js_src/lib/components/Forms/Save.tsx
+++ b/specifyweb/frontend/js_src/lib/components/Forms/Save.tsx
@@ -83,7 +83,6 @@ export function SaveButton<SCHEMA extends AnySchema = AnySchema>({
 
   const blockers = useAllSaveBlockers(resource, filterBlockers);
   const saveBlocked = blockers.length > 0;
-  console.log(blockers);
 
   const [isSaving, setIsSaving] = React.useState(false);
   const [shownBlocker, setShownBlocker] = React.useState<

--- a/specifyweb/frontend/js_src/lib/components/Interactions/LoanReturn.tsx
+++ b/specifyweb/frontend/js_src/lib/components/Interactions/LoanReturn.tsx
@@ -103,9 +103,10 @@ function PreparationReturn({
       remarks: '',
     }))
   );
+
   const canDeselect = state.some(({ resolve }) => resolve > 0);
   const canSelectAll = state.some(
-    ({ resolve, unresolved }) => resolve < unresolved || Number.isNaN(resolve)
+    ({ resolve, unresolved }) => resolve < unresolved
   );
 
   const [bulkReturn, setBulkReturn] = React.useState(0);
@@ -133,12 +134,12 @@ function PreparationReturn({
           type === 'resolve'
             ? updateResolvedChanged({
                 returns,
-                resolve: resolvedCount,
+                resolve: Number.isNaN(resolvedCount) ? 0 : resolvedCount,
                 unresolved,
                 remarks: returnItem.remarks,
               })
             : updateReturnChanged({
-                returns: resolvedCount,
+                returns: Number.isNaN(resolvedCount) ? 0 : resolvedCount,
                 resolve,
                 unresolved,
                 remarks: returnItem.remarks,

--- a/specifyweb/frontend/js_src/lib/components/Interactions/LoanReturn.tsx
+++ b/specifyweb/frontend/js_src/lib/components/Interactions/LoanReturn.tsx
@@ -105,7 +105,7 @@ function PreparationReturn({
   );
   const canDeselect = state.some(({ resolve }) => resolve > 0);
   const canSelectAll = state.some(
-    ({ resolve, unresolved }) => resolve < unresolved
+    ({ resolve, unresolved }) => resolve < unresolved || Number.isNaN(resolve)
   );
 
   const [bulkReturn, setBulkReturn] = React.useState(0);


### PR DESCRIPTION
Fixes #4745

### Checklist

- [x] Self-review the PR after opening it to make sure the changes look good
      and self-explanatory (or properly documented)
- [x] Add relevant issue to release milestone

### Testing instructions

- Go to a loan with preparations
- Click on return loan
- Type a number into the 'bulk return'

- [ ]  Verify select all and deselect all are enabled