### PR TITLE
Add DO_NOTHING for on_delete on TreeDefItems

### DIFF
--- a/specifyweb/specify/build_models.py
+++ b/specifyweb/specify/build_models.py
@@ -73,6 +73,7 @@ def make_model(module, table, datamodel):
         # It will manually send the pre_delete signal for the django model object.
         # The pre_delete function must contain logic that will prevent ForeignKey constraints from being violated.
         # This is needed because database constraints are checked before pre_delete signals are sent.
+        # This is not currently used, but is here for future use.
         pre_delete.send(sender=self.__class__, instance=self)
 
     def save_timestamped(self, *args, **kwargs):
@@ -95,6 +96,7 @@ def make_model(module, table, datamodel):
 
     attrs['Meta'] = Meta
     if table.django_name in tables_with_pre_constraints_delete:
+        # This is not currently used, but is here for future use.
         attrs['pre_constraints_delete'] = pre_constraints_delete
 
     if has_timestamp_fields:

--- a/specifyweb/specify/models.py
+++ b/specifyweb/specify/models.py
@@ -3641,7 +3641,7 @@ class Geographytreedefitem(model_extras.Geographytreedefitem):
     # Relationships: Many-to-One
     createdbyagent = models.ForeignKey('Agent', db_column='CreatedByAgentID', related_name='+', null=True, on_delete=protect_with_blockers)
     modifiedbyagent = models.ForeignKey('Agent', db_column='ModifiedByAgentID', related_name='+', null=True, on_delete=protect_with_blockers)
-    parent = models.ForeignKey('GeographyTreeDefItem', db_column='ParentItemID', related_name='children', null=True, on_delete=protect_with_blockers)
+    parent = models.ForeignKey('GeographyTreeDefItem', db_column='ParentItemID', related_name='children', null=True, on_delete=models.DO_NOTHING)
     treedef = models.ForeignKey('GeographyTreeDef', db_column='GeographyTreeDefID', related_name='treedefitems', null=False, on_delete=protect_with_blockers)
 
     class Meta:
@@ -3746,7 +3746,7 @@ class Geologictimeperiodtreedefitem(model_extras.Geologictimeperiodtreedefitem):
     # Relationships: Many-to-One
     createdbyagent = models.ForeignKey('Agent', db_column='CreatedByAgentID', related_name='+', null=True, on_delete=protect_with_blockers)
     modifiedbyagent = models.ForeignKey('Agent', db_column='ModifiedByAgentID', related_name='+', null=True, on_delete=protect_with_blockers)
-    parent = models.ForeignKey('GeologicTimePeriodTreeDefItem', db_column='ParentItemID', related_name='children', null=True, on_delete=protect_with_blockers)
+    parent = models.ForeignKey('GeologicTimePeriodTreeDefItem', db_column='ParentItemID', related_name='children', null=True, on_delete=models.DO_NOTHING)
     treedef = models.ForeignKey('GeologicTimePeriodTreeDef', db_column='GeologicTimePeriodTreeDefID', related_name='treedefitems', null=False, on_delete=protect_with_blockers)
 
     class Meta:
@@ -4235,7 +4235,7 @@ class Lithostrattreedefitem(model_extras.Lithostrattreedefitem):
     # Relationships: Many-to-One
     createdbyagent = models.ForeignKey('Agent', db_column='CreatedByAgentID', related_name='+', null=True, on_delete=protect_with_blockers)
     modifiedbyagent = models.ForeignKey('Agent', db_column='ModifiedByAgentID', related_name='+', null=True, on_delete=protect_with_blockers)
-    parent = models.ForeignKey('LithoStratTreeDefItem', db_column='ParentItemID', related_name='children', null=True, on_delete=protect_with_blockers)
+    parent = models.ForeignKey('LithoStratTreeDefItem', db_column='ParentItemID', related_name='children', null=True, on_delete=models.DO_NOTHING)
     treedef = models.ForeignKey('LithoStratTreeDef', db_column='LithoStratTreeDefID', related_name='treedefitems', null=False, on_delete=protect_with_blockers)
 
     class Meta:
