### PR TITLE
Clear fields when check/uncheck conditional in formatters

### DIFF
--- a/specifyweb/frontend/js_src/lib/components/Formatters/Formatter.tsx
+++ b/specifyweb/frontend/js_src/lib/components/Formatters/Formatter.tsx
@@ -53,14 +53,14 @@ function ConditionalMapping({
 
   function setConditionField(): void {
     setIsConditionFieldDisplayed(!isConditionFieldDisplayed);
-    if (isConditionFieldDisplayed)
-      setFormatter({
-        ...formatter,
-        definition: {
-          ...formatter.definition,
-          conditionField: undefined,
-        },
-      });
+    setFormatter({
+      ...formatter,
+      definition: {
+        ...formatter.definition,
+        conditionField: undefined,
+        fields: [],
+      },
+    });
   }
 
   return (


### PR DESCRIPTION
Fixes #4784

### Checklist

- [x] Self-review the PR after opening it to make sure the changes look good
      and self-explanatory (or properly documented)
- [x] Add relevant issue to release milestone

### Testing instructions

Go to app resources-> record formatters (using visual editor)
Click on accesssion
Add a conditional format
Save
Reopen
Remove conditional format
- [ ] verify that when you switch between Conditional Format checked and unchecked, the fields are being deleted from the editor (like starting a new formatter from scratch) 
Click on accesssion
Uncheck conditional 
- [ ] verify that when you switch, the fields are being deleted from the editor (like starting a new formatter from scratch) 
- [ ] Check in xml viewer that only the field is present when only field in visual editor 
- [ ] Check in xml viewer that conditionals is/are present when defined in visual editor 
In conclusion, when switching from Conditional Format checked/unchecked the part with the fields should be cleared. 
