### PR TITLE
Change unavailable prep string and filter results

### DIFF
--- a/specifyweb/frontend/js_src/lib/components/Interactions/InteractionDialog.tsx
+++ b/specifyweb/frontend/js_src/lib/components/Interactions/InteractionDialog.tsx
@@ -293,9 +293,8 @@ export function InteractionDialog({
                     {interactionsText.addUnassociated()}
                   </Button.Info>
                 ) : actionTable.name === 'Loan' &&
-                  !(
-                    state.type === 'MissingState' && prepsData?.length === 0
-                  ) ? (
+                  state.type === 'MissingState' &&
+                  prepsData?.length === 0 ? (
                   <Link.Info href={getResourceViewUrl('Loan')}>
                     {interactionsText.withoutPreparations()}
                   </Link.Info>

--- a/specifyweb/frontend/js_src/lib/components/Interactions/InteractionDialog.tsx
+++ b/specifyweb/frontend/js_src/lib/components/Interactions/InteractionDialog.tsx
@@ -153,6 +153,9 @@ export function InteractionDialog({
     const unavailablePrep = prepsData.filter(
       (prepData) => Number.parseInt(prepData[10]) === 0
     );
+    const availablePrep = prepsData.filter(
+      (prepData) => Number.parseInt(prepData[10]) > 0
+    );
     const unavailable =
       typeof entries === 'object'
         ? entries.filter((entry) =>
@@ -162,8 +165,8 @@ export function InteractionDialog({
 
     if (missing.length > 0 || unavailable.length > 0) {
       setState({ type: 'MissingState', missing, unavailableBis: unavailable });
-      setPrepsData(prepsData);
-    } else showPrepSelectDlg(prepsData);
+      setPrepsData(availablePrep);
+    } else showPrepSelectDlg(availablePrep);
   }
 
   const showPrepSelectDlg = (prepsData: RA<PreparationRow>): void =>

--- a/specifyweb/frontend/js_src/lib/localization/interactions.ts
+++ b/specifyweb/frontend/js_src/lib/localization/interactions.ts
@@ -43,14 +43,8 @@ export const interactionsText = createDictionary({
     'uk-ua': 'Не знайдено жодних препаратів для таких записів:',
   },
   preparationsNotAvailableFor: {
-    'en-us': 'No preparations are available for the following records:',
-    'de-ch': 'Für folgende Datensätze sind keine Vorbereitungen verfügbar:',
-    'es-es': 'No se encontraron preparativos para los siguientes registros:',
-    'fr-fr': `
-      Aucune préparation n'est disponible pour les enregistrements suivants :
-    `,
-    'ru-ru': 'Для следующих записей подготовка невозможна:',
-    'uk-ua': 'Продовжити',
+    'en-us':
+      'No preparations are available for at least one type of preparation in the following records:',
   },
   problemsFound: {
     'en-us': 'There are problems with the entry:',


### PR DESCRIPTION
Fixes #4483 

### Checklist

- [x] Self-review the PR after opening it to make sure the changes look good
      and self-explanatory (or properly documented)
- [x] Add relevant issue to release milestone

### Testing instructions

- go in interactions
- click on loan 
- choose by cat # 
- enter a cat # that has some prep type unavailable 
- verify that the warning string is now "No preparations are available for at least one type of preparation in the following records:"