@@ -6629,7 +6629,7 @@ class Storagetreedefitem(model_extras.Storagetreedefitem):
     # Relationships: Many-to-One
     createdbyagent = models.ForeignKey('Agent', db_column='CreatedByAgentID', related_name='+', null=True, on_delete=protect_with_blockers)
     modifiedbyagent = models.ForeignKey('Agent', db_column='ModifiedByAgentID', related_name='+', null=True, on_delete=protect_with_blockers)
-    parent = models.ForeignKey('StorageTreeDefItem', db_column='ParentItemID', related_name='children', null=True, on_delete=protect_with_blockers)
+    parent = models.ForeignKey('StorageTreeDefItem', db_column='ParentItemID', related_name='children', null=True, on_delete=models.DO_NOTHING)
     treedef = models.ForeignKey('StorageTreeDef', db_column='StorageTreeDefID', related_name='treedefitems', null=False, on_delete=protect_with_blockers)
 
     class Meta:
@@ -7057,7 +7057,7 @@ class Taxontreedefitem(model_extras.Taxontreedefitem):
     # Relationships: Many-to-One
     createdbyagent = models.ForeignKey('Agent', db_column='CreatedByAgentID', related_name='+', null=True, on_delete=protect_with_blockers)
     modifiedbyagent = models.ForeignKey('Agent', db_column='ModifiedByAgentID', related_name='+', null=True, on_delete=protect_with_blockers)
-    parent = models.ForeignKey('TaxonTreeDefItem', db_column='ParentItemID', related_name='children', null=True, on_delete=protect_with_blockers)
+    parent = models.ForeignKey('TaxonTreeDefItem', db_column='ParentItemID', related_name='children', null=True, on_delete=models.DO_NOTHING)
     treedef = models.ForeignKey('TaxonTreeDef', db_column='TaxonTreeDefID', related_name='treedefitems', null=False, on_delete=protect_with_blockers)
 
     class Meta:

--- a/specifyweb/specify/views.py
+++ b/specifyweb/specify/views.py
@@ -88,6 +88,13 @@ def raise_error(request):
     raise Exception('This error is a test. You may now return to your regularly '
                     'scheduled hacking.')
 
+DELETE_BLOCKER_EXCEPTIONS = {
+    'Taxontreedefitem': {'Taxontreedefitem'},
+    'Geographytreedefitem': {'Geographytreedefitem'},
+    'Storagetreedef': {'Storagetreedefitem'},
+    'Geologictimeperiodtreedef': {'Geologictimeperiodtreedefitem'},
+    'Lithostrattreedef': {'Lithostrattreedefitem'},
+}
 
 @login_maybe_required
 @require_http_methods(['GET', 'HEAD'])
@@ -110,6 +117,12 @@ def delete_blockers(request, model, id):
             }
         ] for field, sub_objs in collector.delete_blockers
     ])
+
+    # Filter out models that are in the DELETE_BLOCKER_EXCEPTIONS dictionary
+    model_name = obj.__class__.__name__
+    if model_name in DELETE_BLOCKER_EXCEPTIONS:
+        result = [item for item in result if item['table'] not in DELETE_BLOCKER_EXCEPTIONS[model_name]]
+
     return http.HttpResponse(api.toJson(result), content_type='application/json')
 
 

--- a/specifyweb/specify/views.py
+++ b/specifyweb/specify/views.py
@@ -88,6 +88,7 @@ def raise_error(request):
     raise Exception('This error is a test. You may now return to your regularly '
                     'scheduled hacking.')
 
+
 @login_maybe_required
 @require_http_methods(['GET', 'HEAD'])
 def delete_blockers(request, model, id):

