### PR TITLE
Prevent adding children to synonym nodes when not authorized

### DIFF
--- a/specifyweb/frontend/js_src/lib/components/DataModel/__tests__/businessRules.test.ts
+++ b/specifyweb/frontend/js_src/lib/components/DataModel/__tests__/businessRules.test.ts
@@ -3,10 +3,7 @@ import { renderHook } from '@testing-library/react';
 import { overrideAjax } from '../../../tests/ajax';
 import { mockTime, requireContext } from '../../../tests/helpers';
 import { overwriteReadOnly } from '../../../utils/types';
-import {
-  getPref,
-  remotePrefsDefinitions,
-} from '../../InitialContext/remotePrefs';
+import { getPref } from '../../InitialContext/remotePrefs';
 import type { SerializedResource } from '../helperTypes';
 import { getResourceApiUrl } from '../resource';
 import { useSaveBlockers } from '../saveBlockers';

--- a/specifyweb/frontend/js_src/lib/components/DataModel/__tests__/businessRules.test.ts
+++ b/specifyweb/frontend/js_src/lib/components/DataModel/__tests__/businessRules.test.ts
@@ -197,6 +197,7 @@ describe('treeBusinessRules', () => {
     _tableName: 'Taxon',
     id: 3,
     name: 'Acipenser',
+    isAccepted: true,
     rankId: 180,
     definition: '/api/specify/taxontreedef/1/',
     definitionItem: '/api/specify/taxontreedefitem/9/',
@@ -207,6 +208,7 @@ describe('treeBusinessRules', () => {
     _tableName: 'Taxon',
     id: 4,
     name: 'oxyrinchus',
+    isAccepted: true,
     rankId: 220,
     definition: '/api/specify/taxontreedef/1/',
     definitionItem: '/api/specify/taxontreedefitem/2/',
@@ -218,6 +220,7 @@ describe('treeBusinessRules', () => {
     id: 5,
     rankId: 230,
     name: 'oxyrinchus',
+    isAccepted: true,
     definition: '/api/specify/taxontreedef/1/',
     definitionItem: '/api/specify/taxontreedefitem/22/',
   };

--- a/specifyweb/frontend/js_src/lib/components/DataModel/__tests__/businessRules.test.ts
+++ b/specifyweb/frontend/js_src/lib/components/DataModel/__tests__/businessRules.test.ts
@@ -3,6 +3,10 @@ import { renderHook } from '@testing-library/react';
 import { overrideAjax } from '../../../tests/ajax';
 import { mockTime, requireContext } from '../../../tests/helpers';
 import { overwriteReadOnly } from '../../../utils/types';
+import {
+  getPref,
+  remotePrefsDefinitions,
+} from '../../InitialContext/remotePrefs';
 import type { SerializedResource } from '../helperTypes';
 import { getResourceApiUrl } from '../resource';
 import { useSaveBlockers } from '../saveBlockers';
@@ -204,6 +208,17 @@ describe('treeBusinessRules', () => {
     parent: '/api/specify/taxon/2/',
   };
 
+  const husoResponse: Partial<SerializedResource<Taxon>> = {
+    _tableName: 'Taxon',
+    id: 6,
+    name: 'Huso',
+    isAccepted: false,
+    rankId: 180,
+    definition: '/api/specify/taxontreedef/1/',
+    definitionItem: '/api/specify/taxontreedefitem/9/',
+    parent: '/api/specify/taxon/2/',
+  };
+
   const oxyrinchusSpeciesResponse: Partial<SerializedResource<Taxon>> = {
     _tableName: 'Taxon',
     id: 4,
@@ -268,9 +283,11 @@ describe('treeBusinessRules', () => {
   };
 
   const oxyrinchusFullNameResponse = 'Acipenser oxyrinchus';
+  const dauricusFullNameResponse = 'Huso dauricus';
 
   overrideAjax('/api/specify/taxon/2/', animaliaResponse);
   overrideAjax('/api/specify/taxon/3/', acipenserResponse);
+  overrideAjax('/api/specify/taxon/6/', husoResponse);
   overrideAjax('/api/specify/taxon/4/', oxyrinchusSpeciesResponse);
   overrideAjax('/api/specify/taxon/5/', oxyrinchusSubSpeciesResponse);
   overrideAjax('/api/specify/taxontreedefitem/9/', genusResponse);
@@ -279,6 +296,10 @@ describe('treeBusinessRules', () => {
   overrideAjax(
     '/api/specify_tree/taxon/3/predict_fullname/?name=oxyrinchus&treedefitemid=2',
     oxyrinchusFullNameResponse
+  );
+  overrideAjax(
+    '/api/specify_tree/taxon/6/predict_fullname/?name=dauricus&treedefitemid=2',
+    dauricusFullNameResponse
   );
   overrideAjax('/api/specify/taxon/?limit=1&parent=4&orderby=rankid', {
     objects: [oxyrinchusSubSpeciesResponse],
@@ -331,5 +352,53 @@ describe('treeBusinessRules', () => {
       useSaveBlockers(taxon, tables.Taxon.getField('parent'))
     );
     expect(result.current[0]).toStrictEqual(['Bad tree structure.']);
+  });
+  test('saveBlocker on synonymized parent', async () => {
+    const taxon = new tables.Taxon.Resource({
+      name: 'dauricus',
+      parent: '/api/specify/taxon/6/',
+      rankId: 220,
+      definition: '/api/specify/taxontreedef/1/',
+      definitionItem: '/api/specify/taxontreedefitem/2/',
+    });
+
+    await taxon.businessRuleManager?.checkField('parent');
+
+    const { result } = renderHook(() =>
+      useSaveBlockers(taxon, tables.Taxon.getField('parent'))
+    );
+    expect(result.current[0]).toStrictEqual(['Bad tree structure.']);
+
+    await taxon.businessRuleManager?.checkField('integer1');
+
+    const { result: fieldChangeResult } = renderHook(() =>
+      useSaveBlockers(taxon, tables.Taxon.getField('parent'))
+    );
+    expect(fieldChangeResult.current[0]).toStrictEqual(['Bad tree structure.']);
+  });
+  test('saveBlocker not on synonymized parent w/preference', async () => {
+    const remotePrefs = await import('../../InitialContext/remotePrefs');
+    jest
+      .spyOn(remotePrefs, 'getPref')
+      .mockImplementation((key) =>
+        key === 'sp7.allow_adding_child_to_synonymized_parent.Taxon'
+          ? true
+          : getPref(key)
+      );
+
+    const taxon = new tables.Taxon.Resource({
+      name: 'dauricus',
+      parent: '/api/specify/taxon/6/',
+      rankId: 220,
+      definition: '/api/specify/taxontreedef/1/',
+      definitionItem: '/api/specify/taxontreedefitem/2/',
+    });
+
+    await taxon.businessRuleManager?.checkField('parent');
+
+    const { result } = renderHook(() =>
+      useSaveBlockers(taxon, tables.Taxon.getField('parent'))
+    );
+    expect(result.current[0]).toStrictEqual([]);
   });
 });

--- a/specifyweb/frontend/js_src/lib/components/DataModel/treeBusinessRules.ts
+++ b/specifyweb/frontend/js_src/lib/components/DataModel/treeBusinessRules.ts
@@ -41,17 +41,12 @@ export const treeBusinessRules = async (
     const doExpandSynonymActionsPref = getPref(
       `sp7.allow_adding_child_to_synonymized_parent.${resource.specifyTable.name}`
     );
-    const isSynonym = parent.get('isAccepted');
-
-    const canAddToSynonym =
-      (!doExpandSynonymActionsPref && isSynonym) ||
-      (doExpandSynonymActionsPref && !isSynonym) ||
-      isSynonym === undefined;
+    const isParentSynonym = !parent.get('isAccepted');
 
     const hasBadTreeStrcuture =
       parent.id === resource.id ||
-      !canAddToSynonym ||
       definitionItem === undefined ||
+      (isParentSynonym && !doExpandSynonymActionsPref) ||
       parent.get('rankId') >= definitionItem.get('rankId') ||
       (possibleRanks !== undefined &&
         !possibleRanks
@@ -72,6 +67,7 @@ export const treeBusinessRules = async (
       };
 
     if (
+      hasBadTreeStrcuture ||
       (resource.get('name')?.length ?? 0) === 0 ||
       definitionItem === undefined
     )

--- a/specifyweb/frontend/js_src/lib/components/DataModel/treeBusinessRules.ts
+++ b/specifyweb/frontend/js_src/lib/components/DataModel/treeBusinessRules.ts
@@ -41,12 +41,15 @@ export const treeBusinessRules = async (
     const doExpandSynonymActionsPref = getPref(
       `sp7.allow_adding_child_to_synonymized_parent.${resource.specifyTable.name}`
     );
-    const cannotAddToSynonym =
-      !parent.get('isAccepted') && !doExpandSynonymActionsPref;
+    const isSynonym = parent.get('isAccepted');
+
+    const canAddToSynonym =
+      (doExpandSynonymActionsPref === false && isSynonym === false) ||
+      (doExpandSynonymActionsPref === true && isSynonym === true);
 
     const hasBadTreeStrcuture =
       parent.id === resource.id ||
-      cannotAddToSynonym ||
+      !canAddToSynonym ||
       definitionItem === undefined ||
       parent.get('rankId') >= definitionItem.get('rankId') ||
       (possibleRanks !== undefined &&

--- a/specifyweb/frontend/js_src/lib/components/DataModel/treeBusinessRules.ts
+++ b/specifyweb/frontend/js_src/lib/components/DataModel/treeBusinessRules.ts
@@ -1,6 +1,7 @@
 import { treeText } from '../../localization/tree';
 import { ajax } from '../../utils/ajax';
 import { f } from '../../utils/functools';
+import { getPref } from '../InitialContext/remotePrefs';
 import { fetchPossibleRanks } from '../PickLists/TreeLevelPickList';
 import { formatUrl } from '../Router/queryString';
 import type { BusinessRuleResult } from './businessRules';
@@ -37,8 +38,15 @@ export const treeBusinessRules = async (
         ? undefined
         : await fetchPossibleRanks(resource, parentDefItem.get('rankId'));
 
+    const doExpandSynonymActionsPref = getPref(
+      `sp7.allow_adding_child_to_synonymized_parent.${resource.specifyTable.name}`
+    );
+    const cannotAddToSynonym =
+      parent.get('isAccepted') === false && doExpandSynonymActionsPref;
+
     const hasBadTreeStrcuture =
       parent.id === resource.id ||
+      cannotAddToSynonym ||
       definitionItem === undefined ||
       parent.get('rankId') >= definitionItem.get('rankId') ||
       (possibleRanks !== undefined &&

--- a/specifyweb/frontend/js_src/lib/components/DataModel/treeBusinessRules.ts
+++ b/specifyweb/frontend/js_src/lib/components/DataModel/treeBusinessRules.ts
@@ -41,12 +41,12 @@ export const treeBusinessRules = async (
     const doExpandSynonymActionsPref = getPref(
       `sp7.allow_adding_child_to_synonymized_parent.${resource.specifyTable.name}`
     );
-    const isNotSynonym = parent.get('isAccepted');
+    const isSynonym = parent.get('isAccepted');
 
     const canAddToSynonym =
-      (doExpandSynonymActionsPref === false && isNotSynonym === true) ||
-      (doExpandSynonymActionsPref === true && isNotSynonym === false) ||
-      isNotSynonym === undefined;
+      (doExpandSynonymActionsPref === false && isSynonym === true) ||
+      (doExpandSynonymActionsPref === true && isSynonym === false) ||
+      isSynonym === undefined;
 
     const hasBadTreeStrcuture =
       parent.id === resource.id ||

--- a/specifyweb/frontend/js_src/lib/components/DataModel/treeBusinessRules.ts
+++ b/specifyweb/frontend/js_src/lib/components/DataModel/treeBusinessRules.ts
@@ -42,7 +42,7 @@ export const treeBusinessRules = async (
       `sp7.allow_adding_child_to_synonymized_parent.${resource.specifyTable.name}`
     );
     const cannotAddToSynonym =
-      parent.get('isAccepted') === false && !doExpandSynonymActionsPref;
+      !parent.get('isAccepted') && !doExpandSynonymActionsPref;
 
     const hasBadTreeStrcuture =
       parent.id === resource.id ||

--- a/specifyweb/frontend/js_src/lib/components/DataModel/treeBusinessRules.ts
+++ b/specifyweb/frontend/js_src/lib/components/DataModel/treeBusinessRules.ts
@@ -41,12 +41,12 @@ export const treeBusinessRules = async (
     const doExpandSynonymActionsPref = getPref(
       `sp7.allow_adding_child_to_synonymized_parent.${resource.specifyTable.name}`
     );
-    const isSynonym = parent.get('isAccepted');
+    const isNotSynonym = parent.get('isAccepted');
 
     const canAddToSynonym =
-      (doExpandSynonymActionsPref === false && isSynonym === false) ||
-      (doExpandSynonymActionsPref === true && isSynonym === true) ||
-      isSynonym === undefined;
+      (doExpandSynonymActionsPref === false && isNotSynonym === true) ||
+      (doExpandSynonymActionsPref === true && isNotSynonym === false) ||
+      isNotSynonym === undefined;
 
     const hasBadTreeStrcuture =
       parent.id === resource.id ||

--- a/specifyweb/frontend/js_src/lib/components/DataModel/treeBusinessRules.ts
+++ b/specifyweb/frontend/js_src/lib/components/DataModel/treeBusinessRules.ts
@@ -42,7 +42,7 @@ export const treeBusinessRules = async (
       `sp7.allow_adding_child_to_synonymized_parent.${resource.specifyTable.name}`
     );
     const cannotAddToSynonym =
-      parent.get('isAccepted') === false && doExpandSynonymActionsPref;
+      parent.get('isAccepted') === false && !doExpandSynonymActionsPref;
 
     const hasBadTreeStrcuture =
       parent.id === resource.id ||

--- a/specifyweb/frontend/js_src/lib/components/DataModel/treeBusinessRules.ts
+++ b/specifyweb/frontend/js_src/lib/components/DataModel/treeBusinessRules.ts
@@ -44,8 +44,8 @@ export const treeBusinessRules = async (
     const isSynonym = parent.get('isAccepted');
 
     const canAddToSynonym =
-      (doExpandSynonymActionsPref === false && isSynonym === true) ||
-      (doExpandSynonymActionsPref === true && isSynonym === false) ||
+      (!doExpandSynonymActionsPref && isSynonym) ||
+      (doExpandSynonymActionsPref && !isSynonym) ||
       isSynonym === undefined;
 
     const hasBadTreeStrcuture =

--- a/specifyweb/frontend/js_src/lib/components/DataModel/treeBusinessRules.ts
+++ b/specifyweb/frontend/js_src/lib/components/DataModel/treeBusinessRules.ts
@@ -45,7 +45,8 @@ export const treeBusinessRules = async (
 
     const canAddToSynonym =
       (doExpandSynonymActionsPref === false && isSynonym === false) ||
-      (doExpandSynonymActionsPref === true && isSynonym === true);
+      (doExpandSynonymActionsPref === true && isSynonym === true) ||
+      isSynonym === undefined;
 
     const hasBadTreeStrcuture =
       parent.id === resource.id ||


### PR DESCRIPTION
Fixes #4868

### Checklist

- [ ] Self-review the PR after opening it to make sure the changes look good
      and self-explanatory (or properly documented)
- [ ] Add relevant issue to release milestone

### Testing instructions
Note: Remote Preferences should not have the line: [sp7.allow_adding_child_to_synonymized_parent.TREENAME=true](https://discourse.specifysoftware.org/t/enable-creating-children-for-synonymized-nodes/987)
If it does, set it =false or delete the line, then clear your cache.

- Go to a Synonymized node in a tree (ex: testchild-syn on Taxon https://umherb11024-edge.test.specifysystems.org/specify/tree/taxon/?conformation=%7E%7E1%7E573177%7E573193----)
- Click on Edit -> Add
- Input the synonymized node's name into Parent field, then fill in required fields (ex: testchild-syn; test)
- [ ] verify that a tree structure warning is shown and save is disabled 
