### PR TITLE
Don't set unload protect for new tree records 

### DIFF
--- a/specifyweb/frontend/js_src/lib/components/PickLists/TreeLevelPickList.tsx
+++ b/specifyweb/frontend/js_src/lib/components/PickLists/TreeLevelPickList.tsx
@@ -150,6 +150,7 @@ export function TreeLevelComboBox(props: DefaultComboBoxProps): JSX.Element {
       resource?.set('definitionItem', newDefinitionItem);
       return void resource?.businessRuleManager?.checkField('parent');
     }
+    return undefined;
   }, [items]);
 
   return (

--- a/specifyweb/frontend/js_src/lib/components/PickLists/TreeLevelPickList.tsx
+++ b/specifyweb/frontend/js_src/lib/components/PickLists/TreeLevelPickList.tsx
@@ -131,22 +131,25 @@ export function TreeLevelComboBox(props: DefaultComboBoxProps): JSX.Element {
     const resource = toTreeTable(props.resource);
     const definitionItem = resource?.get('definitionItem');
 
+    const newDefinitionItem =
+      props.defaultValue ?? items?.slice(-1)[0]?.value ?? '';
+
+    const isDifferentDefinitionItem =
+      newDefinitionItem !== (definitionItem ?? '');
+
     const invalidDefinitionItem =
       typeof definitionItem !== 'string' ||
       (!(items?.map(({ value }) => value).includes(definitionItem) ?? true) &&
         !Object.keys(resource?.changed ?? {}).includes('definitionitem'));
 
     if (
+      isDifferentDefinitionItem &&
       (items !== undefined || typeof resource?.get('parent') !== 'string') &&
       invalidDefinitionItem
     ) {
-      resource?.set(
-        'definitionItem',
-        props.defaultValue ?? items?.slice(-1)[0]?.value ?? ''
-      );
+      resource?.set('definitionItem', newDefinitionItem);
+      return void resource?.businessRuleManager?.checkField('parent');
     }
-
-    return void resource?.businessRuleManager?.checkField('parent');
   }, [items]);
 
   return (


### PR DESCRIPTION
Fixes #4856 

### Checklist

- [x] Self-review the PR after opening it to make sure the changes look good
      and self-explanatory (or properly documented)
- [x] Add relevant issue to release milestone

Currently, it is known that unload protect is still triggered specifically when using the `Add Child` functionality on a tree node. 

https://github.com/specify/specify7/assets/64045831/4b205aae-a347-4dba-b771-b6703175c629

@specify/ux-testing, is this behavior 'acceptable' or should that case also additionally covered? 

### Testing instructions
- Open a DataEntry form for a Tree table (Taxon, Storage, Geography, Chronostrat, or Lithostrat)
- Do not make any changes to the form and attempt to navigate away from the form
- [ ] Ensure that the Unload Protect Dialog does not appear and the user can navigate away from the form without interruption
 
Additionally, light testing can be done (following the testing instructions in https://github.com/specify/specify7/pull/4811#issue-2253172557) to ensure that no other prior tree functionality has been impacted. 
