### PR TITLE
Disable save and delete buttons in QCBX overlay in app resources

### DIFF
--- a/specifyweb/frontend/js_src/lib/components/FormEditor/Create.tsx
+++ b/specifyweb/frontend/js_src/lib/components/FormEditor/Create.tsx
@@ -2,8 +2,8 @@ import React from 'react';
 import { useOutletContext } from 'react-router';
 import { useNavigate } from 'react-router-dom';
 import type { LocalizedString } from 'typesafe-i18n';
-import { useAsyncState } from '../../hooks/useAsyncState';
 
+import { useAsyncState } from '../../hooks/useAsyncState';
 import { useBooleanState } from '../../hooks/useBooleanState';
 import { useId } from '../../hooks/useId';
 import { commonText } from '../../localization/common';

--- a/specifyweb/frontend/js_src/lib/components/Forms/ResourceView.tsx
+++ b/specifyweb/frontend/js_src/lib/components/Forms/ResourceView.tsx
@@ -17,6 +17,7 @@ import type { AnySchema } from '../DataModel/helperTypes';
 import type { SpecifyResource } from '../DataModel/legacyTypes';
 import type { Tables } from '../DataModel/types';
 import { ErrorBoundary } from '../Errors/ErrorBoundary';
+import { InFormEditorContext } from '../FormEditor/Context';
 import { AppTitle } from '../Molecules/AppTitle';
 import { Dialog, dialogClassNames } from '../Molecules/Dialog';
 import { IsNotReadOnly } from '../Molecules/ResourceLink';
@@ -28,7 +29,6 @@ import { useResourceView } from './BaseResourceView';
 import { DeleteButton } from './DeleteButton';
 import { SaveButton } from './Save';
 import { propsToFormMode } from './useViewDefinition';
