### PR TITLE
Send RSS Export Feed notifications to the correct users

### DIFF
--- a/specifyweb/export/feed.py
+++ b/specifyweb/export/feed.py
@@ -66,7 +66,8 @@ def update_feed(force=False, notify_user: Optional[Specifyuser] = None):
             if notify_user_id:
                 user = Specifyuser.objects.get(id=notify_user_id)
                 create_notification(user, filename)
-                create_notification(notify_user, None)
+                if notify_user_id != user.id:
+                    create_notification(notify_user, None)
             elif notify_user:
                 create_notification(notify_user)
 

--- a/specifyweb/export/feed.py
+++ b/specifyweb/export/feed.py
@@ -68,8 +68,10 @@ def update_feed(force=False, notify_user: Optional[Specifyuser] = None):
                 create_notification(user, filename)
                 if notify_user and user.id != notify_user.id:
                     create_notification(notify_user, None)
-            elif notify_user:
-                create_notification(notify_user)
+            else:
+                create_notification(user, filename)
+                if notify_user: 
+                    create_notification(notify_user, None)
 
         else:
             logger.info('No update needed: %s', filename)

--- a/specifyweb/export/feed.py
+++ b/specifyweb/export/feed.py
@@ -66,11 +66,10 @@ def update_feed(force=False, notify_user: Optional[Specifyuser] = None):
             if notify_user_id:
                 user = Specifyuser.objects.get(id=notify_user_id)
                 create_notification(user, filename)
-                if notify_user and user.id != notify_user.id:
-                    create_notification(notify_user, None)
             else:
                 create_notification(user, filename)
-                if notify_user: 
+
+            if notify_user and user.id != notify_user.id:
                     create_notification(notify_user, None)
 
         else:

--- a/specifyweb/export/feed.py
+++ b/specifyweb/export/feed.py
@@ -66,7 +66,7 @@ def update_feed(force=False, notify_user: Optional[Specifyuser] = None):
             if notify_user_id:
                 user = Specifyuser.objects.get(id=notify_user_id)
                 create_notification(user, filename)
-                if notify_user_id != user.id:
+                if notify_user and user.id != notify_user.id:
                     create_notification(notify_user, None)
             elif notify_user:
                 create_notification(notify_user)

--- a/specifyweb/export/feed.py
+++ b/specifyweb/export/feed.py
@@ -3,25 +3,28 @@ import json
 import logging
 import os
 import time
-from xml.etree import ElementTree as ET
 
+from xml.etree import ElementTree as ET
 from django.conf import settings
 
 from .dwca import make_dwca
 from ..context.app_resource import get_app_resource, get_app_resource_from_db
 from ..notifications.models import Message
-from ..specify.models import Spappresourcedata, Collection, Specifyuser
+from ..specify.models import Collection, Specifyuser
 
 logger = logging.getLogger(__name__)
 
 FEED_DIR = os.path.join(settings.DEPOSITORY_DIR, "export_feed")
 
+
 class MissingFeedResource(Exception):
     pass
+
 
 def get_feed_resource():
     from_db = get_app_resource_from_db(None, None, 'Common', 'ExportFeed')
     return None if from_db is None else from_db[0]
+
 
 def update_feed(force=False, notify_user=None):
     feed_resource = get_feed_resource()
@@ -42,17 +45,22 @@ def update_feed(force=False, notify_user=None):
         if force or needs_update(path, int(item_node.attrib['days'])):
             logger.info('Generating: %s', filename)
             temp_file = os.path.join(FEED_DIR, '%s.tmp.zip' % filename)
-            collection_id = item_node.attrib.get('collectionid', item_node.attrib.get('collectionId'))
+            collection_id = item_node.attrib.get(
+                'collectionid', item_node.attrib.get('collectionId'))
             collection = Collection.objects.get(id=collection_id)
-            user_id = item_node.attrib.get('userid', item_node.attrib.get('userId'))
+            user_id = item_node.attrib.get(
+                'userid', item_node.attrib.get('userId'))
             user = Specifyuser.objects.get(id=user_id)
