### PR TITLE
Attachment Mapping File Support

### DIFF
--- a/specifyweb/frontend/js_src/lib/components/AttachmentsBulkImport/Datasets.tsx
+++ b/specifyweb/frontend/js_src/lib/components/AttachmentsBulkImport/Datasets.tsx
@@ -32,6 +32,7 @@ import type {
   AttachmentDataSet,
   AttachmentDataSetPlan,
   FetchedDataSet,
+  PartialUploadableFileSpec,
 } from './types';
 import { useEagerDataSet } from './useEagerDataset';
 
@@ -97,10 +98,14 @@ function ModifyDataset({
   );
 }
 
-const createEmpty = async (name: LocalizedString) =>
+export const createEmptyAttachmentDataset = async (
+  name: LocalizedString,
+  rows: RA<PartialUploadableFileSpec> = []
+) =>
   createEmptyDataSet<AttachmentDataSet>('/attachment_gw/dataset/', name, {
     uploadplan: { staticPathKey: undefined },
     uploaderstatus: 'main',
+    rows,
   });
 
 export function AttachmentsImportOverlay(): JSX.Element | null {
@@ -274,7 +279,7 @@ function NewDataSet(): JSX.Element | null {
             id={id('form')}
             onSubmit={async () => {
               loading(
-                createEmpty(pendingName).then(({ id }) =>
+                createEmptyAttachmentDataset(pendingName).then(({ id }) =>
                   navigate(`/specify/attachments/import/${id}`)
                 )
               );

--- a/specifyweb/frontend/js_src/lib/components/AttachmentsBulkImport/ImportFromMappingFile.tsx
+++ b/specifyweb/frontend/js_src/lib/components/AttachmentsBulkImport/ImportFromMappingFile.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import { localized, RA } from '../../utils/types';
+import { CsvFilePicker } from '../Molecules/CsvFilePicker';
+import { attachmentsText } from '../../localization/attachments';
+import { useNavigate } from 'react-router-dom';
+
+import { PartialUploadableFileSpec } from './types';
+import { createEmptyAttachmentDataset } from './Datasets';
+
+// TODO: Is this needed?
+//const requiredHeaders = ['filename', 'identifier'];
+
+export function ImportFromMappingFile(): JSX.Element {
+  const navigate = useNavigate();
+  return (
+    <>
+      <CsvFilePicker
+        header={attachmentsText.importFromMappingFile()}
+        onFileImport={({ data: rawRows, fileName }) => {
+          // To support mapping file, we just create a new dataset with files. Matching behaviour
+          // within dataset takes care of rest
+          const attachmentRows: RA<PartialUploadableFileSpec> = rawRows.map(
+            ([fileName, parsedName]) => ({
+              uploadFile: {
+                file: {
+                  name: fileName,
+                },
+                parsedName,
+              },
+            })
+          );
+          createEmptyAttachmentDataset(
+            localized(fileName),
+            attachmentRows
+          ).then(({ id }) => navigate(`/specify/attachments/import/${id}`));
+        }}
+      />
+    </>
+  );
+}

--- a/specifyweb/frontend/js_src/lib/components/AttachmentsBulkImport/ViewAttachmentFiles.tsx
+++ b/specifyweb/frontend/js_src/lib/components/AttachmentsBulkImport/ViewAttachmentFiles.tsx
@@ -62,7 +62,10 @@ const resolveAttachmentDatasetData = (
             {uploadFile.file.name}
           </div>,
         ],
-        fileSize: formatFileSize(uploadFile.file.size),
+        fileSize:
+          uploadFile.file.size === undefined
+            ? ''
+            : formatFileSize(uploadFile.file.size),
         record: [
           resolvedRecord?.type === 'matched'
             ? resolvedRecord.id

--- a/specifyweb/frontend/js_src/lib/components/AttachmentsBulkImport/types.ts
+++ b/specifyweb/frontend/js_src/lib/components/AttachmentsBulkImport/types.ts
@@ -9,7 +9,6 @@ import type { DatasetBase, DatasetBriefBase } from '../WbPlanView/Wrapped';
 import type { PartialAttachmentUploadSpec } from './Import';
 import type { staticAttachmentImportPaths } from './importPaths';
 import type { keyLocalizationMapAttachment } from './utils';
-import { Optional } from 'typedoc/dist/lib/utils/validation';
 
 export type UploadAttachmentSpec = {
   readonly token: string;

--- a/specifyweb/frontend/js_src/lib/components/AttachmentsBulkImport/types.ts
+++ b/specifyweb/frontend/js_src/lib/components/AttachmentsBulkImport/types.ts
@@ -9,6 +9,7 @@ import type { DatasetBase, DatasetBriefBase } from '../WbPlanView/Wrapped';
 import type { PartialAttachmentUploadSpec } from './Import';
 import type { staticAttachmentImportPaths } from './importPaths';
 import type { keyLocalizationMapAttachment } from './utils';
+import { Optional } from 'typedoc/dist/lib/utils/validation';
 
 export type UploadAttachmentSpec = {
   readonly token: string;
@@ -57,7 +58,8 @@ type UploadableFileSpec = {
  * Forcing keys to be primitive because objects would be
  * ignored during syncing to backend.
  */
-export type BoundFile = Pick<File, 'name' | 'size' | 'type'>;
+export type BoundFile = Pick<File, 'name'> &
+  Partial<Pick<File, 'size' | 'type'>>;
 
 export type UnBoundFile = {
   readonly file: BoundFile | File;

--- a/specifyweb/frontend/js_src/lib/components/Molecules/CsvFilePicker.tsx
+++ b/specifyweb/frontend/js_src/lib/components/Molecules/CsvFilePicker.tsx
@@ -25,11 +25,13 @@ export function CsvFilePicker({
     hasHeader,
     encoding,
     getSetDelimiter,
+    fileName,
   }: {
     readonly data: RA<RA<string>>;
     readonly hasHeader: boolean;
     readonly encoding: string;
     readonly getSetDelimiter: GetOrSet<string | undefined>;
+    readonly fileName: string;
   }) => void;
 }): JSX.Element {
   const [file, setFile] = React.useState<File | undefined>();
@@ -69,11 +71,13 @@ export function CsvFilePreview({
     hasHeader,
     encoding,
     getSetDelimiter,
+    fileName,
   }: {
     readonly data: RA<RA<string>>;
     readonly hasHeader: boolean;
     readonly encoding: string;
     readonly getSetDelimiter: GetOrSet<string | undefined>;
+    readonly fileName: string;
   }) => void;
 }): JSX.Element {
   const [encoding, setEncoding] = React.useState<string>('utf-8');
@@ -94,6 +98,7 @@ export function CsvFilePreview({
           hasHeader,
           encoding,
           getSetDelimiter,
+          fileName: file.name,
         });
       }}
     >

--- a/specifyweb/frontend/js_src/lib/components/Router/Routes.tsx
+++ b/specifyweb/frontend/js_src/lib/components/Router/Routes.tsx
@@ -192,6 +192,13 @@ export const routes: RA<EnhancedRoute> = [
             ({ AttachmentImportById }) => AttachmentImportById
           ),
       },
+      {
+        path: 'import',
+        element: () =>
+          import('../AttachmentsBulkImport/ImportFromMappingFile').then(
+            ({ ImportFromMappingFile }) => ImportFromMappingFile
+          ),
+      },
     ],
   },
   {

--- a/specifyweb/frontend/js_src/lib/components/WbImport/helpers.ts
+++ b/specifyweb/frontend/js_src/lib/components/WbImport/helpers.ts
@@ -21,10 +21,6 @@ import type { Dataset, DatasetBrief } from '../WbPlanView/Wrapped';
  *   and update the usages in code to fix that rule
  */
 
-/** Remove the extension from the file name */
-export const extractFileName = (fileName: string): string =>
-  fileName.replace(/\.[^.]*$/u, '');
-
 export const wbImportPreviewSize = 100;
 
 const fileMimeMapper: IR<'csv' | 'xls'> = {

--- a/specifyweb/frontend/js_src/lib/components/WbImport/index.tsx
+++ b/specifyweb/frontend/js_src/lib/components/WbImport/index.tsx
@@ -22,13 +22,13 @@ import { CsvFilePreview } from '../Molecules/CsvFilePicker';
 import { FilePicker, Layout } from '../Molecules/FilePicker';
 import {
   createDataSet,
-  extractFileName,
   getMaxDataSetLength,
   inferDataSetType,
   parseCsv,
   parseXls,
   wbImportPreviewSize,
 } from './helpers';
+import { stripFileExtension } from '../../utils/utils';
 
 export function WbImportView(): JSX.Element {
   useMenuItem('workBench');
@@ -50,7 +50,7 @@ export function WbImportView(): JSX.Element {
 
 function FilePicked({ file }: { readonly file: File }): JSX.Element {
   const fileType = inferDataSetType(file);
-  const getSetDataSetName = useTriggerState(extractFileName(file.name));
+  const getSetDataSetName = useTriggerState(stripFileExtension(file.name));
   const [hasHeader = true, setHasHeader] = useCachedState(
     'wbImport',
     'hasHeader'

--- a/specifyweb/frontend/js_src/lib/localization/attachments.ts
+++ b/specifyweb/frontend/js_src/lib/localization/attachments.ts
@@ -674,4 +674,7 @@ export const attachmentsText = createDictionary({
       під час читання файлу сталася помилка.
     `,
   },
+  importFromMappingFile: {
+    'en-us': 'Import from Mapping File',
+  },
 } as const);


### PR DESCRIPTION
Fixes #https://github.com/specify/specify7/issues/4766

Realized that previously implemented logic covered most of the cases. We already supported matching files to previously selected files. So, now, we just make a new attachment dataset based on the selected csv. When user selects files, they will be matched to this dataset (which is based on csv) so we just preserve the parsed name. 

I'll add more automated tests for this before making this open for review for everything seems to be working!

EDIT: I based it off @melton-jason coge-import because I realized I could reuse some of that code. I'm still considering directly using workbench's implementation though

![image](https://github.com/specify/specify7/assets/61122018/311f0486-9505-48d0-9be1-20bdd59e8e30)

![image](https://github.com/specify/specify7/assets/61122018/c845979d-146d-413b-b968-e74edf1b7ded)

### Checklist

- [ ] Self-review the PR after opening it to make sure the changes look good
      and self-explanatory (or properly documented)
- [ ] Add automated tests
- [ ] Add relevant issue to release milestone

### Testing instructions

<!-- What are the steps to verify the fixes/changes in this PR? -->
<!-- Can part of that be replaced by automated tests? -->
