### PR TITLE
Fix index error for the table formatter

### DIFF
--- a/specifyweb/stored_queries/format.py
+++ b/specifyweb/stored_queries/format.py
@@ -162,17 +162,10 @@ class ObjectFormatter(object):
         cycle_with_self = [*cycle_detector, (inspect(orm_table).class_.__name__, 'formatting')] if (
                 cycle_detector is not None) else None
 
-        def make_case(query: QueryConstruct, caseNode: Element) -> Tuple[
-            QueryConstruct, Optional[str], blank_nulls]:
-            field_exprs = []
-            for node in caseNode.findall('field'):
-                query, expr, _ = self.make_expr(query, node.text, node.attrib, orm_table, specify_model, cycle_with_self)
-                field_exprs.append(expr)
-            
-            expr = ""
-            if field_exprs:
-                expr = concat(*field_exprs) if len(field_exprs) > 1 else field_exprs[0]
-
+        def make_case(query: QueryConstruct, caseNode: Element) -> Tuple[QueryConstruct, Optional[str], blank_nulls]:
+            field_exprs = [self.make_expr(query, node.text, node.attrib, orm_table, specify_model, cycle_with_self)[1] 
+                        for node in caseNode.findall('field')]
+            expr = concat(*field_exprs) if field_exprs else ""
             return query, caseNode.attrib.get('value', None), expr
 
         switchNode = formatterNode.find('switch')

--- a/specifyweb/stored_queries/format.py
+++ b/specifyweb/stored_queries/format.py
@@ -168,7 +168,11 @@ class ObjectFormatter(object):
             for node in caseNode.findall('field'):
                 query, expr, _ = self.make_expr(query, node.text, node.attrib, orm_table, specify_model, cycle_with_self)
                 field_exprs.append(expr)
-            expr = concat(*field_exprs) if len(field_exprs) > 1 else field_exprs[0]
+            
+            expr = ""
+            if field_exprs:
+                expr = concat(*field_exprs) if len(field_exprs) > 1 else field_exprs[0]
+
             return query, caseNode.attrib.get('value', None), expr
 
         switchNode = formatterNode.find('switch')


### PR DESCRIPTION
Fixes #4774

Fixes the case where a blank condition field value in a table formatter causes an index out of range error when creating a query with the formatted field.

### Checklist

- [ ] Self-review the PR after opening it to make sure the changes look good
      and self-explanatory (or properly documented)
- [ ] Add automated tests
- [ ] Add relevant issue to release milestone

### Testing instructions

Follow the multiple videos showing the process of recreating the bug in the issue.
