### PR TITLE
Display aggregator/formatter label in schema config

### DIFF
--- a/specifyweb/frontend/js_src/lib/components/SchemaConfig/Components.tsx
+++ b/specifyweb/frontend/js_src/lib/components/SchemaConfig/Components.tsx
@@ -84,7 +84,7 @@ export function PickList({
             .flatMap((group) =>
               Array.isArray(group)
                 ? group.map(([name]) => name)
-                : Object.values(group)
+                : Object.keys(group)
             )
             .includes(value) ? undefined : (
             <option value={value}>{`${queryText.invalidPicklistValue({

--- a/specifyweb/frontend/js_src/lib/components/SchemaConfig/Components.tsx
+++ b/specifyweb/frontend/js_src/lib/components/SchemaConfig/Components.tsx
@@ -55,7 +55,7 @@ export function PickList({
 }: {
   readonly label?: LocalizedString;
   readonly value: string | null;
-  readonly groups: IR<IR<string> | RA<readonly [string, string]>>;
+  readonly groups: IR<IR<string> | RA<readonly [name: string, title: string]>>;
   readonly disabled?: boolean;
   readonly onChange: (value: string | null) => void;
   readonly className?: string;
@@ -110,7 +110,7 @@ export function PickList({
 function Values({
   values,
 }: {
-  readonly values: IR<string> | RA<readonly [string, string]>;
+  readonly values: IR<string> | RA<readonly [value: string, label: string]>;
 }): JSX.Element {
   return (
     <>


### PR DESCRIPTION
Fixes #4797

### Checklist

- [x] Self-review the PR after opening it to make sure the changes look good
      and self-explanatory (or properly documented)
- [x] Add relevant issue to release milestone

### Testing instructions

Go to table formats/aggregation through schema config
Select any table
Make the title and name different values
- [ ] Verify the name of the formatter is correct 