### PR TITLE
Modify Workbench GeoMap to use single cell selections and show all rows by default

### DIFF
--- a/specifyweb/frontend/js_src/lib/components/WbToolkit/GeoLocate.tsx
+++ b/specifyweb/frontend/js_src/lib/components/WbToolkit/GeoLocate.tsx
@@ -168,7 +168,9 @@ export function getSelectedLocalities(
   columns: RA<string>,
   localityColumns: RA<IR<string>>,
   // If false, treat single cell selection as entire spreadsheet selection
-  allowSingleCell: boolean
+  allowSingleCell: boolean,
+  // Default behavior when no cell is selected
+  defaultSelectAll: boolean = false
 ):
   | {
       readonly length: number;
@@ -208,10 +210,13 @@ export function getSelectedLocalities(
     )
   ).sort(sortFunction(f.id));
 
+  const noneSelected = hot.getSelected() === undefined;
+
   const selectAll =
-    !allowSingleCell &&
-    selectedHeaders.length === 1 &&
-    selectedRows.length === 1;
+    (noneSelected && defaultSelectAll) ||
+    (!allowSingleCell &&
+      selectedHeaders.length === 1 &&
+      selectedRows.length === 1);
 
   const localityColumnGroups = selectAll
     ? localityColumns

--- a/specifyweb/frontend/js_src/lib/components/WbToolkit/WbLeafletMap.tsx
+++ b/specifyweb/frontend/js_src/lib/components/WbToolkit/WbLeafletMap.tsx
@@ -39,7 +39,8 @@ export function WbLeafletMap({
             hot,
             dataset.columns,
             mappings.localityColumns,
-            false
+            true,
+            true
           );
     const localityPoints =
       selection === undefined || mappings === undefined

--- a/specifyweb/frontend/js_src/lib/components/WbToolkit/WbLeafletMap.tsx
+++ b/specifyweb/frontend/js_src/lib/components/WbToolkit/WbLeafletMap.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 
 import { localityText } from '../../localization/locality';
 import { wbText } from '../../localization/workbench';
-import type { RA, IR } from '../../utils/types';
+import type { IR, RA } from '../../utils/types';
 import { Button } from '../Atoms/Button';
 import type { Field } from '../Leaflet/helpers';
 import { LeafletMap } from '../Leaflet/Map';

--- a/specifyweb/frontend/js_src/lib/components/WbToolkit/WbLeafletMap.tsx
+++ b/specifyweb/frontend/js_src/lib/components/WbToolkit/WbLeafletMap.tsx
@@ -1,10 +1,9 @@
 import type Handsontable from 'handsontable';
 import React from 'react';
 
-import { useBooleanState } from '../../hooks/useBooleanState';
 import { localityText } from '../../localization/locality';
 import { wbText } from '../../localization/workbench';
-import type { RA } from '../../utils/types';
+import type { RA, IR } from '../../utils/types';
 import { Button } from '../Atoms/Button';
 import type { Field } from '../Leaflet/helpers';
 import { LeafletMap } from '../Leaflet/Map';
@@ -25,10 +24,8 @@ export function WbLeafletMap({
   readonly dataset: Dataset;
   readonly mappings: WbMapping | undefined;
 }): JSX.Element {
-  const [showLeafletMap, openLeafletMap, closeLeafletMap] = useBooleanState();
-
   const [localityPoints, setLocalityPoints] = React.useState<
-    RA<Readonly<Record<string, Field<number | string>>>> | undefined
+    RA<IR<Field<number | string>>> | undefined
   >(undefined);
 
   const handleOpen = () => {
@@ -54,24 +51,23 @@ export function WbLeafletMap({
             selection.visualRows
           );
     setLocalityPoints(localityPoints);
-    openLeafletMap();
   };
 
   return (
     <>
       <Button.Small
         aria-haspopup="dialog"
-        aria-pressed={showLeafletMap}
+        aria-pressed={localityPoints !== undefined}
         disabled={!hasLocality}
         title={wbText.unavailableWithoutLocality()}
         onClick={handleOpen}
       >
         {localityText.geoMap()}
       </Button.Small>
-      {showLeafletMap && (
+      {localityPoints !== undefined && (
         <LeafletMap
           localityPoints={localityPoints}
-          onClose={closeLeafletMap}
+          onClose={() => setLocalityPoints(undefined)}
           onMarkerClick={(localityPoint: any): void => {
             if (localityPoints === undefined) return;
             const rowNumber = localityPoints[localityPoint].rowNumber.value;


### PR DESCRIPTION
Fixes #4938

Additional change:
- `getSelectedLocalities()` now has a parameter `defaultSelectAll` to specify the default behavior when no cell is selected

### Checklist

- [x] Self-review the PR after opening it to make sure the changes look good
      and self-explanatory (or properly documented)
- [ ] Add automated tests
- [x] Add relevant issue to release milestone

### Testing instructions

<!-- What are the steps to verify the fixes/changes in this PR? -->
<!-- Can part of that be replaced by automated tests? -->
- Go to a Workbench dataset with locality information (Eg: MammalData)
- Click on Tools -> GeoMap
- Verify GeoMap works for the following scenarios:
  - [ ] GeoMap shows all rows when no cell is selected
  - [ ] GeoMap shows the correct record when 1 cell is selected
  - [ ] GeoMap shows the correct records when multiple cells are selected
  - [ ] GeoMap shows the correct record when 1 row is selected
  - [ ] GeoMap shows the correct records when multiple rows are selected
- [ ] Additionally, make sure GeoLocate works as expected and has no side effects