### PR TITLE
Display date input when accessible full date off and no precision

### DIFF
--- a/specifyweb/frontend/js_src/lib/components/FormPlugins/DateInput.tsx
+++ b/specifyweb/frontend/js_src/lib/components/FormPlugins/DateInput.tsx
@@ -90,9 +90,6 @@ export function DateInput({
   return (
     <>
       <Input.Generic
-        className={
-          !dateSupported && canChangePrecision ? '' : '!w-[unset] grow'
-        }
         forwardRef={validationRef}
         id={id}
         isReadOnly={isReadOnly}

--- a/specifyweb/frontend/js_src/lib/components/FormPlugins/DateInput.tsx
+++ b/specifyweb/frontend/js_src/lib/components/FormPlugins/DateInput.tsx
@@ -21,12 +21,14 @@ export function DateInput({
   parser,
   id,
   isRequired,
+  canChangePrecision,
 }: {
   readonly moment: GetSet<ReturnType<typeof dayjs> | undefined>;
   readonly precision: PartialDatePrecision;
   readonly parser: Parser;
   readonly id?: string;
   readonly isRequired?: boolean;
+  readonly canChangePrecision?: boolean;
 }): JSX.Element {
   const {
     dateType,
@@ -88,6 +90,9 @@ export function DateInput({
   return (
     <>
       <Input.Generic
+        className={
+          !dateSupported && canChangePrecision ? '' : '!w-[unset] grow'
+        }
         forwardRef={validationRef}
         id={id}
         isReadOnly={isReadOnly}

--- a/specifyweb/frontend/js_src/lib/components/FormPlugins/DateInput.tsx
+++ b/specifyweb/frontend/js_src/lib/components/FormPlugins/DateInput.tsx
@@ -21,14 +21,12 @@ export function DateInput({
   parser,
   id,
   isRequired,
-  canChangePrecision,
 }: {
   readonly moment: GetSet<ReturnType<typeof dayjs> | undefined>;
   readonly precision: PartialDatePrecision;
   readonly parser: Parser;
   readonly id?: string;
   readonly isRequired?: boolean;
-  readonly canChangePrecision?: boolean;
 }): JSX.Element {
   const {
     dateType,

--- a/specifyweb/frontend/js_src/lib/components/FormPlugins/PartialDateUi.tsx
+++ b/specifyweb/frontend/js_src/lib/components/FormPlugins/PartialDateUi.tsx
@@ -10,6 +10,7 @@ import { getDateParser } from './dateUtils';
 import type { PartialDatePrecision } from './useDatePrecision';
 import { useDatePrecision } from './useDatePrecision';
 import { useMoment } from './useMoment';
+import { useDatePreferences } from './useDatePreferences';
 
 /** A date picker with precision selection (full, month-year, year) */
 export function PartialDateUi({
@@ -49,7 +50,11 @@ export function PartialDateUi({
     React.useContext(ReadOnlyContext) || resource === undefined;
 
   return (
-    <div className="grid w-full grid-cols-[fit-content(40%)_1fr] gap-1">
+    <div
+      className={`${
+        canChangePrecision ? 'grid grid-cols-[fit-content(40%)_1fr]' : ''
+      } w-full gap-1`}
+    >
       {!isReadOnly && canChangePrecision ? (
         <DatePrecisionPicker moment={moment} {...precisionProps} />
       ) : undefined}

--- a/specifyweb/frontend/js_src/lib/components/FormPlugins/PartialDateUi.tsx
+++ b/specifyweb/frontend/js_src/lib/components/FormPlugins/PartialDateUi.tsx
@@ -61,6 +61,7 @@ export function PartialDateUi({
             moment={moment}
             parser={parser}
             precision={precision}
+            canChangePrecision={canChangePrecision}
           />
         </div>
       </ReadOnlyContext.Provider>

--- a/specifyweb/frontend/js_src/lib/components/FormPlugins/PartialDateUi.tsx
+++ b/specifyweb/frontend/js_src/lib/components/FormPlugins/PartialDateUi.tsx
@@ -10,7 +10,6 @@ import { getDateParser } from './dateUtils';
 import type { PartialDatePrecision } from './useDatePrecision';
 import { useDatePrecision } from './useDatePrecision';
 import { useMoment } from './useMoment';
-import { useDatePreferences } from './useDatePreferences';
 
 /** A date picker with precision selection (full, month-year, year) */
 export function PartialDateUi({
@@ -66,7 +65,6 @@ export function PartialDateUi({
             moment={moment}
             parser={parser}
             precision={precision}
-            canChangePrecision={canChangePrecision}
           />
         </div>
       </ReadOnlyContext.Provider>

--- a/specifyweb/frontend/js_src/lib/components/FormPlugins/__tests__/__snapshots__/PartialDateUi.test.tsx.snap
+++ b/specifyweb/frontend/js_src/lib/components/FormPlugins/__tests__/__snapshots__/PartialDateUi.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`PartialDateUi renders without errors 1`] = `
 <DocumentFragment>
   <div
-    class="grid w-full grid-cols-[fit-content(40%)_1fr] gap-1"
+    class="grid grid-cols-[fit-content(40%)_1fr] w-full gap-1"
   >
     <label
       class="print:hidden"
@@ -37,7 +37,7 @@ exports[`PartialDateUi renders without errors 1`] = `
       class="flex"
     >
       <input
-        class="not-touched w-full !w-[unset] grow"
+        class="not-touched w-full"
         max="9999-12-31"
         placeholder="MM/DD/YYYY"
         type="date"
@@ -51,13 +51,13 @@ exports[`PartialDateUi renders without errors 1`] = `
 exports[`PartialDateUi renders without errors 2`] = `
 <DocumentFragment>
   <div
-    class="grid w-full grid-cols-[fit-content(40%)_1fr] gap-1"
+    class=" w-full gap-1"
   >
     <div
       class="flex"
     >
       <input
-        class="not-touched w-full !w-[unset] grow"
+        class="not-touched w-full"
         placeholder="MM/YYYY"
         type="month"
         value=""
@@ -70,13 +70,13 @@ exports[`PartialDateUi renders without errors 2`] = `
 exports[`PartialDateUi renders without errors 3`] = `
 <DocumentFragment>
   <div
-    class="grid w-full grid-cols-[fit-content(40%)_1fr] gap-1"
+    class=" w-full gap-1"
   >
     <div
       class="flex"
     >
       <input
-        class="not-touched w-full !w-[unset] grow"
+        class="not-touched w-full"
         max="9999"
         min="1"
         placeholder="YYYY"

--- a/specifyweb/frontend/js_src/lib/components/FormPlugins/__tests__/__snapshots__/PartialDateUi.test.tsx.snap
+++ b/specifyweb/frontend/js_src/lib/components/FormPlugins/__tests__/__snapshots__/PartialDateUi.test.tsx.snap
@@ -37,7 +37,7 @@ exports[`PartialDateUi renders without errors 1`] = `
       class="flex"
     >
       <input
-        class="not-touched w-full"
+        class="not-touched w-full !w-[unset] grow"
         max="9999-12-31"
         placeholder="MM/DD/YYYY"
         type="date"
@@ -57,7 +57,7 @@ exports[`PartialDateUi renders without errors 2`] = `
       class="flex"
     >
       <input
-        class="not-touched w-full"
+        class="not-touched w-full !w-[unset] grow"
         placeholder="MM/YYYY"
         type="month"
         value=""
@@ -76,7 +76,7 @@ exports[`PartialDateUi renders without errors 3`] = `
       class="flex"
     >
       <input
-        class="not-touched w-full"
+        class="not-touched w-full !w-[unset] grow"
         max="9999"
         min="1"
         placeholder="YYYY"


### PR DESCRIPTION
Fixes #4783

### Checklist

- [x] Self-review the PR after opening it to make sure the changes look good
      and self-explanatory (or properly documented)
- [x] Add relevant issue to release milestone

### Testing instructions

- Go to Preferences
- Turn off "Use accessible date picker"
- Go to a form that has date fields with date precision selection (CO)
- [ ] Verify that the date precision is visible 
- Go to a form that has date fields with no date precision selection (Borrow in interactions) 
- [ ] Verify that the date precision is visible 
- [ ] verify the same but with  "Use accessible date picker" on 