--- a/specifyweb/specify/views.py
+++ b/specifyweb/specify/views.py
@@ -88,6 +88,7 @@ def raise_error(request):
     raise Exception('This error is a test. You may now return to your regularly '
                     'scheduled hacking.')
 
+# Maps model names to a set of related models that should not block deletion
 DELETE_BLOCKER_EXCEPTIONS = {
     'Taxontreedefitem': {'Taxontreedefitem'},
     'Geographytreedefitem': {'Geographytreedefitem'},

--- a/specifyweb/specify/views.py
+++ b/specifyweb/specify/views.py
@@ -88,15 +88,6 @@ def raise_error(request):
     raise Exception('This error is a test. You may now return to your regularly '
                     'scheduled hacking.')
 
-# Maps model names to a set of related models that should not block deletion
-DELETE_BLOCKER_EXCEPTIONS = {
-    'Taxontreedefitem': {'Taxontreedefitem'},
-    'Geographytreedefitem': {'Geographytreedefitem'},
-    'Storagetreedef': {'Storagetreedefitem'},
-    'Geologictimeperiodtreedef': {'Geologictimeperiodtreedefitem'},
-    'Lithostrattreedef': {'Lithostrattreedefitem'},
-}
-
 @login_maybe_required
 @require_http_methods(['GET', 'HEAD'])
 def delete_blockers(request, model, id):
@@ -118,12 +109,6 @@ def delete_blockers(request, model, id):
             }
         ] for field, sub_objs in collector.delete_blockers
     ])
-
-    # Filter out models that are in the DELETE_BLOCKER_EXCEPTIONS dictionary
-    model_name = obj.__class__.__name__
-    if model_name in DELETE_BLOCKER_EXCEPTIONS:
-        result = list(filter(lambda item: item['table'] not in DELETE_BLOCKER_EXCEPTIONS[model_name], result))
-
     return http.HttpResponse(api.toJson(result), content_type='application/json')
 
 

--- a/specifyweb/specify/views.py
+++ b/specifyweb/specify/views.py
@@ -121,7 +121,7 @@ def delete_blockers(request, model, id):
     # Filter out models that are in the DELETE_BLOCKER_EXCEPTIONS dictionary
     model_name = obj.__class__.__name__
     if model_name in DELETE_BLOCKER_EXCEPTIONS:
-        result = [item for item in result if item['table'] not in DELETE_BLOCKER_EXCEPTIONS[model_name]]
+        result = list(filter(lambda item: item['table'] not in DELETE_BLOCKER_EXCEPTIONS[model_name], result))
 
     return http.HttpResponse(api.toJson(result), content_type='application/json')
 


### PR DESCRIPTION
Fixes #5021

The issue was that the specify models.py file was generated after the add_deete_ranks PR was merged.  So the `on_delete=models.DO_NOTHING` wasn't applied in the re-definition.

Old:
~~Add a filter to delete_blockers, so that blockers that aren't really actually blockers and filtered out.  This will fix the delete_blockers issue we are having with deleting tree ranks.  Delete a Taxontreedefitem should only be blocked by a Taxon, not another Taxontreedefitem, this dependency is handled in the api call for tree rank deletion.  Let me know if someone has a better idea, this just seemed like a simple solution.  Is there a case where we would want these blockers not to be filtered?~~

### Checklist

- [x] Self-review the PR after opening it to make sure the changes look good
      and self-explanatory (or properly documented)
- [x] Add relevant issue to release milestone

### Testing instructions

1. Go to any tree
2. Add a new rank by pressing the pencil button, then the plus button, select the parent, press continue, fill out fields, press save, wait for the page to reload.
3. Select any parent node that is not the last one when adding a new rank.
4. Try to delete the rank by pressing the pencil button, then press the pencil button next to your test rank, then press delete, confirm delete, wait for the page to reload. 
5. Make sure there is no error, and that the tree rank is no longer there


https://github.com/specify/specify7/issues/5021#issue-2364614751
