### PR TITLE
Restore `<Formatter Not Defined.>` for empty formats

### DIFF
--- a/specifyweb/stored_queries/format.py
+++ b/specifyweb/stored_queries/format.py
@@ -182,7 +182,7 @@ class ObjectFormatter(object):
             logger.warn(
                 "dataobjformatter for %s contains switch clause no fields",
                 specify_model)
-            return query, literal(_("<Formatter not defined.>"))
+            return query, literal(_text("<Formatter not defined.>"))
 
         if single:
             value, expr = cases[0]


### PR DESCRIPTION
Fixes #4817 

### Checklist

- [x] Self-review the PR after opening it to make sure the changes look good
      and self-explanatory (or properly documented)
- [ ] Add automated tests
- [x] Add relevant issue to release milestone

### Testing instructions
- Create or edit any table's Record Formatter so that it does not contain any fields (i.e., never click on the `Add Field` button)

For the following: 
  - In the QueryBuilder for the table of which the formatter was defined, add and query on the `(formatted)` field 
  - In a QueryCombobox which searches on the table

-  [ ] Ensure no error occurs and the query returns rows which display `<Formatter Not Defined.>`