### PR TITLE
Increase dnasequencingrun->tracefilename from length 32 to 64

### DIFF
--- a/specifyweb/specify/datamodel.py
+++ b/specifyweb/specify/datamodel.py
@@ -2564,7 +2564,7 @@ datamodel = Datamodel(tables=[
             Field(name='text3', column='Text3', indexed=False, unique=False, required=False, type='java.lang.String', length=64),
             Field(name='timestampCreated', column='TimestampCreated', indexed=False, unique=False, required=True, type='java.sql.Timestamp'),
             Field(name='timestampModified', column='TimestampModified', indexed=False, unique=False, required=False, type='java.sql.Timestamp'),
-            Field(name='traceFileName', column='TraceFileName', indexed=False, unique=False, required=False, type='java.lang.String', length=32),
+            Field(name='traceFileName', column='TraceFileName', indexed=False, unique=False, required=False, type='java.lang.String', length=64),
             Field(name='version', column='Version', indexed=False, unique=False, required=False, type='java.lang.Integer'),
             Field(name='yesNo1', column='YesNo1', indexed=False, unique=False, required=False, type='java.lang.Boolean'),
             Field(name='yesNo2', column='YesNo2', indexed=False, unique=False, required=False, type='java.lang.Boolean'),

--- a/specifyweb/specify/migrations/001_dnasequencerun_tracefilename_64.py
+++ b/specifyweb/specify/migrations/001_dnasequencerun_tracefilename_64.py
@@ -1,0 +1,19 @@
+from django.conf import settings
+from django.db import migrations, models
+
+class Migration(migrations.Migration):
+
+    # dependencies = [
+    #     ('specify', '000x_previous_migration'),
+    # ]
+    dependencies = [
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='dnasequencingrun',
+            name='tracefilename',
+            field=models.CharField(blank=True, max_length=64, null=True, unique=False, db_column='TraceFileName', db_index=False),
+        ),
+    ]

--- a/specifyweb/specify/migrations/001_dnasequencerun_tracefilename_64.py
+++ b/specifyweb/specify/migrations/001_dnasequencerun_tracefilename_64.py
@@ -3,12 +3,7 @@ from django.db import migrations, models
 
 class Migration(migrations.Migration):
 
-    # dependencies = [
-    #     ('specify', '000x_previous_migration'),
-    # ]
-    dependencies = [
-        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
-    ]
+    dependencies = []
 
     operations = [
         migrations.AlterField(

--- a/specifyweb/specify/models.py
+++ b/specifyweb/specify/models.py
@@ -2377,7 +2377,7 @@ class Dnasequencingrun(models.Model):
     text3 = models.CharField(blank=True, max_length=64, null=True, unique=False, db_column='Text3', db_index=False)
     timestampcreated = models.DateTimeField(blank=False, null=False, unique=False, db_column='TimestampCreated', db_index=False)
     timestampmodified = models.DateTimeField(blank=True, null=True, unique=False, db_column='TimestampModified', db_index=False)
-    tracefilename = models.CharField(blank=True, max_length=32, null=True, unique=False, db_column='TraceFileName', db_index=False)
+    tracefilename = models.CharField(blank=True, max_length=64, null=True, unique=False, db_column='TraceFileName', db_index=False)
     version = models.IntegerField(blank=True, null=True, unique=False, db_column='Version', db_index=False)
     yesno1 = models.BooleanField(blank=True, null=True, unique=False, db_column='YesNo1', db_index=False)
     yesno2 = models.BooleanField(blank=True, null=True, unique=False, db_column='YesNo2', db_index=False)


### PR DESCRIPTION
Fixes #4835

Increase dnasequencingrun->tracefilename from length 32 to 64

### Checklist

- [x] Self-review the PR after opening it to make sure the changes look good
      and self-explanatory (or properly documented)
- [ ] Add automated tests
- [ ] Add relevant issue to release milestone

### Testing instructions

Check that you can create a dnasequencingrun with a tracefilename that has a length greater than 32
