### PR TITLE
Add min width to aggregator preview

### DIFF
--- a/specifyweb/frontend/js_src/lib/components/Formatters/Aggregator.tsx
+++ b/specifyweb/frontend/js_src/lib/components/Formatters/Aggregator.tsx
@@ -114,6 +114,10 @@ function AggregatorPreview({
   );
   return typeof aggregator.table === 'object' &&
     hasTablePermission(aggregator.table.name, 'read') ? (
-    <ResourcePreview doFormatting={doFormatting} table={aggregator.table} />
+    <ResourcePreview
+      doFormatting={doFormatting}
+      isAggregator
+      table={aggregator.table}
+    />
   ) : null;
 }

--- a/specifyweb/frontend/js_src/lib/components/Formatters/Preview.tsx
+++ b/specifyweb/frontend/js_src/lib/components/Formatters/Preview.tsx
@@ -19,7 +19,10 @@ import { SearchDialog } from '../SearchDialog';
 
 const defaultPreviewSize = 4;
 
-export function useResourcePreview(table: SpecifyTable): {
+export function useResourcePreview(
+  table: SpecifyTable,
+  isAggregator: boolean = false
+): {
   readonly resources: GetOrSet<RA<SpecifyResource<AnySchema>> | undefined>;
   readonly children: (
     callback: (
@@ -60,7 +63,9 @@ export function useResourcePreview(table: SpecifyTable): {
     children: (children) => (
       <div
         // Setting width prevents dialog resizing when output is loaded
-        className="flex flex-col gap-2"
+        className={`flex ${
+          isAggregator ? 'w-[min(40rem,50vw)] break-all' : undefined
+        } flex-col gap-2`}
       >
         <span className="font-bold">{resourcesText.preview()}</span>
         {resourcesText.previewExplainer()}
@@ -78,19 +83,17 @@ export function useResourcePreview(table: SpecifyTable): {
                 className="flex gap-2 rounded bg-[color:var(--form-background)] p-2"
                 key={index}
               >
-                {output !== undefined && (
-                  <ResourceLink
-                    component={Link.Icon}
-                    props={{
-                      icon: 'eye',
-                    }}
-                    resource={resource}
-                    resourceView={{
-                      onDeleted: (): void =>
-                        setResources(removeItem(resources, index)),
-                    }}
-                  />
-                )}
+                <ResourceLink
+                  component={Link.Icon}
+                  props={{
+                    icon: 'eye',
+                  }}
+                  resource={resource}
+                  resourceView={{
+                    onDeleted: (): void =>
+                      setResources(removeItem(resources, index)),
+                  }}
+                />
                 <output className="whitespace-pre-wrap">{output}</output>
               </div>
             );
@@ -117,16 +120,18 @@ export function useResourcePreview(table: SpecifyTable): {
 export function ResourcePreview({
   table,
   doFormatting,
+  isAggregator,
 }: {
   readonly table: SpecifyTable;
   readonly doFormatting: (
     resources: RA<SpecifyResource<AnySchema>>
   ) => Promise<RA<React.ReactNode>>;
+  readonly isAggregator?: boolean;
 }): JSX.Element | null {
   const {
     resources: [resources],
     children,
-  } = useResourcePreview(table);
+  } = useResourcePreview(table, isAggregator);
   const [formatted] = useAsyncState(
     React.useCallback(
       async () => f.maybe(resources, doFormatting),


### PR DESCRIPTION
Fixes #4858 



### Checklist

- [x] Self-review the PR after opening it to make sure the changes look good
      and self-explanatory (or properly documented)
- [x] Add relevant issue to release milestone

### Testing instructions

- Go to Schema Config / App Resources
- Create a new Table Aggregator
  - Change the limit between 0 and 4
    - [ ] Verify the dialog does not rapidly resize 
  - Add a sufficiently large suffix or edit any of the other fields
    - [ ] Verify the dialog does not rapidly resize 

Note: There still is a rapid re-render but it's inside previews rather the entire dialog. To solve that we possibly need to rewrite the underlying component which is also being used by Table Formatter and WebLinks.
