### PR TITLE
Filter out empty conditional format def

### DIFF
--- a/specifyweb/frontend/js_src/lib/components/Formatters/Definitions.tsx
+++ b/specifyweb/frontend/js_src/lib/components/Formatters/Definitions.tsx
@@ -181,11 +181,7 @@ function ConditionalFormatter({
               ) : null}
             </div>
             {isExpanded ? (
-              <span>
-                {index === 0
-                  ? resourcesText.elseConditionDescription()
-                  : resourcesText.conditionDescription()}
-              </span>
+              <span>{resourcesText.conditionDescription()}</span>
             ) : null}
           </Label.Block>
         </div>

--- a/specifyweb/frontend/js_src/lib/components/Formatters/spec.ts
+++ b/specifyweb/frontend/js_src/lib/components/Formatters/spec.ts
@@ -22,12 +22,14 @@ export const formattersSpec = f.store(() =>
               ...formatter,
               definition: {
                 ...definition,
-                fields: definition.fields.map((fieldGroup) => ({
-                  ...fieldGroup,
-                  fields: fieldGroup.fields.filter(
-                    (field) => field.field !== undefined
-                  ),
-                })),
+                fields: definition.fields
+                  .filter((fieldGroup) => fieldGroup.fields.length > 0)
+                  .map((fieldGroup) => ({
+                    ...fieldGroup,
+                    fields: fieldGroup.fields.filter(
+                      (field) => field.field !== undefined
+                    ),
+                  })),
                 isSingle: definition.fields.length <= 1,
               },
             })

--- a/specifyweb/frontend/js_src/lib/localization/resources.ts
+++ b/specifyweb/frontend/js_src/lib/localization/resources.ts
@@ -621,27 +621,7 @@ export const resourcesText = createDictionary({
   conditionDescription: {
     'en-us': `
       This format will be used only if the condition field value equals this
-      condition.
-    `,
-    'de-ch': `
-      Dieses Format wird nur verwendet, wenn der Wert des Bedingungsfelds dieser
-      Bedingung entspricht.
-    `,
-    'es-es': `
-      Este formato se utilizará sólo si el valor del campo de condición es igual
-      a esta condición.
-    `,
-    'fr-fr': `
-      Ce format ne sera utilisé que si la valeur du champ de condition est égale
-      à cette condition.
-    `,
-    'ru-ru': `
-      Этот формат будет использоваться только в том случае, если значение поля
-      условия соответствует этому условию.
-    `,
-    'uk-ua': `
-      Цей формат використовуватиметься, лише якщо значення поля умови дорівнює
-      цій умові.
+      condition and is not null.
     `,
   },
   elseConditionDescription: {

--- a/specifyweb/frontend/js_src/lib/localization/resources.ts
+++ b/specifyweb/frontend/js_src/lib/localization/resources.ts
@@ -624,33 +624,6 @@ export const resourcesText = createDictionary({
       condition and is not null.
     `,
   },
-  elseConditionDescription: {
-    'en-us': `
-      This format will be used only if the condition field value equals this
-      condition or if no other format matches it.
-    `,
-    'de-ch': `
-      Dieses Format wird nur verwendet, wenn der Wert des Bedingungsfelds dieser
-      Bedingung entspricht oder wenn kein anderes Format damit übereinstimmt.
-    `,
-    'es-es': `
-      Este formato se utilizará sólo si el valor del campo de condición es igual
-      a esta condición o si ningún otro formato coincide con ella.
-    `,
-    'fr-fr': `
-      Ce format ne sera utilisé que si la valeur du champ de condition est égale
-      à cette condition ou si aucun autre format ne lui correspond.
-    `,
-    'ru-ru': `
-      Этот формат будет использоваться только в том случае, если значение поля
-      условия соответствует этому условию или если ему не соответствует никакой
-      другой формат.
-    `,
-    'uk-ua': `
-      Цей формат використовуватиметься, лише якщо значення поля умови дорівнює
-      цій умові або якщо жоден інший формат їй не відповідає.
-    `,
-  },
   wrongScopeWarning: {
     'en-us': `
       This resource belongs to a different collection/discipline than the one


### PR DESCRIPTION
Fixes #4774

### Checklist

- [x] Self-review the PR after opening it to make sure the changes look good
      and self-explanatory (or properly documented)
- [x] Add relevant issue to release milestone

### Testing instructions

- Go to App Resources -> Record Formatters -> Any table
- Check 'Conditional Format'
- Add a blank field or invalid value 
- Close and save
- Try to query with formatted 
- [ ]Verify you can query and when opening back the record formatter the empty fields are gone 
