### PR TITLE
Use table `defaulttype` for some subviews if not present on cell definition

### DIFF
--- a/specifyweb/frontend/js_src/lib/components/FormCells/index.tsx
+++ b/specifyweb/frontend/js_src/lib/components/FormCells/index.tsx
@@ -154,7 +154,7 @@ const cellRenderers: {
                   typeof viewDefinition === 'object'
                     ? resolveViewDefinition(
                         viewDefinition,
-                        viewDefinition.defaultSubviewFormType ?? formType,
+                        formType,
                         propsToFormMode(isReadOnly, isInSearchDialog)
                       )
                     : undefined

--- a/specifyweb/frontend/js_src/lib/components/FormCells/index.tsx
+++ b/specifyweb/frontend/js_src/lib/components/FormCells/index.tsx
@@ -154,7 +154,7 @@ const cellRenderers: {
                   typeof viewDefinition === 'object'
                     ? resolveViewDefinition(
                         viewDefinition,
-                        formType,
+                        viewDefinition.defaultSubviewFormType ?? formType,
                         propsToFormMode(isReadOnly, isInSearchDialog)
                       )
                     : undefined

--- a/specifyweb/frontend/js_src/lib/components/FormEditor/Create.tsx
+++ b/specifyweb/frontend/js_src/lib/components/FormEditor/Create.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { useOutletContext } from 'react-router';
 import { useNavigate } from 'react-router-dom';
 import type { LocalizedString } from 'typesafe-i18n';
+import { useAsyncState } from '../../hooks/useAsyncState';
 
 import { useBooleanState } from '../../hooks/useBooleanState';
 import { useId } from '../../hooks/useId';
@@ -192,10 +193,14 @@ export function PreviewView({
   readonly onSelect: () => void;
 }): JSX.Element {
   const resource = React.useMemo(() => new table.Resource(), [table]);
-  const viewDefinition = React.useMemo(
-    () => parseViewDefinition(view, 'form', 'edit', table),
-    [view, table]
-  );
+  const viewDefinition = useAsyncState(
+    React.useCallback(
+      async () => parseViewDefinition(view, 'form', 'edit', table),
+      [view, table]
+    ),
+    true
+  )[0];
+
   return (
     <Dialog
       buttons={

--- a/specifyweb/frontend/js_src/lib/components/FormEditor/Editor.tsx
+++ b/specifyweb/frontend/js_src/lib/components/FormEditor/Editor.tsx
@@ -295,39 +295,37 @@ function FormPreview({
     ViewDescription | undefined
   >(undefined);
   React.useEffect(() => {
-    try {
-      const parsed = parseViewDefinition(
-        {
-          altviews: {
-            [table.name]: {
-              default: 'true',
-              mode: 'edit',
-              name: '',
-              viewdef: table.name,
-            },
+    parseViewDefinition(
+      {
+        altviews: {
+          [table.name]: {
+            default: 'true',
+            mode: 'edit',
+            name: '',
+            viewdef: table.name,
           },
-          busrules: '',
-          class: table.longName,
-          name: localized(table.name),
-          view: '',
-          resourcelabels: 'true',
-          viewdefs: {
-            [table.name]: xml,
-          },
-          viewsetLevel: '',
-          viewsetName: '',
-          viewsetSource: '',
-          viewsetFile: null,
-          viewsetId: null,
         },
-        'form',
-        'edit',
-        table
-      );
-      setViewDefinition(parsed);
-    } catch {
+        busrules: '',
+        class: table.longName,
+        name: localized(table.name),
+        view: '',
+        resourcelabels: 'true',
+        viewdefs: {
+          [table.name]: xml,
+        },
+        viewsetLevel: '',
+        viewsetName: '',
+        viewsetSource: '',
+        viewsetFile: null,
+        viewsetId: null,
+      },
+      'form',
+      'edit',
+      table
+    )
+      .then((definition) => setViewDefinition(definition))
       // Ignore errors, as they would already be reported by the editor
-    }
+      .catch(() => undefined);
   }, [xml, table]);
   const resource = React.useMemo(() => new table.Resource(), [table]);
   const [layout = 'horizontal'] = useCachedState('formEditor', 'layout');

--- a/specifyweb/frontend/js_src/lib/components/FormParse/__tests__/cells.test.ts
+++ b/specifyweb/frontend/js_src/lib/components/FormParse/__tests__/cells.test.ts
@@ -363,6 +363,33 @@ describe('parseFormCell', () => {
       })
     ));
 
+  test('Subview with table defaulttype', async () =>
+    expect(
+      parseFormCell(
+        tables.CollectingEvent,
+        xml(
+          '<cell type="subview" viewname="Collectors" id="5" name="collectors" colspan="13" rows="3"/>'
+        )
+      )
+    ).resolves.toEqual(
+      cell({
+        align: 'left',
+        ariaLabel: undefined,
+        colSpan: 7,
+        fieldNames: ['collectors'],
+        formType: 'formTable',
+        icon: undefined,
+        id: '5',
+        isButton: false,
+        isCollapsed: false,
+        sortField: undefined,
+        type: 'SubView',
+        verticalAlign: 'stretch',
+        viewName: 'Collectors',
+        visible: true,
+      })
+    ));
+
   test('Panel with conditional rendering', async () =>
     expect(
       parseFormCell(

--- a/specifyweb/frontend/js_src/lib/components/FormParse/__tests__/index.test.ts
+++ b/specifyweb/frontend/js_src/lib/components/FormParse/__tests__/index.test.ts
@@ -391,10 +391,10 @@ theories(resolveAltView, [
   },
 ]);
 
-test('parseFormTableDefinition', () =>
+test('parseFormTableDefinition', async () =>
   expect(
     parseFormTableDefinition(simpleFormView, tables.CollectionObject)
-  ).toEqual(parsedFormView));
+  ).resolves.toEqual(parsedFormView));
 
 const formTableColumns = [
   { colSpan: 1 },
@@ -417,14 +417,14 @@ theories(parseFormTableColumns, {
 });
 
 describe('parseFormDefinition', () => {
-  test('single view definition', () => {
+  test('single view definition', async () => {
     jest.spyOn(console, 'warn').mockImplementation();
-    expect(
+    await expect(
       parseFormDefinition(
         toSimpleXmlNode(xmlToJson(strictParseXml(tinyFormView))),
         tables.CollectionObject
       )
-    ).toEqual([
+    ).resolves.toEqual([
       {
         condition: undefined,
         definition: parsedTinyView,

--- a/specifyweb/frontend/js_src/lib/components/FormParse/__tests__/index.test.ts
+++ b/specifyweb/frontend/js_src/lib/components/FormParse/__tests__/index.test.ts
@@ -284,6 +284,7 @@ describe('fetchView', () => {
   const expectedCollectorsView = {
     name: localized('Collectors'),
     class: 'edu.ku.brc.specify.datamodel.Collector',
+    defaultSubviewFormType: 'formTable',
     busrules: 'edu.ku.brc.specify.datamodel.busrules.CollectorBusRules',
     altviews: {
       'Collectors Table View': {
@@ -331,9 +332,9 @@ describe('fetchView', () => {
     ));
 });
 
-test('parseViewDefinition', () => {
+test('parseViewDefinition', async () => {
   jest.spyOn(console, 'warn').mockImplementation();
-  const result = parseViewDefinition(
+  const result = await parseViewDefinition(
     {
       ...viewDefinition,
       viewdefs: {
@@ -345,8 +346,8 @@ test('parseViewDefinition', () => {
     tables.CollectionObject
   )!;
   expect(result).toBeDefined();
-  expect(result.table?.name).toBe(tables.CollectionObject.name);
-  expect(removeKey(result, 'table')).toEqual({
+  expect(result!.table?.name).toBe(tables.CollectionObject.name);
+  expect(removeKey(result!, 'table')).toEqual({
     ...parsedTinyView,
     errors: [],
     name: '',
@@ -431,23 +432,25 @@ describe('parseFormDefinition', () => {
     ]);
   });
 
-  test('conditional view definitions', () => {
+  test('conditional view definitions', async () => {
     jest.spyOn(console, 'warn').mockImplementation();
-    expect(
+    await expect(
       parseFormDefinition(
         toSimpleXmlNode(xmlToJson(conditionalTinyFormView)),
         tables.CollectionObject
-      ).map(({ condition, ...rest }) => ({
-        ...rest,
-        condition:
-          condition === undefined || condition.type !== 'Value'
-            ? condition
-            : {
-                ...condition,
-                field: condition.field.map((field) => field.name),
-              },
-      }))
-    ).toEqual([
+      ).then((formDefinition) =>
+        formDefinition.map(({ condition, ...rest }) => ({
+          ...rest,
+          condition:
+            condition === undefined || condition.type !== 'Value'
+              ? condition
+              : {
+                  ...condition,
+                  field: condition.field.map((field) => field.name),
+                },
+        }))
+      )
+    ).resolves.toEqual([
       {
         condition: undefined,
         definition: parsedTinyView,

--- a/specifyweb/frontend/js_src/lib/components/FormParse/index.ts
+++ b/specifyweb/frontend/js_src/lib/components/FormParse/index.ts
@@ -83,7 +83,7 @@ export type ViewDefinition = {
    *
    * See https://github.com/specify/specify7/issues/4878
    */
-  readonly defaultSubviewFormType: FormType | undefined;
+  readonly defaultSubviewFormType?: FormType;
 };
 
 export const formTypes = ['form', 'formTable'] as const;

--- a/specifyweb/frontend/js_src/lib/components/FormParse/index.ts
+++ b/specifyweb/frontend/js_src/lib/components/FormParse/index.ts
@@ -219,12 +219,12 @@ async function correctDefaultViewDefinition(
   return view;
 }
 
-export function parseViewDefinition(
+export async function parseViewDefinition(
   view: ViewDefinition,
   defaultType: FormType,
   originalMode: FormMode,
   currentTable: SpecifyTable
-): ViewDescription | undefined {
+): Promise<ViewDescription | undefined> {
   const logContext = getLogContext();
   addContext({ view, defaultType, originalMode });
 
@@ -236,13 +236,15 @@ export function parseViewDefinition(
   const parser =
     formType === 'formTable'
       ? parseFormTableDefinition
-      : (
+      : async (
           viewDefinition: SimpleXmlNode,
           table: SpecifyTable
-        ): ParsedFormDefinition =>
-          parseFormDefinition(viewDefinition, table)[0].definition;
+        ): Promise<ParsedFormDefinition> =>
+          parseFormDefinition(viewDefinition, table).then(
+            (definition) => definition[0].definition
+          );
 
-  const [errors, parsed] = captureLogOutput(() =>
+  const [errors, parsed] = captureLogOutput(async () =>
     parser(viewDefinition, table)
   );
   setLogContext(logContext);
@@ -254,7 +256,7 @@ export function parseViewDefinition(
     viewSetId: view.viewsetId ?? undefined,
     errors,
     name: view.name,
-    ...parsed,
+    ...(await parsed),
   };
 }
 
@@ -383,11 +385,14 @@ export type ParsedFormDefinition = {
   readonly rows: RA<RA<FormCellDefinition>>;
 };
 
-function parseFormTableDefinition(
+async function parseFormTableDefinition(
   viewDefinition: SimpleXmlNode,
   table: SpecifyTable
-): ParsedFormDefinition {
-  const { rows } = parseFormDefinition(viewDefinition, table)[0].definition;
+): Promise<ParsedFormDefinition> {
+  const definition = await parseFormDefinition(viewDefinition, table);
+
+  const { rows } = definition[0].definition;
+
   const labelsForCells = Object.fromEntries(
     filterArray(
       rows
@@ -467,77 +472,82 @@ export type ConditionalFormDefinition = RA<{
   readonly definition: ParsedFormDefinition;
 }>;
 
-export function parseFormDefinition(
+export async function parseFormDefinition(
   viewDefinition: SimpleXmlNode,
   table: SpecifyTable
-): ConditionalFormDefinition {
+): Promise<ConditionalFormDefinition> {
   const rowsContainers = viewDefinition?.children?.rows ?? [];
   const context = getLogContext();
-  const definition = rowsContainers.map((rowsContainer, definitionIndex) => {
-    const context = getLogContext();
-    pushContext({
-      type: 'Root',
-      node: rowsContainer,
-      extras: { definitionIndex },
-    });
-    const directColumnDefinitions = getColumnDefinitions(rowsContainer);
-    const rows = rowsContainer?.children?.row ?? [];
-    const definition = postProcessFormDef(
-      processColumnDefinition(
-        directColumnDefinitions.length === 0
-          ? getColumnDefinitions(viewDefinition)
-          : directColumnDefinitions
-      ),
-      rows.map((row, index) => {
-        const context = getLogContext();
-        pushContext({
-          type: 'Child',
-          tagName: 'row',
-          extras: { row: index + 1 },
-        });
+  const definition = await Promise.all(
+    rowsContainers.map(async (rowsContainer, definitionIndex) => {
+      const context = getLogContext();
+      pushContext({
+        type: 'Root',
+        node: rowsContainer,
+        extras: { definitionIndex },
+      });
+      const directColumnDefinitions = getColumnDefinitions(rowsContainer);
+      const rows = rowsContainer?.children?.row ?? [];
+      const definition = postProcessFormDef(
+        processColumnDefinition(
+          directColumnDefinitions.length === 0
+            ? getColumnDefinitions(viewDefinition)
+            : directColumnDefinitions
+        ),
+        await Promise.all(
+          rows.map(async (row, index) => {
+            const context = getLogContext();
+            pushContext({
+              type: 'Child',
+              tagName: 'row',
+              extras: { row: index + 1 },
+            });
 
-        const data = row.children.cell?.map((cell, index) => {
-          const context = getLogContext();
-          pushContext({
-            type: 'Child',
-            tagName: 'cell',
-            extras: { cell: index + 1 },
-          });
+            const data = await Promise.all(
+              row.children.cell?.map(async (cell, index) => {
+                const context = getLogContext();
+                pushContext({
+                  type: 'Child',
+                  tagName: 'cell',
+                  extras: { cell: index + 1 },
+                });
+                const data = await parseFormCell(table, cell);
 
-          const data = parseFormCell(table, cell);
+                setLogContext(context);
+                return data;
+              })
+            );
+            setLogContext(context);
+            return data ?? [];
+          })
+        ),
+        table
+      );
 
-          setLogContext(context);
-          return data;
-        });
-        setLogContext(context);
-        return data ?? [];
-      }),
-      table
-    );
-
-    const condition = getParsedAttribute(rowsContainer, 'condition')?.split(
-      '='
-    );
-    if (typeof condition === 'object') {
-      if (condition.length === 1 && condition[0] === 'always')
-        return { condition: { type: 'Always' }, definition } as const;
-      const value = condition.slice(1).join('=');
-      const parsedField = table.getFields(condition[0]);
-      if (Array.isArray(parsedField)) {
-        return {
-          condition: {
-            type: 'Value',
-            field: parsedField,
-            value,
-          },
-          definition,
-        } as const;
+      const condition = getParsedAttribute(rowsContainer, 'condition')?.split(
+        '='
+      );
+      if (typeof condition === 'object') {
+        if (condition.length === 1 && condition[0] === 'always')
+          return { condition: { type: 'Always' }, definition } as const;
+        const value = condition.slice(1).join('=');
+        const parsedField = table.getFields(condition[0]);
+        if (Array.isArray(parsedField)) {
+          return {
+            condition: {
+              type: 'Value',
+              field: parsedField,
+              value,
+            },
+            definition,
+          } as const;
+        }
       }
-    }
 
-    setLogContext(context);
-    return { condition: undefined, definition };
-  });
+      setLogContext(context);
+      return { condition: undefined, definition };
+    })
+  );
 
   setLogContext(context);
   return definition;

--- a/specifyweb/frontend/js_src/lib/components/FormParse/index.ts
+++ b/specifyweb/frontend/js_src/lib/components/FormParse/index.ts
@@ -73,6 +73,17 @@ export type ViewDefinition = {
   readonly viewsetSource: string;
   readonly viewsetId: number | null;
   readonly viewsetFile: string | null;
+
+  // REFACTOR: remove this once Specify 7 gets default forms
+  /**
+   * If `defaulttype` is not specified on a subview cell, Specify assumes the
+   * subview should be rendered in 'Form' mode. However there are many default
+   * `to-many` subviews which do not specify a `defaulttype` and should be
+   * rendered as a table by default
+   *
+   * See https://github.com/specify/specify7/issues/4878
+   */
+  readonly defaultSubviewFormType: FormType | undefined;
 };
 
 export const formTypes = ['form', 'formTable'] as const;
@@ -198,6 +209,7 @@ async function correctDefaultViewDefinition(
             )
           ),
         };
+        overwriteReadOnly(view, 'defaultSubviewFormType', 'formTable');
         overwriteReadOnly(view, 'altviews', newAltViews);
         overwriteReadOnly(view, 'viewdefs', newViewDefs);
         return view;


### PR DESCRIPTION
Fixes #4878 
Related to the changes introduced in #4740 and #4776

See https://github.com/specify/specify7/issues/4878#issuecomment-2093605099

This solution is the 'messiest' I have considered for this case, but covers the most cases and theoretically a user will never encounter #4878. 

A cleaner, but more prone to users encountering the bug, solution involves implementing a hard-coded list of views which should be rendered as a table (see https://github.com/specify/specify7/commit/5c91a89e633130899af46b3446aaa282ef41920d). 

This solution runs the risk that these default views can be copied (or a similar view/viewdef can be manually created/copied) and the viewname can be changed. Thus, if the cell which renders the view does not specify a `defaulttype`, Specify will always assume that the defaulttype will be `form`. 

@specify/ux-testing, if this is not likely, then I'd vastly prefer the simpler solution until we can define default forms for Specify 7. 

(Also note currently that even if the affected view/viewdefs are copied, they can not be edited via the Visual Editor, although they _can_ be added to a ViewSet when added + saved. 
This behavior can be reproduced by attempting to copy the Collector view titled `Collectors`)

### Checklist

- [x] Self-review the PR after opening it to make sure the changes look good
      and self-explanatory (or properly documented)
- [x] Add automated tests
- [x] Add relevant issue to release milestone

### Testing instructions
- On the form for CollectingEvent, ensure there is a cell to render the `collectors` relationship as a SubView
- Use the for the `viewname` attribute, use `Collectors` and make sure the is not a `defaulttype` defined on the cell
- [ ] Open the CollectingEvent form and make sure that Collectors opens as a table
- On the CollectingEvent form, modify the `collectors` cell and add `defaulttype="form"`
- [ ] Open the CollectingEvent form and make sure that Collectors opens as a form

Example `collectors` SubView on a CollectingEvent form with no `defaulttype`:

```xml
<cell type="subview" viewname="Collectors" id="5" name="collectors" colspan="13" rows="3"/>
```
