### PR TITLE
Fix readonly mode triggering permission denied error in FormMeta

### DIFF
--- a/specifyweb/frontend/js_src/lib/components/FormMeta/index.tsx
+++ b/specifyweb/frontend/js_src/lib/components/FormMeta/index.tsx
@@ -24,9 +24,9 @@ import { isTreeResource } from '../InitialContext/treeRanks';
 import { interactionTables } from '../Interactions/config';
 import { recordMergingTableSpec } from '../Merging/definitions';
 import { Dialog } from '../Molecules/Dialog';
+import { hasTablePermission } from '../Permissions/helpers';
 import {
   ProtectedAction,
-  ProtectedTable,
   ProtectedTool,
 } from '../Permissions/PermissionDenied';
 import { UnloadProtectsContext } from '../Router/UnloadProtect';
@@ -218,14 +218,10 @@ function MetaDialog({
             </ProtectedTool>
             <ProtectedAction action="update" resource="/record/merge">
               <ProtectedAction action="delete" resource="/record/merge">
-                <ProtectedTable
-                  action="update"
-                  tableName={resource.specifyTable.name}
-                >
-                  {resource.specifyTable.name in recordMergingTableSpec && (
-                    <MergeRecord resource={resource} />
-                  )}
-                </ProtectedTable>
+                {resource.specifyTable.name in recordMergingTableSpec &&
+                hasTablePermission(resource.specifyTable.name, 'update') ? (
+                  <MergeRecord resource={resource} />
+                ) : undefined}
               </ProtectedAction>
             </ProtectedAction>
           </>

--- a/specifyweb/frontend/js_src/lib/components/FormMeta/index.tsx
+++ b/specifyweb/frontend/js_src/lib/components/FormMeta/index.tsx
@@ -24,7 +24,7 @@ import { isTreeResource } from '../InitialContext/treeRanks';
 import { interactionTables } from '../Interactions/config';
 import { recordMergingTableSpec } from '../Merging/definitions';
 import { Dialog } from '../Molecules/Dialog';
-import { hasTablePermission } from '../Permissions/helpers';
+import { hasPermission, hasTablePermission } from '../Permissions/helpers';
 import {
   ProtectedAction,
   ProtectedTool,
@@ -216,14 +216,12 @@ function MetaDialog({
                 ))}
               </ProtectedAction>
             </ProtectedTool>
-            <ProtectedAction action="update" resource="/record/merge">
-              <ProtectedAction action="delete" resource="/record/merge">
-                {resource.specifyTable.name in recordMergingTableSpec &&
-                hasTablePermission(resource.specifyTable.name, 'update') ? (
-                  <MergeRecord resource={resource} />
-                ) : undefined}
-              </ProtectedAction>
-            </ProtectedAction>
+            {resource.specifyTable.name in recordMergingTableSpec &&
+            hasPermission('/record/merge', 'update') &&
+            hasPermission('/record/merge', 'delete') &&
+            hasTablePermission(resource.specifyTable.name, 'update') ? (
+              <MergeRecord resource={resource} />
+            ) : undefined}
           </>
         }
         header={formsText.recordInformation()}

--- a/specifyweb/frontend/js_src/lib/components/QueryBuilder/Header.tsx
+++ b/specifyweb/frontend/js_src/lib/components/QueryBuilder/Header.tsx
@@ -16,11 +16,11 @@ import { tables } from '../DataModel/tables';
 import type { RecordSet, SpQuery, SpQueryField } from '../DataModel/types';
 import { ErrorBoundary } from '../Errors/ErrorBoundary';
 import { TableIcon } from '../Molecules/TableIcon';
-import { hasToolPermission } from '../Permissions/helpers';
 import {
-  ProtectedAction,
-  ProtectedTable,
-} from '../Permissions/PermissionDenied';
+  hasPermission,
+  hasTablePermission,
+  hasToolPermission,
+} from '../Permissions/helpers';
 import { SaveQueryButtons, ToggleMappingViewButton } from './Components';
 import { useQueryViewPref } from './Context';
 import { QueryEditButton } from './Edit';
@@ -109,23 +109,19 @@ export function QueryHeader({
           />
         )}
       </div>
-      {state.baseTableName === 'LoanPreparation' && (
-        <ProtectedAction action="execute" resource="/querybuilder/query">
-          <ProtectedTable action="update" tableName="Loan">
-            <ProtectedTable action="create" tableName="LoanReturnPreparation">
-              <ProtectedTable action="read" tableName="LoanPreparation">
-                <ErrorBoundary dismissible>
-                  <QueryLoanReturn
-                    fields={state.fields}
-                    getQueryFieldRecords={getQueryFieldRecords}
-                    queryResource={queryResource}
-                  />
-                </ErrorBoundary>
-              </ProtectedTable>
-            </ProtectedTable>
-          </ProtectedTable>
-        </ProtectedAction>
-      )}
+      {state.baseTableName === 'LoanPreparation' &&
+      hasPermission('/querybuilder/query', 'execute') &&
+      hasTablePermission('Loan', 'update') &&
+      hasTablePermission('LoanReturnPreparation', 'create') &&
+      hasTablePermission('LoanPreparation', 'read') ? (
+        <ErrorBoundary dismissible>
+          <QueryLoanReturn
+            fields={state.fields}
+            getQueryFieldRecords={getQueryFieldRecords}
+            queryResource={queryResource}
+          />
+        </ErrorBoundary>
+      ) : undefined}
       <div className="flex flex-wrap justify-center gap-2">
         <Button.Small onClick={() => setIsBasic(!isBasic)}>
           {isBasic


### PR DESCRIPTION
Fixes #4997



### Checklist

- [x] Self-review the PR after opening it to make sure the changes look good
      and self-explanatory (or properly documented)
- [ ] Add automated tests
- [x] Add relevant issue to release milestone

### Testing instructions

- Go to any pre-existing form (e.g. Collection Object)
- Click on the form meta button in the top right
- Click on 'Enable Read-Only Mode'
- Click on form meta again
- [ ] Verify there is no permission denied error and read only mode can be disabled again
- [ ] Re-run the same steps for a form with merge records enabled (Agent, Locality, PaleoContext, CollectingEvent)

Additional test:
- In Readonly mode, make a query on LoanPreparation
- [ ] Verify the page loads correctly and there is no permission denied error dialog
