### PR TITLE
fix(FormEditor): allow condition="always"

### DIFF
--- a/specifyweb/frontend/js_src/lib/components/FormParse/index.ts
+++ b/specifyweb/frontend/js_src/lib/components/FormParse/index.ts
@@ -440,18 +440,19 @@ function parseFormTableColumns(
     }).fill(undefined),
   ];
 }
+export type FormCondition =
+  | State<
+      'Value',
+      {
+        readonly field: RA<LiteralField | Relationship>;
+        readonly value: string;
+      }
+    >
+  | State<'Always'>
+  | undefined;
 
 export type ConditionalFormDefinition = RA<{
-  readonly condition:
-    | State<
-        'Value',
-        {
-          readonly field: RA<LiteralField | Relationship>;
-          readonly value: string;
-        }
-      >
-    | State<'Always'>
-    | undefined;
+  readonly condition: FormCondition;
   readonly definition: ParsedFormDefinition;
 }>;
 


### PR DESCRIPTION
Fixes #4872



### Checklist

- [x] Self-review the PR after opening it to make sure the changes look good
      and self-explanatory (or properly documented)
- [ ] Add automated tests
- [x] Add relevant issue to release milestone

### Testing instructions

- [ ] Make sure there is no validation error for `condition="always"`
- [ ] Make sure there is no validation error for any valid field name `condition="text1=abc"`
- [ ] Make sure there are validation errors for any other values