### PR TITLE
Handle case when `row` element contains no children

### DIFF
--- a/specifyweb/frontend/js_src/lib/components/FormParse/__tests__/index.test.ts
+++ b/specifyweb/frontend/js_src/lib/components/FormParse/__tests__/index.test.ts
@@ -30,6 +30,7 @@ const {
   parseFormTableColumns,
   getColumnDefinitions,
   getColumnDefinition,
+  parseRows,
 } = exportsForTests;
 
 requireContext();
@@ -529,3 +530,105 @@ theories(getColumnDefinition, [
     out: 'B',
   },
 ]);
+
+const testRows = `
+<viewdef>
+<rows>
+  <row>
+    <cell type="label" labelFor="tt" label="test" />
+  </row> 
+  <row>
+    <cell type="field" name=" stationFieldNumber " uiType="text" colSpan="4" align="right" id="tt" />
+    <cell type="field" name="collectingTrip.text1" uiType="checkbox" label="2" colSpan="1" align="right" />
+  </row> 
+  <row>
+  </row>
+  <row>
+    <cell type="subview" id="dt" viewname="Collectors" name="collectors"/>
+  </row>
+</rows>
+</viewdef>`;
+
+test('parseRows', async () => {
+  const viewDef = xml(testRows);
+  const rowsContainer = viewDef.children.rows[0];
+  const rawRows = rowsContainer?.children?.row ?? [];
+
+  await expect(parseRows(rawRows, tables.CollectingEvent)).resolves.toEqual([
+    [
+      {
+        align: 'right',
+        ariaLabel: undefined,
+        colSpan: 1,
+        fieldNames: undefined,
+        id: undefined,
+        labelForCellId: 'tt',
+        text: 'test',
+        title: undefined,
+        type: 'Label',
+        verticalAlign: 'center',
+        visible: true,
+      },
+    ],
+    [
+      {
+        align: 'left',
+        ariaLabel: undefined,
+        colSpan: 2,
+        fieldDefinition: {
+          defaultValue: undefined,
+          isReadOnly: false,
+          max: undefined,
+          maxLength: undefined,
+          min: undefined,
+          minLength: undefined,
+          step: undefined,
+          type: 'Text',
+        },
+        fieldNames: ['stationFieldNumber'],
+        id: 'tt',
+        isRequired: false,
+        type: 'Field',
+        verticalAlign: 'center',
+        visible: true,
+      },
+      {
+        align: 'left',
+        ariaLabel: undefined,
+        colSpan: 1,
+        fieldDefinition: {
+          defaultValue: undefined,
+          isReadOnly: false,
+          label: '2',
+          printOnSave: false,
+          type: 'Checkbox',
+        },
+        fieldNames: ['collectingTrip', 'text1'],
+        id: undefined,
+        isRequired: false,
+        type: 'Field',
+        verticalAlign: 'center',
+        visible: true,
+      },
+    ],
+    [],
+    [
+      {
+        align: 'left',
+        ariaLabel: undefined,
+        colSpan: 1,
+        fieldNames: ['collectors'],
+        formType: 'formTable',
+        icon: undefined,
+        id: 'dt',
+        isButton: false,
+        isCollapsed: false,
+        sortField: undefined,
+        type: 'SubView',
+        verticalAlign: 'stretch',
+        viewName: 'Collectors',
+        visible: true,
+      },
+    ],
+  ]);
+});

--- a/specifyweb/frontend/js_src/lib/components/FormParse/index.ts
+++ b/specifyweb/frontend/js_src/lib/components/FormParse/index.ts
@@ -585,4 +585,5 @@ export const exportsForTests = {
   parseFormTableColumns,
   getColumnDefinitions,
   getColumnDefinition,
+  parseRows,
 };

--- a/specifyweb/frontend/js_src/lib/components/FormParse/index.ts
+++ b/specifyweb/frontend/js_src/lib/components/FormParse/index.ts
@@ -494,33 +494,7 @@ export async function parseFormDefinition(
             ? getColumnDefinitions(viewDefinition)
             : directColumnDefinitions
         ),
-        await Promise.all(
-          rows.map(async (row, index) => {
-            const context = getLogContext();
-            pushContext({
-              type: 'Child',
-              tagName: 'row',
-              extras: { row: index + 1 },
-            });
-
-            const data = await Promise.all(
-              row.children.cell?.map(async (cell, index) => {
-                const context = getLogContext();
-                pushContext({
-                  type: 'Child',
-                  tagName: 'cell',
-                  extras: { cell: index + 1 },
-                });
-                const data = await parseFormCell(table, cell);
-
-                setLogContext(context);
-                return data;
-              })
-            );
-            setLogContext(context);
-            return data ?? [];
-          })
-        ),
+        await parseRows(rows, table),
         table
       );
 
@@ -570,6 +544,38 @@ const getColumnDefinition = (
   viewDefinition.children.columnDef?.find((child) =>
     typeof os === 'string' ? getParsedAttribute(child, 'os') === os : true
   )?.text;
+
+const parseRows = async (
+  rawRows: RA<SimpleXmlNode>,
+  table: SpecifyTable
+): Promise<RA<RA<FormCellDefinition>>> =>
+  Promise.all(
+    rawRows.map(async (row, index) => {
+      const context = getLogContext();
+      pushContext({
+        type: 'Child',
+        tagName: 'row',
+        extras: { row: index + 1 },
+      });
+
+      const data = await Promise.all(
+        (row.children.cell ?? []).map(async (cell, index) => {
+          const context = getLogContext();
+          pushContext({
+            type: 'Child',
+            tagName: 'cell',
+            extras: { cell: index + 1 },
+          });
+          const data = await parseFormCell(table, cell);
+
+          setLogContext(context);
+          return data;
+        })
+      );
+      setLogContext(context);
+      return data ?? [];
+    })
+  );
 
 export const exportsForTests = {
   views,


### PR DESCRIPTION
Fixes #4910

Caused by the changes in #4888

### Checklist

- [x] Self-review the PR after opening it to make sure the changes look good
      and self-explanatory (or properly documented)
- [ ] Add automated tests
- [ ] Add relevant issue to release milestone

### Testing instructions
- [ ] Using the default Disposal view definition, ensure the Disposal form opens correctly
- On any view definition, add a `row` element with no `cells`:
```xml
<row>
</row>

<!-- OR -->

<row/>
```
- [ ] Open the form and ensure that it loads and displays correctly
