### PR TITLE
Fix permission error in development

### DIFF
--- a/specifyweb/specify/tree_views.py
+++ b/specifyweb/specify/tree_views.py
@@ -381,10 +381,10 @@ class StorageMutationPT(PermissionTarget):
     resource = "/tree/edit/storage"
     merge = PermissionTargetAction()
     move = PermissionTargetAction()
-    bulk_move = PermissionTargetAction()
     synonymize = PermissionTargetAction()
     desynonymize = PermissionTargetAction()
     repair = PermissionTargetAction()
+    bulk_move = PermissionTargetAction()
 
 
 class GeologictimeperiodMutationPT(PermissionTarget):


### PR DESCRIPTION
Fixes this console error when webpack is in 'development' mode

<img width="651" alt="Screenshot 2024-05-28 at 10 07 57 AM" src="https://github.com/specify/specify7/assets/64045831/89fb4ea0-ce55-4dad-a480-41af24631eb5">

From 
https://github.com/specify/specify7/blob/7cf9feaf3e2b3a3ba040e69fc24eadce65d49547/specifyweb/frontend/js_src/lib/components/Permissions/index.ts#L88-L90

The frontend expects the ordering of the permissions for each action to be the same on the backend and the frontend. 
The `bulk_move` permission for '/tree/edit/storage' has a different order: 

Frontend: 
https://github.com/specify/specify7/blob/7cf9feaf3e2b3a3ba040e69fc24eadce65d49547/specifyweb/frontend/js_src/lib/components/Permissions/definitions.ts#L34-L41

Backend: 
https://github.com/specify/specify7/blob/7cf9feaf3e2b3a3ba040e69fc24eadce65d49547/specifyweb/specify/tree_views.py#L380-L387 

Alternatively, we an refactor the function such that the order of the individual actions does not matter. 

### Checklist

- [ ] Self-review the PR after opening it to make sure the changes look good
      and self-explanatory (or properly documented)
- [ ] Add automated tests
- [ ] Add relevant issue to release milestone

### Testing instructions
(no UI/UX testing required for this PR)

- [ ] With webpack in development mode, ensure the `'Front-end has outdated list of operation policies'` error is not thrown