-import { InFormEditorContext } from '../FormEditor/Context';
 
 /**
  * There is special behavior required when creating one of these resources,

--- a/specifyweb/frontend/js_src/lib/components/Forms/ResourceView.tsx
+++ b/specifyweb/frontend/js_src/lib/components/Forms/ResourceView.tsx
@@ -28,6 +28,7 @@ import { useResourceView } from './BaseResourceView';
 import { DeleteButton } from './DeleteButton';
 import { SaveButton } from './Save';
 import { propsToFormMode } from './useViewDefinition';
+import { InFormEditorContext } from '../FormEditor/Context';
 
 /**
  * There is special behavior required when creating one of these resources,
@@ -162,6 +163,8 @@ export function ResourceView<SCHEMA extends AnySchema>({
     resource?.specifyTable.name
   );
   const isInSearchDialog = React.useContext(SearchDialogContext);
+  const isInFormEditor = React.useContext(InFormEditorContext);
+
   const {
     formElement,
     formPreferences,
@@ -247,7 +250,8 @@ export function ResourceView<SCHEMA extends AnySchema>({
     !isSubForm &&
     typeof resource === 'object' &&
     !resource.isNew() &&
-    hasTablePermission(resource.specifyTable.name, 'delete') ? (
+    hasTablePermission(resource.specifyTable.name, 'delete') &&
+    !isInFormEditor ? (
       <ErrorBoundary dismissible>
         <DeleteButton
           deletionMessage={deletionMessage}

--- a/specifyweb/frontend/js_src/lib/components/Forms/Save.tsx
+++ b/specifyweb/frontend/js_src/lib/components/Forms/Save.tsx
@@ -31,6 +31,7 @@ import { userPreferences } from '../Preferences/userPreferences';
 import { generateMappingPathPreview } from '../WbPlanView/mappingPreview';
 import { FormContext } from './BaseResourceView';
 import { FORBID_ADDING, NO_CLONE } from './ResourceView';
+import { useLocation } from 'react-router-dom';
 
 export const saveFormUnloadProtect = formsText.unsavedFormUnloadProtect();
 
@@ -107,8 +108,14 @@ export function SaveButton<SCHEMA extends AnySchema = AnySchema>({
   const canUpdate = hasTablePermission(resource.specifyTable.name, 'update');
   const canSave = resource.isNew() ? canCreate : canUpdate;
 
+  const location = useLocation();
+  const currentUrl = location.pathname;
+  const isInViewSet = currentUrl.includes('view-set');
+  const saveNotAllowed = isInViewSet && handleAdd === undefined;
+
   const isSaveDisabled =
     disabled ||
+    saveNotAllowed ||
     isSaving ||
     !canSave ||
     (!saveRequired &&

--- a/specifyweb/frontend/js_src/lib/components/Forms/Save.tsx
+++ b/specifyweb/frontend/js_src/lib/components/Forms/Save.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { useLocation } from 'react-router-dom';
 import type { LocalizedString } from 'typesafe-i18n';
 
 import { useUnloadProtect } from '../../hooks/navigation';

--- a/specifyweb/frontend/js_src/lib/components/Forms/Save.tsx
+++ b/specifyweb/frontend/js_src/lib/components/Forms/Save.tsx
@@ -32,6 +32,7 @@ import { userPreferences } from '../Preferences/userPreferences';
 import { generateMappingPathPreview } from '../WbPlanView/mappingPreview';
 import { FormContext } from './BaseResourceView';
 import { FORBID_ADDING, NO_CLONE } from './ResourceView';
+import { InFormEditorContext } from '../FormEditor/Context';
 
 export const saveFormUnloadProtect = formsText.unsavedFormUnloadProtect();
 
@@ -108,14 +109,11 @@ export function SaveButton<SCHEMA extends AnySchema = AnySchema>({
   const canUpdate = hasTablePermission(resource.specifyTable.name, 'update');
   const canSave = resource.isNew() ? canCreate : canUpdate;
 
-  const location = useLocation();
-  const currentUrl = location.pathname;
-  const isInViewSet = currentUrl.includes('view-set');
-  const saveNotAllowed = isInViewSet && handleAdd === undefined;
+  const isInFormEditor = React.useContext(InFormEditorContext);
 
   const isSaveDisabled =
     disabled ||
-    saveNotAllowed ||
+    isInFormEditor ||
     isSaving ||
     !canSave ||
     (!saveRequired &&

--- a/specifyweb/frontend/js_src/lib/components/Forms/Save.tsx
+++ b/specifyweb/frontend/js_src/lib/components/Forms/Save.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { useLocation } from 'react-router-dom';
 import type { LocalizedString } from 'typesafe-i18n';
 
 import { useUnloadProtect } from '../../hooks/navigation';
@@ -31,7 +32,6 @@ import { userPreferences } from '../Preferences/userPreferences';
 import { generateMappingPathPreview } from '../WbPlanView/mappingPreview';
 import { FormContext } from './BaseResourceView';
 import { FORBID_ADDING, NO_CLONE } from './ResourceView';
-import { useLocation } from 'react-router-dom';
 
 export const saveFormUnloadProtect = formsText.unsavedFormUnloadProtect();
 

--- a/specifyweb/frontend/js_src/lib/components/Forms/Save.tsx
+++ b/specifyweb/frontend/js_src/lib/components/Forms/Save.tsx
@@ -25,13 +25,13 @@ import type { LiteralField, Relationship } from '../DataModel/specifyField';
 import type { Tables } from '../DataModel/types';
 import { error } from '../Errors/assert';
 import { errorHandledBy } from '../Errors/FormatError';
+import { InFormEditorContext } from '../FormEditor/Context';
 import { Dialog } from '../Molecules/Dialog';
 import { hasTablePermission } from '../Permissions/helpers';
 import { userPreferences } from '../Preferences/userPreferences';
 import { generateMappingPathPreview } from '../WbPlanView/mappingPreview';
 import { FormContext } from './BaseResourceView';
 import { FORBID_ADDING, NO_CLONE } from './ResourceView';
-import { InFormEditorContext } from '../FormEditor/Context';
 
 export const saveFormUnloadProtect = formsText.unsavedFormUnloadProtect();
 


### PR DESCRIPTION
Fixes #4886

### Checklist

- [ ] Self-review the PR after opening it to make sure the changes look good
      and self-explanatory (or properly documented)
- [ ] Add relevant issue to release milestone

### Testing instructions

- Go to app resources -> form definition
- Click on any table with a query combo box in the form (e.g. collection object with the accession qcbx)
- In visual editor click the add button for the query combo box
- Fill out some information in the form
- [ ] verify save button is disabled 
- [ ] verify there is no delete button 
