### PR TITLE
Fix unload protect being triggered in locality record sets

### DIFF
--- a/specifyweb/frontend/js_src/lib/components/FormPlugins/LatLongUi.tsx
+++ b/specifyweb/frontend/js_src/lib/components/FormPlugins/LatLongUi.tsx
@@ -141,7 +141,6 @@ function Coordinate({
     fieldType,
     step,
     handleFormatted,
-    setValidation,
     parser,
   ]);
 


### PR DESCRIPTION

Fixes #4995 

Caused by #4939 
The changes in that PR sets the validation blocker more times than it needs to which somehow causes an unload protect to trigger. My guess is it's a timing error.



### Checklist

- [x] Self-review the PR after opening it to make sure the changes look good
      and self-explanatory (or properly documented)
- [ ] Add automated tests
- [x] Add relevant issue to release milestone

### Testing instructions

- Go to a locality record set
- Navigate between records
- [ ] Verify unload protect does not trigger
