### PR TITLE
Only use query builder in the search formatter

### DIFF
--- a/specifyweb/frontend/js_src/lib/components/Formatters/Preview.tsx
+++ b/specifyweb/frontend/js_src/lib/components/Formatters/Preview.tsx
@@ -106,6 +106,7 @@ export function useResourcePreview(table: SpecifyTable): {
             table={table}
             onClose={handleClose}
             onSelected={setResources}
+            onlyUseQueryBuilder={true}
           />
         )}
       </div>

--- a/specifyweb/frontend/js_src/lib/components/Formatters/Preview.tsx
+++ b/specifyweb/frontend/js_src/lib/components/Formatters/Preview.tsx
@@ -103,10 +103,10 @@ export function useResourcePreview(table: SpecifyTable): {
             extraFilters={undefined}
             forceCollection={undefined}
             multiple
+            onlyUseQueryBuilder
             table={table}
             onClose={handleClose}
             onSelected={setResources}
-            onlyUseQueryBuilder={true}
           />
         )}
       </div>

--- a/specifyweb/frontend/js_src/lib/components/SearchDialog/index.tsx
+++ b/specifyweb/frontend/js_src/lib/components/SearchDialog/index.tsx
@@ -60,6 +60,7 @@ export function SearchDialog<SCHEMA extends AnySchema>(props: {
   readonly onClose: () => void;
   readonly searchView?: string;
   readonly onSelected: (resources: RA<SpecifyResource<SCHEMA>>) => void;
+  readonly onlyUseQueryBuilder?: boolean;
 }): JSX.Element | null {
   const [alwaysUseQueryBuilder] = userPreferences.use(
     'form',
@@ -67,7 +68,7 @@ export function SearchDialog<SCHEMA extends AnySchema>(props: {
     'alwaysUseQueryBuilder'
   );
   const [useQueryBuilder, handleUseQueryBuilder] = useBooleanState(
-    alwaysUseQueryBuilder
+    props.onlyUseQueryBuilder ? true : alwaysUseQueryBuilder
   );
   return useQueryBuilder ? (
     <QueryBuilderSearch


### PR DESCRIPTION
Fixes #4756

### Checklist

- [x] Self-review the PR after opening it to make sure the changes look good
      and self-explanatory (or properly documented)
- [x] Add relevant issue to release milestone

### Testing instructions

- Go to a table formatter
- Click Search
- [ ] Verify that the search dialog opens only the query builder tool 
- Proceed with the selection 
- [ ] Verify that the search is still accessible from other places in sp 7. i.e a combobox in data entry. Test also changing the pref to always use query builder in the search dialog 