### PR TITLE
Modify ResourceSelector to use existing resource instance

### DIFF
--- a/specifyweb/frontend/js_src/lib/components/FormSliders/IntegratedRecordSelector.tsx
+++ b/specifyweb/frontend/js_src/lib/components/FormSliders/IntegratedRecordSelector.tsx
@@ -252,7 +252,7 @@ export function IntegratedRecordSelector({
                 viewName={viewName}
                 onAdd={(resources): void => {
                   if (!isInteraction) collection.add(resources);
-                  if (typeof handleAdd === 'function') handleAdd(resources);
+                  handleAdd?.(resources);
                 }}
                 onClose={handleClose}
                 onDelete={(_resource, index): void => {

--- a/specifyweb/frontend/js_src/lib/components/FormSliders/IntegratedRecordSelector.tsx
+++ b/specifyweb/frontend/js_src/lib/components/FormSliders/IntegratedRecordSelector.tsx
@@ -77,6 +77,9 @@ export function IntegratedRecordSelector({
     if (hasBlockers && isCollapsed) handleExpand();
   }, [hasBlockers, isCollapsed, handleExpand]);
 
+  const [interactionResource, setInteractionResource] =
+    React.useState<SpecifyResource<AnySchema>>();
+
   const collapsibleButton = (
     <Button.Icon
       disabled={hasBlockers}
@@ -116,11 +119,14 @@ export function IntegratedRecordSelector({
         collection={collection}
         defaultIndex={isToOne ? 0 : index}
         relationship={relationship}
-        onAdd={(resource) => {
-          if (isInteraction) handleOpenDialog();
+        onAdd={(resources) => {
+          if (isInteraction) {
+            setInteractionResource(resources[0]);
+            handleOpenDialog();
+          }
           if (!isInteraction && formType !== 'formTable')
-            collection.add(resource);
-          handleAdding(resource);
+            collection.add(resources);
+          handleAdding(resources);
         }}
         onDelete={(...args): void => {
           if (isCollapsed) handleExpand();
@@ -146,6 +152,7 @@ export function IntegratedRecordSelector({
             isDialogOpen ? (
               <InteractionDialog
                 actionTable={collection.related.specifyTable}
+                interactionResource={interactionResource}
                 itemCollection={
                   collection as Collection<
                     DisposalPreparation | GiftPreparation | LoanPreparation

--- a/specifyweb/frontend/js_src/lib/components/FormSliders/IntegratedRecordSelector.tsx
+++ b/specifyweb/frontend/js_src/lib/components/FormSliders/IntegratedRecordSelector.tsx
@@ -180,7 +180,9 @@ export function IntegratedRecordSelector({
                         }
                         onClick={(): void => {
                           focusFirstField();
-                          handleAdd();
+                          const resource =
+                            new collection.table.specifyTable.Resource();
+                          handleAdd([resource]);
                         }}
                       />
                     ) : undefined}
@@ -243,7 +245,7 @@ export function IntegratedRecordSelector({
                 viewName={viewName}
                 onAdd={(resources): void => {
                   if (!isInteraction) collection.add(resources);
-                  if (typeof handleAdd === 'function') handleAdd();
+                  if (typeof handleAdd === 'function') handleAdd(resources);
                 }}
                 onClose={handleClose}
                 onDelete={(_resource, index): void => {

--- a/specifyweb/frontend/js_src/lib/components/FormSliders/RecordSelector.tsx
+++ b/specifyweb/frontend/js_src/lib/components/FormSliders/RecordSelector.tsx
@@ -49,7 +49,9 @@ export type RecordSelectorState<SCHEMA extends AnySchema> = {
   // Use this to render <ResourceView>
   readonly resource: SpecifyResource<SCHEMA> | undefined;
   // Set this as an "Add" button event listener
-  readonly onAdd: (() => void) | undefined;
+  readonly onAdd:
+    | ((resources: RA<SpecifyResource<SCHEMA>>) => void)
+    | undefined;
   // Set this as an "Remove" button event listener
   readonly onRemove:
     | ((source: 'deleteButton' | 'minusButton') => void)
@@ -123,9 +125,9 @@ export function useRecordSelector<SCHEMA extends AnySchema>({
       ) : null,
     onAdd:
       typeof handleAdded === 'function'
-        ? (): void => {
+        ? (resources: RA<SpecifyResource<SCHEMA>>): void => {
             if (typeof relatedResource === 'object') {
-              const resource = new table.Resource();
+              const resource = resources[0];
               if (
                 typeof field?.otherSideName === 'string' &&
                 !relatedResource.isNew()

--- a/specifyweb/frontend/js_src/lib/components/FormSliders/RecordSelectorFromIds.tsx
+++ b/specifyweb/frontend/js_src/lib/components/FormSliders/RecordSelectorFromIds.tsx
@@ -206,7 +206,10 @@ export function RecordSelectorFromIds<SCHEMA extends AnySchema>({
                   aria-label={addLabel}
                   disabled={isReadOnly}
                   title={addLabel}
-                  onClick={handleAdding}
+                  onClick={() => {
+                    const resource = new table.Resource();
+                    handleAdding([resource]);
+                  }}
                 />
               ) : undefined}
               {typeof handleRemove === 'function' && canRemove ? (

--- a/specifyweb/frontend/js_src/lib/components/Interactions/InteractionDialog.tsx
+++ b/specifyweb/frontend/js_src/lib/components/Interactions/InteractionDialog.tsx
@@ -215,6 +215,14 @@ export function InteractionDialog({
     return parsed;
   }
 
+  const addInteractionResource = (): void => {
+    itemCollection?.add(
+      (interactionResource as SpecifyResource<
+        DisposalPreparation | GiftPreparation | LoanPreparation
+      >) ?? new itemCollection.table.specifyTable.Resource()
+    );
+  }
+
   return state.type === 'LoanReturnDoneState' ? (
     <Dialog
       buttons={commonText.close()}
@@ -245,11 +253,7 @@ export function InteractionDialog({
             {typeof itemCollection === 'object' ? (
               <Button.Info
                 onClick={(): void => {
-                  itemCollection?.add(
-                    (interactionResource as SpecifyResource<
-                      DisposalPreparation | GiftPreparation | LoanPreparation
-                    >) ?? new itemCollection.table.specifyTable.Resource()
-                  );
+                  addInteractionResource();
                   handleClose();
                 }}
               >
@@ -286,13 +290,7 @@ export function InteractionDialog({
                 {typeof itemCollection === 'object' ? (
                   <Button.Info
                     onClick={(): void => {
-                      itemCollection?.add(
-                        (interactionResource as SpecifyResource<
-                          | DisposalPreparation
-                          | GiftPreparation
-                          | LoanPreparation
-                        >) ?? new itemCollection.table.specifyTable.Resource()
-                      );
+                      addInteractionResource();
                       handleClose();
                     }}
                   >

--- a/specifyweb/frontend/js_src/lib/components/Interactions/InteractionDialog.tsx
+++ b/specifyweb/frontend/js_src/lib/components/Interactions/InteractionDialog.tsx
@@ -25,7 +25,8 @@ import { H3 } from '../Atoms';
 import { Button } from '../Atoms/Button';
 import { Link } from '../Atoms/Link';
 import { LoadingContext, ReadOnlyContext } from '../Core/Contexts';
-import type { SerializedResource } from '../DataModel/helperTypes';
+import type { AnySchema, SerializedResource } from '../DataModel/helperTypes';
+import type { SpecifyResource } from '../DataModel/legacyTypes';
 import { getResourceViewUrl } from '../DataModel/resource';
 import type { LiteralField } from '../DataModel/specifyField';
 import type { Collection, SpecifyTable } from '../DataModel/specifyTable';
@@ -53,6 +54,7 @@ export function InteractionDialog({
   actionTable,
   isLoanReturn = false,
   itemCollection,
+  interactionResource,
 }: {
   readonly onClose: () => void;
   readonly actionTable: SpecifyTable;
@@ -60,6 +62,7 @@ export function InteractionDialog({
   readonly itemCollection?: Collection<
     DisposalPreparation | GiftPreparation | LoanPreparation
   >;
+  readonly interactionResource?: SpecifyResource<AnySchema>;
 }): JSX.Element {
   const itemTable = isLoanReturn ? tables.Loan : tables.CollectionObject;
   const searchField = itemTable.strictGetLiteralField(
@@ -243,7 +246,9 @@ export function InteractionDialog({
               <Button.Info
                 onClick={(): void => {
                   itemCollection?.add(
-                    new itemCollection.table.specifyTable.Resource()
+                    (interactionResource as SpecifyResource<
+                      DisposalPreparation | GiftPreparation | LoanPreparation
+                    >) ?? new itemCollection.table.specifyTable.Resource()
                   );
                   handleClose();
                 }}
@@ -282,7 +287,11 @@ export function InteractionDialog({
                   <Button.Info
                     onClick={(): void => {
                       itemCollection?.add(
-                        new itemCollection.table.specifyTable.Resource()
+                        (interactionResource as SpecifyResource<
+                          | DisposalPreparation
+                          | GiftPreparation
+                          | LoanPreparation
+                        >) ?? new itemCollection.table.specifyTable.Resource()
                       );
                       handleClose();
                     }}

--- a/specifyweb/frontend/js_src/lib/components/Interactions/InteractionDialog.tsx
+++ b/specifyweb/frontend/js_src/lib/components/Interactions/InteractionDialog.tsx
@@ -221,7 +221,7 @@ export function InteractionDialog({
         DisposalPreparation | GiftPreparation | LoanPreparation
       >) ?? new itemCollection.table.specifyTable.Resource()
     );
-  }
+  };
 
   return state.type === 'LoanReturnDoneState' ? (
     <Dialog


### PR DESCRIPTION
Fixes #4865 

When adding a form table subview, 2 resources were being created. 

First one in `FormTable.tsx`: https://github.com/specify/specify7/blob/907d1524cfbc56380fc038b0f7a3663e7ff46576/specifyweb/frontend/js_src/lib/components/FormCells/FormTable.tsx#L458-L459

Which gets set as an expanded record and gets passed up the parent chain:
https://github.com/specify/specify7/blob/907d1524cfbc56380fc038b0f7a3663e7ff46576/specifyweb/frontend/js_src/lib/components/FormCells/FormTable.tsx#L125-L132

But that resource instance gets lost in `RecordSelector.tsx`, which creates a new resource that does not get added to expandedRecords and gets passed all the way up to `SubView.tsx`
https://github.com/specify/specify7/blob/907d1524cfbc56380fc038b0f7a3663e7ff46576/specifyweb/frontend/js_src/lib/components/FormSliders/RecordSelector.tsx#L128-L134

My change ensures RecordSelector uses the resource initialized by a child component.


### Checklist

- [x] Self-review the PR after opening it to make sure the changes look good
      and self-explanatory (or properly documented)
- [ ] Add automated tests
- [x] Add relevant issue to release milestone

### Testing instructions

**For to-one relations**:
- Use a Paleo database
- Go to Data Entry -> Collection Object
- Add a PaleoContext
  - [ ] Verify the PaleoContext subview is not collapsed by default
  - [ ] Verify data can be saved in the subview and persists on refresh
- [ ] Additionally, verify other subviews in the form still work like they used to

**For interactions**:
- Click on Interactions -> Gift
- Add a gift preparation 
- Click on add unassociated item
  - [ ] Verify subview is not collapsed by default
- Add another gift preparation by using a record set with no preparations
  - [ ] Verify subview is not collapsed by default

<!-- What are the steps to verify the fixes/changes in this PR? -->
<!-- Can part of that be replaced by automated tests? -->