-            dwca_def, _, __ = get_app_resource(collection, user, item_node.attrib['definition'])
-            eml, _, __ = get_app_resource(collection, user, item_node.attrib['metadata'])
+            dwca_def, _, __ = get_app_resource(
+                collection, user, item_node.attrib['definition'])
+            eml, _, __ = get_app_resource(
+                collection, user, item_node.attrib['metadata'])
             make_dwca(collection, user, dwca_def, temp_file, eml=eml)
             os.rename(temp_file, path)
 
             logger.info('Finished updating: %s', filename)
-            notify_user_id = item_node.attrib.get('notifyuserid', item_node.attrib.get('notifyUserId'))
+            notify_user_id = item_node.attrib.get(
+                'notifyuserid', item_node.attrib.get('notifyUserId'))
             if notify_user is not None:
                 create_notification(notify_user, filename)
             elif notify_user_id:
@@ -61,6 +69,7 @@ def update_feed(force=False, notify_user=None):
 
         else:
             logger.info('No update needed: %s', filename)
+
 
 def needs_update(path, days):
     try:
@@ -71,8 +80,10 @@ def needs_update(path, days):
     else:
         update_interval = 24*60*60 * days
         age = time.time() - mtime
-        logger.debug("archive age: %s update interval: %s", age, update_interval)
+        logger.debug("archive age: %s update interval: %s",
+                     age, update_interval)
         return age > update_interval
+
 
 def create_notification(user, filename):
     Message.objects.create(user=user, content=json.dumps({

--- a/specifyweb/frontend/js_src/lib/components/Notifications/NotificationRenderers.tsx
+++ b/specifyweb/frontend/js_src/lib/components/Notifications/NotificationRenderers.tsx
@@ -29,13 +29,15 @@ export const notificationRenderers: IR<
     return (
       <>
         {notificationsText.feedItemUpdated()}
-        <Link.Success
-          className="w-fit normal-case"
-          download
-          href={`/static/depository/export_feed/${filename}`}
-        >
-          {filename}
-        </Link.Success>
+        {filename !== null && (
+          <Link.Success
+            className="w-fit normal-case"
+            download
+            href={`/static/depository/export_feed/${filename}`}
+          >
+            {filename}
+          </Link.Success>
+        )}
       </>
     );
   },


### PR DESCRIPTION
Fixes #4267 

@specify/ux-testing 
Currently, these changes only affect the notifications if the update is successful. 
If a failure occurs, the past behavior should still be observed (only the user which initiated the RSS Export Feed Update receives a notification). Should the complete failure be sent to the user who started the RSS Export Feed Update (so that they can make changes/notify someone?), or should they also only receive a notification that the Update has failed and send a more complete notification to the `notifyUserId` of the Export Feed? 

### Checklist

- [x] Self-review the PR after opening it to make sure the changes look good
      and self-explanatory (or properly documented)
- [ ] Add automated tests
- [x] Add relevant issue to release milestone

### Testing instructions
- Ensure you are logged in as a user which has permission to update the RSS Export Feed, but not the same user as specified in the `notifyUserId` ('Send completion notification to user') of the Export Feed
- Update the Export Feed from the User Tools menu 
- [ ] Ensure you receive a notification (without a link to the Export Feed zip) when the Export Feed update completes 
- [ ] Login as the user specified in the `notifyUserId` of the Export Feed and ensure you received a notification which contains a link to the zip

- Update the RSS Export Feed as the user specified as the `notifyUserId` of the Export Feed
- [ ] Ensure you only receive a single notification (containing the resulting zip)

- Edit the RSS Export Feed so that it no longer has a `notifyUserId` specified
- Login as the user specified by `userId` ('Run as user')
- Update the Export Feed from the User Tools menu
- [ ] Ensure you only receive a single notification (containing the resulting zip)

- Login as a different user who has permission to update the RSS Export Feed
- Update the RSS Export Feed from the User Tools menu
- [ ] Ensure you receive a notification (without a link to the Export Feed zip) when the Export Feed update completes
- [ ] Login as the user specified in the `userId` of the Export Feed and ensure you received a notification which contains a link to the zip
