### PR TITLE
Remove disable from order picker when read only

### DIFF
--- a/specifyweb/frontend/js_src/lib/components/Preferences/Renderers.tsx
+++ b/specifyweb/frontend/js_src/lib/components/Preferences/Renderers.tsx
@@ -148,10 +148,8 @@ export function OrderPicker<SCHEMA extends AnySchema>({
       | (string & keyof SCHEMA['fields'])
   ) => void;
 }): JSX.Element {
-  const isReadOnly = React.useContext(ReadOnlyContext);
   return (
     <Select
-      disabled={isReadOnly}
       value={order}
       onValueChange={(newOrder): void =>
         handleChange(newOrder as Exclude<typeof order, undefined>)


### PR DESCRIPTION
Fixes #4769

### Checklist

- [x] Self-review the PR after opening it to make sure the changes look good
      and self-explanatory (or properly documented)
- [x] Add relevant issue to release milestone

### Testing instructions

- Go to a Collection Object
- Enable read only mode through its form meta
- Go to a subview's form meta after it reloads 
- See that you can change "Order By"
