### PR TITLE
Close resource picker on select and remove skip as an option for metadata resource in ExportFeed

### DIFF
--- a/specifyweb/frontend/js_src/lib/components/ExportFeed/Editor.tsx
+++ b/specifyweb/frontend/js_src/lib/components/ExportFeed/Editor.tsx
@@ -318,7 +318,7 @@ function ResourcePicker({
       : headerText.chooseMetadataResource();
   return (
     <div className="flex gap-2">
-      <Input.Text value={value} required />
+      <Input.Text required value={value} />
       {!isReadOnly && (
         <Button.Info onClick={handleOpen}>{headerText.choose()}</Button.Info>
       )}

--- a/specifyweb/frontend/js_src/lib/components/ExportFeed/Editor.tsx
+++ b/specifyweb/frontend/js_src/lib/components/ExportFeed/Editor.tsx
@@ -318,7 +318,7 @@ function ResourcePicker({
       : headerText.chooseMetadataResource();
   return (
     <div className="flex gap-2">
-      <Input.Text isReadOnly value={value} />
+      <Input.Text value={value} required />
       {!isReadOnly && (
         <Button.Info onClick={handleOpen}>{headerText.choose()}</Button.Info>
       )}

--- a/specifyweb/frontend/js_src/lib/components/ExportFeed/Editor.tsx
+++ b/specifyweb/frontend/js_src/lib/components/ExportFeed/Editor.tsx
@@ -330,11 +330,11 @@ function ResourcePicker({
             filters={dwcaAppResourceFilter}
             header={title}
             resources={resources}
-            skippable={type === 'metadata'}
             onClose={handleClose}
-            onSelected={(definition): void =>
-              setValue(localized(definition?.name ?? ''))
-            }
+            onSelected={(definition): void => {
+              setValue(localized(definition?.name ?? ''));
+              handleClose();
+            }}
           />
         )
       ) : undefined}


### PR DESCRIPTION
Fixes #5000 

- Resource picker should now close when updating ExportFeed
- Skip is no longer an option in ExportFeed to prevent empty metadata resource
- DwCA and metadata resource fields are now required in ExportFeed


### Checklist

- [x] Self-review the PR after opening it to make sure the changes look good
      and self-explanatory (or properly documented)
- [ ] Add automated tests
- [x] Add relevant issue to release milestone

### Testing instructions

<!-- What are the steps to verify the fixes/changes in this PR? -->
<!-- Can part of that be replaced by automated tests? -->
- Go to App Resources > RSS Export Feed
- Change DwCA and metadata resource
- [ ] Verify the resource picker closes on selecting a resource
- [ ] Verify metadata resource can no longer be skipped and saved without input
