### PR TITLE
Add a view button by default to parent taxon QCBX

### DIFF
--- a/specifyweb/frontend/js_src/lib/components/FormParse/fields.ts
+++ b/specifyweb/frontend/js_src/lib/components/FormParse/fields.ts
@@ -212,18 +212,23 @@ const processFieldType: {
       maxLength: f.parseInt(getProperty('maxLength')),
     };
   },
-  QueryComboBox({ getProperty, fields }) {
+  QueryComboBox({ getProperty, fields, table, cell }) {
     if (fields === undefined) {
       console.error('Trying to render a query combobox without a field name');
       return { type: 'Blank' };
     } else if (fields.at(-1)?.isRelationship === true) {
+      const isParentTaxon =
+        table.name === 'Taxon' && cell.attributes.name === 'parent';
       return {
         type: 'QueryComboBox',
         hasCloneButton: getProperty('cloneBtn')?.toLowerCase() === 'true',
         hasNewButton: getProperty('newBtn')?.toLowerCase() !== 'false',
         hasSearchButton: getProperty('searchBtn')?.toLowerCase() !== 'false',
         hasEditButton: getProperty('editBtn')?.toLowerCase() !== 'false',
-        hasViewButton: getProperty('viewBtn')?.toLowerCase() === 'true',
+        hasViewButton:
+          getProperty('viewBtn') === undefined && isParentTaxon
+            ? true
+            : getProperty('viewBtn')?.toLowerCase() === 'true',
         typeSearch: getProperty('name'),
         searchView: getProperty('searchView'),
       };

--- a/specifyweb/frontend/js_src/lib/components/FormParse/fields.ts
+++ b/specifyweb/frontend/js_src/lib/components/FormParse/fields.ts
@@ -212,13 +212,11 @@ const processFieldType: {
       maxLength: f.parseInt(getProperty('maxLength')),
     };
   },
-  QueryComboBox({ getProperty, fields, table, cell }) {
+  QueryComboBox({ getProperty, fields }) {
     if (fields === undefined) {
       console.error('Trying to render a query combobox without a field name');
       return { type: 'Blank' };
     } else if (fields.at(-1)?.isRelationship === true) {
-      const isParentTaxon =
-        table.name === 'Taxon' && cell.attributes.name === 'parent';
       return {
         type: 'QueryComboBox',
         hasCloneButton: getProperty('cloneBtn')?.toLowerCase() === 'true',
@@ -226,7 +224,8 @@ const processFieldType: {
         hasSearchButton: getProperty('searchBtn')?.toLowerCase() !== 'false',
         hasEditButton: getProperty('editBtn')?.toLowerCase() !== 'false',
         hasViewButton:
-          getProperty('viewBtn') === undefined && isParentTaxon
+          getProperty('viewBtn') === undefined &&
+          getProperty('editBtn')?.toLowerCase() === 'false'
             ? true
             : getProperty('viewBtn')?.toLowerCase() === 'true',
         typeSearch: getProperty('name'),


### PR DESCRIPTION
Fixes #4895

### Checklist

- [x] Self-review the PR after opening it to make sure the changes look good
      and self-explanatory (or properly documented)
- [x] Add relevant issue to release milestone

### Testing instructions

- in a taxon data entry form: 
- [ ] Verify that there is a view button next to the parent QCBX when the form def has the attribute initialize="editbtn=false" and no viewBtn=... 
- [ ] Verify that there is a view button next to the parent QCBX when the form def has the attribute initialize="editbtn=false" and viewBtn=true
- [ ] Verify that there is a view button next to the parent QCBX when the form def has the attribute initialize="editbtn=true" and viewBtn=true
- [ ] Verify that there is not a view button next to the parent QCBX when the form def has the attribute initialize="editbtn=true" and no viewBtn=...   
- [ ] Verify that there is not a view button next to the parent QCBX when the form def has the attribute initialize="editbtn=true" and viewBtn=false 

- [ ] can be verified too for other tables and QCBX fields 

<cell type="label" labelfor="parent"/>
<cell type="field" id="parent" uitype="querycbx" isrequired="true" initialize="name=Taxon;title=Taxon;editbtn=true;newbtn=false;editoncreate=true;" name="parent" colspan="3"/>

<cell type="label" labelfor="parent"/>
<cell type="field" id="parent" uitype="querycbx" isrequired="true" initialize="name=Taxon;title=Taxon;editbtn=true;newbtn=false;editoncreate=true;viewBtn=true" name="parent" colspan="3"/>
