### PR TITLE
Enable close button only when changes saved, display close and cancel

### DIFF
--- a/specifyweb/frontend/js_src/lib/components/Forms/ResourceView.tsx
+++ b/specifyweb/frontend/js_src/lib/components/Forms/ResourceView.tsx
@@ -337,19 +337,17 @@ export function ResourceView<SCHEMA extends AnySchema>({
           <>
             {deleteButton}
             {extraButtons ?? <span className="-ml-2 flex-1" />}
-            {
-              <Button.Info
-                onClick={handleClose}
-                disabled={resource?.needsSaved}
-                title={
-                  resource?.needsSaved
-                    ? commonText.saveBeforeClose()
-                    : commonText.close()
-                }
-              >
-                {commonText.close()}
-              </Button.Info>
-            }
+            <Button.Info
+              disabled={resource?.needsSaved}
+              title={
+                resource?.needsSaved
+                  ? commonText.saveBeforeClose()
+                  : commonText.close()
+              }
+              onClick={handleClose}
+            >
+              {commonText.close()}
+            </Button.Info>
             {saveButtonElement}
           </>
         )

--- a/specifyweb/frontend/js_src/lib/components/Forms/ResourceView.tsx
+++ b/specifyweb/frontend/js_src/lib/components/Forms/ResourceView.tsx
@@ -337,17 +337,13 @@ export function ResourceView<SCHEMA extends AnySchema>({
           <>
             {deleteButton}
             {extraButtons ?? <span className="-ml-2 flex-1" />}
-            <Button.Info
-              disabled={resource?.needsSaved}
-              title={
-                resource?.needsSaved
-                  ? commonText.saveBeforeClose()
-                  : commonText.close()
-              }
-              onClick={handleClose}
-            >
-              {commonText.close()}
-            </Button.Info>
+            {isModified && !isDependent ? (
+              <Button.DialogClose>{commonText.cancel()}</Button.DialogClose>
+            ) : (
+              <Button.Info onClick={handleClose}>
+                {commonText.close()}
+              </Button.Info>
+            )}
             {saveButtonElement}
           </>
         )

--- a/specifyweb/frontend/js_src/lib/components/Forms/ResourceView.tsx
+++ b/specifyweb/frontend/js_src/lib/components/Forms/ResourceView.tsx
@@ -337,15 +337,19 @@ export function ResourceView<SCHEMA extends AnySchema>({
           <>
             {deleteButton}
             {extraButtons ?? <span className="-ml-2 flex-1" />}
-            {isModified && !isDependent ? (
-              <Button.Danger onClick={handleClose}>
-                {commonText.cancel()}
-              </Button.Danger>
-            ) : (
-              <Button.Info onClick={handleClose}>
+            {
+              <Button.Info
+                onClick={handleClose}
+                disabled={resource?.needsSaved}
+                title={
+                  resource?.needsSaved
+                    ? commonText.saveBeforeClose()
+                    : commonText.close()
+                }
+              >
                 {commonText.close()}
               </Button.Info>
-            )}
+            }
             {saveButtonElement}
           </>
         )

--- a/specifyweb/frontend/js_src/lib/localization/common.ts
+++ b/specifyweb/frontend/js_src/lib/localization/common.ts
@@ -739,4 +739,7 @@ export const commonText = createDictionary({
     'ru-ru': 'Выберите файлы или перетащите их сюда',
     'uk-ua': 'Виберіть файли або перетягніть їх сюди',
   },
+  saveBeforeClose: {
+    'en-us': 'Save your changes before closing.',
+  },
 } as const);

--- a/specifyweb/frontend/js_src/lib/localization/common.ts
+++ b/specifyweb/frontend/js_src/lib/localization/common.ts
@@ -739,7 +739,4 @@ export const commonText = createDictionary({
     'ru-ru': 'Выберите файлы или перетащите их сюда',
     'uk-ua': 'Виберіть файли або перетягніть їх сюди',
   },
-  saveBeforeClose: {
-    'en-us': 'Save your changes before closing.',
-  },
 } as const);


### PR DESCRIPTION
Fixes #4746

### Checklist

- [x] Self-review the PR after opening it to make sure the changes look good
      and self-explanatory (or properly documented)
- [ ] Add relevant issue to release milestone

### Testing instructions

- Go to existing Collection Object
- Click on pencil icon by a qcbx with data already entered (i.e Cataloger) 
- Make a change in the Agent overlay dialog 
- Save
- Reopen the Agent dialog with the edit button 
- [ ] Verify the changes are present 
- Don't make any changes 
- [ ] Verify you can close the dialog and no message is being displayed 
-  Reopen the Agent dialog with the edit button 
- Make a change 
- Click Cancel 
- [ ] Verify a pop up dialog opens with a warning for unsaved changes 
- Click Cancel 
- [ ] Verify that you go back to the Agent overlay dialog  
- Click Cancel 
- The overlay dialog with unsaved warning opens 
- Click Leave btn 
- [ ] Verify that you are going back to the main form 
- Reload the page 
- [ ] Verify that you lost your changes in Agent edit form 
