### PR TITLE
Enable collection gallery once the attachment is loaded

### DIFF
--- a/specifyweb/frontend/js_src/lib/components/FormSliders/AttachmentsCollection.tsx
+++ b/specifyweb/frontend/js_src/lib/components/FormSliders/AttachmentsCollection.tsx
@@ -48,7 +48,11 @@ export function AttachmentsCollection({
           return undefined;
         })
       ),
-    [collection.models]
+    [
+      collection.models,
+      collection.models.length > 0 &&
+        collection.models[collection.models.length - 1].needsSaved,
+    ]
   );
 
   const isAttachmentsNotLoaded = attachments.some(

--- a/specifyweb/frontend/js_src/lib/components/FormSliders/AttachmentsCollection.tsx
+++ b/specifyweb/frontend/js_src/lib/components/FormSliders/AttachmentsCollection.tsx
@@ -33,8 +33,7 @@ export function AttachmentsCollection({
   );
 
   const attachmentHasChanged =
-    collection.models.length > 0 &&
-    collection.models[collection.models.length - 1].needsSaved;
+    collection.models.length > 0 && collection.models.at(-1).needsSaved;
 
   const attachments: RA<SerializedResource<Attachment>> = React.useMemo(
     () =>

--- a/specifyweb/frontend/js_src/lib/components/FormSliders/AttachmentsCollection.tsx
+++ b/specifyweb/frontend/js_src/lib/components/FormSliders/AttachmentsCollection.tsx
@@ -32,6 +32,10 @@ export function AttachmentsCollection({
     'scale'
   );
 
+  const attachmentHasChanged =
+    collection.models.length > 0 &&
+    collection.models[collection.models.length - 1].needsSaved;
+
   const attachments: RA<SerializedResource<Attachment>> = React.useMemo(
     () =>
       filterArray(
@@ -48,11 +52,7 @@ export function AttachmentsCollection({
           return undefined;
         })
       ),
-    [
-      collection.models,
-      collection.models.length > 0 &&
-        collection.models[collection.models.length - 1].needsSaved,
-    ]
+    [collection.models, attachmentHasChanged]
   );
 
   const isAttachmentsNotLoaded = attachments.some(


### PR DESCRIPTION
Fixes #4775

### Checklist

- [x] Self-review the PR after opening it to make sure the changes look good
      and self-explanatory (or properly documented)
- [x] Add relevant issue to release milestone

### Testing instructions

- Add an attachment to a record.
- Click on the attachment gallery.
- [ ] See that the attachment gallery opens.
