### PR TITLE
Remove auto close from DWCA dialog

### DIFF
--- a/specifyweb/frontend/js_src/lib/components/ExportFeed/Dwca.tsx
+++ b/specifyweb/frontend/js_src/lib/components/ExportFeed/Dwca.tsx
@@ -91,13 +91,13 @@ export function PickAppResource({
       buttons={
         skippable ? (
           <>
-            <Button.DialogClose>{commonText.back()}</Button.DialogClose>
+            <Button.DialogClose>{commonText.close()}</Button.DialogClose>
             <Button.Info onClick={(): void => handleSelected(undefined)}>
               {commonText.skip()}
             </Button.Info>
           </>
         ) : (
-          commonText.back()
+          commonText.close()
         )
       }
       header={header}
@@ -111,7 +111,6 @@ export function PickAppResource({
           resources={resources}
           onOpen={(selected): void => {
             f.maybe(toResource(selected, 'SpAppResource'), handleSelected);
-            handleClose();
           }}
         />
       </ReadOnlyContext.Provider>


### PR DESCRIPTION
Fixes #4957

### Checklist

- [ ] Self-review the PR after opening it to make sure the changes look good
      and self-explanatory (or properly documented)
- [ ] Add relevant issue to release milestone

### Testing instructions

- Go to User Tools -> Create DwC Archive.
- Choose a DwCA definition that you know has worked previously and click skip.
- [ ] Verify that it opens the dialog with DWCA has started.
- [ ] Verify you get a notification for failure or success 

NOTES: 
I added the handleClose() in [issue-4886](https://github.com/specify/specify7/tree/issue-4886) to close the DWCA dialog when in ExportFeed app resources to avoid to do it manually but it introduced this bug. 
Reverting the changes, will have to close the dialog manually in both places. 