### PR TITLE
Remove cloning option from certain resources

### DIFF
--- a/specifyweb/frontend/js_src/lib/components/Forms/Save.tsx
+++ b/specifyweb/frontend/js_src/lib/components/Forms/Save.tsx
@@ -10,6 +10,7 @@ import { formsText } from '../../localization/forms';
 import { smoothScroll } from '../../utils/dom';
 import { listen } from '../../utils/events';
 import { replaceKey } from '../../utils/utils';
+import { appResourceSubTypes } from '../AppResources/types';
 import { Button } from '../Atoms/Button';
 import { className } from '../Atoms/className';
 import { Submit } from '../Atoms/Submit';
@@ -31,7 +32,6 @@ import { userPreferences } from '../Preferences/userPreferences';
 import { generateMappingPathPreview } from '../WbPlanView/mappingPreview';
 import { FormContext } from './BaseResourceView';
 import { FORBID_ADDING, NO_CLONE } from './ResourceView';
-import { appResourceSubTypes } from '../AppResources/types';
 
 export const saveFormUnloadProtect = formsText.unsavedFormUnloadProtect();
 

--- a/specifyweb/frontend/js_src/lib/components/Forms/Save.tsx
+++ b/specifyweb/frontend/js_src/lib/components/Forms/Save.tsx
@@ -34,6 +34,21 @@ import { FORBID_ADDING, NO_CLONE } from './ResourceView';
 
 export const saveFormUnloadProtect = formsText.unsavedFormUnloadProtect();
 
+const resourcesToNotClone = new Set([
+  'TypeSearches',
+  'WebLinks',
+  'DataObjFormatters',
+  'UIFormatters',
+  'QueryFreqList',
+  'QueryExtraList',
+  'DataEntryTaskInit',
+  'InteractionsTaskInit',
+  'UserPreferences',
+  'CollectionPreferences',
+  'ExpressSearchConfig',
+  'leaflet-layers',
+]);
+
 /*
  * REFACTOR: move this logic into ResourceView, so that <form> and button is
  *   defined in the same place
@@ -192,6 +207,8 @@ export function SaveButton<SCHEMA extends AnySchema = AnySchema>({
   // Don't allow cloning the resource if it changed
   const isChanged = saveRequired || externalSaveRequired;
 
+  const cannotClone = resourcesToNotClone.has(resource.get('name') || '');
+
   const copyButton = (
     label: LocalizedString,
     description: LocalizedString,
@@ -215,12 +232,13 @@ export function SaveButton<SCHEMA extends AnySchema = AnySchema>({
     <>
       {typeof handleAdd === 'function' && canCreate ? (
         <>
-          {showClone &&
-            copyButton(
-              formsText.clone(),
-              formsText.cloneDescription(),
-              async () => resource.clone(true)
-            )}
+          {showClone && !cannotClone
+            ? copyButton(
+                formsText.clone(),
+                formsText.cloneDescription(),
+                async () => resource.clone(true)
+              )
+            : undefined}
           {showCarry &&
             copyButton(
               formsText.carryForward(),

--- a/specifyweb/frontend/js_src/lib/components/Forms/Save.tsx
+++ b/specifyweb/frontend/js_src/lib/components/Forms/Save.tsx
@@ -9,6 +9,7 @@ import { commonText } from '../../localization/common';
 import { formsText } from '../../localization/forms';
 import { smoothScroll } from '../../utils/dom';
 import { listen } from '../../utils/events';
+import { filterArray } from '../../utils/types';
 import { replaceKey } from '../../utils/utils';
 import { appResourceSubTypes } from '../AppResources/types';
 import { Button } from '../Atoms/Button';
@@ -31,7 +32,6 @@ import { userPreferences } from '../Preferences/userPreferences';
 import { generateMappingPathPreview } from '../WbPlanView/mappingPreview';
 import { FormContext } from './BaseResourceView';
 import { FORBID_ADDING, NO_CLONE } from './ResourceView';
-import { filterArray } from '../../utils/types';
 
 export const saveFormUnloadProtect = formsText.unsavedFormUnloadProtect();
 


### PR DESCRIPTION
Fixes #4809

### Checklist

- [ ] Self-review the PR after opening it to make sure the changes look good
      and self-explanatory (or properly documented)
- [ ] Add relevant issue to release milestone

### Testing instructions

- Go to app resource
- Click on any resource with a visual editor (e.g. web links)
- [ ] Verify that there is no clone option for: 

- TypeSearches
- WebLinks
- DataObjFormatters
- UIFormatters
- DataEntryTaskInit
- InteractionsTaskInit
- UserPreferences
- CollectionPreferences
- ExpressSearchConfig
- leaflet-layers