### PR TITLE
Correctly set isAccepted on Tree save

### DIFF
--- a/specifyweb/businessrules/rules/tree_rules.py
+++ b/specifyweb/businessrules/rules/tree_rules.py
@@ -40,8 +40,8 @@ def post_tree_rank_deletion_handler(sender, obj):
     if is_instance_of_tree_def_item(obj): # is it a treedefitem?
         post_tree_rank_deletion(obj)
 
-# @orm_signal_handler('pre_save')
-def set_is_accepted_if_prefereed(sender, obj):
+@orm_signal_handler('pre_save')
+def set_is_accepted_if_preferred(sender, obj):
     if hasattr(obj, 'isaccepted'):
         obj.isaccepted = obj.accepted_id == None
 

--- a/specifyweb/businessrules/tests/geography.py
+++ b/specifyweb/businessrules/tests/geography.py
@@ -5,6 +5,7 @@ from django.db.models import ProtectedError
 from specifyweb.specify import models
 from specifyweb.specify.tests.test_api import ApiTests
 
+
 class GeographyTests(ApiTests):
     def test_delete_blocked_by_locality(self):
         geography = models.Geography.objects.create(
@@ -38,6 +39,31 @@ class GeographyTests(ApiTests):
 
         models.Agentgeography.objects.filter(geography=geography).delete()
         geography.delete()
+
+    def test_isaccepted_on_save(self):
+        earth = models.Geography.objects.create(
+            name="Earth",
+            definition=self.geographytreedef,
+            definitionitem=self.geographytreedef.treedefitems.all()[0])
+
+        continent = earth.definitionitem.children.create(
+            name="Continent",
+            treedef=earth.definition,
+            rankid=earth.definitionitem.rankid+100)
+
+        na = earth.children.create(
+            name="North America",
+            definition=earth.definition,
+            definitionitem=continent)
+
+        other_na = earth.children.create(
+            name="Americas",
+            acceptedgeography=na,
+            definition=earth.definition,
+            definitionitem=continent)
+
+        self.assertTrue(na.isaccepted)
+        self.assertFalse(other_na.isaccepted)
 
     @skip("this behavior was eliminated by https://github.com/specify/specify7/issues/136")
     def test_delete_cascades_to_deletable_children(self):
@@ -73,7 +99,8 @@ class GeographyTests(ApiTests):
 
         earth.delete()
 
-        self.assertEqual(models.Geography.objects.filter(id__in=(na.id, sa.id)).count(), 0)
+        self.assertEqual(models.Geography.objects.filter(
+            id__in=(na.id, sa.id)).count(), 0)
 
     @skip("not clear if this is correct.")
     def test_accepted_children_acceptedparent_set_to_null_on_delete(self):
@@ -109,4 +136,5 @@ class GeographyTests(ApiTests):
             definitionitem=country)
 
         asia.delete()
-        self.assertEqual(models.Geography.objects.get(id=lugash.id).acceptedgeography, None)
+        self.assertEqual(models.Geography.objects.get(
+            id=lugash.id).acceptedgeography, None)

--- a/specifyweb/businessrules/tests/taxon.py
+++ b/specifyweb/businessrules/tests/taxon.py
@@ -6,6 +6,7 @@ from django.db.models import ProtectedError
 from specifyweb.specify import models
 from specifyweb.specify.tests.test_api import ApiTests
 
+
 class TaxonTests(ApiTests):
     def setUp(self):
         super(TaxonTests, self).setUp()
@@ -39,7 +40,8 @@ class TaxonTests(ApiTests):
             name="test")
 
         self.roottaxon.delete()
-        self.assertEqual(models.Commonnametx.objects.filter(id=commonname.id).count(), 0)
+        self.assertEqual(models.Commonnametx.objects.filter(
+            id=commonname.id).count(), 0)
 
     def test_delete_blocked_by_determinations(self):
         det = self.collectionobjects[0].determinations.create(
@@ -95,6 +97,28 @@ class TaxonTests(ApiTests):
         tax2.delete()
         self.roottaxon.delete()
 
+    def test_isaccepted_on_save(self):
+        kingdom = self.roottaxontreedefitem.children.create(
+            name="Kingdom",
+            treedef=self.taxontreedef,
+            rankid=self.roottaxontreedefitem.rankid+100)
+
+        animalia = self.roottaxon.children.create(
+            name="Animalia",
+            definition=self.taxontreedef,
+            definitionitem=kingdom
+        )
+
+        metazoa = self.roottaxon.children.create(
+            name="Metazoa",
+            acceptedtaxon=animalia,
+            definition=self.taxontreedef,
+            definitionitem=kingdom
+        )
+
+        self.assertTrue(animalia.isaccepted)
+        self.assertFalse(metazoa.isaccepted)
+
     @skip("not sure if rule is valid")
     def test_delete_blocked_by_taxoncitations(self):
         rw = models.Referencework.objects.create(
@@ -139,7 +163,8 @@ class TaxonTests(ApiTests):
 
         det.delete()
         self.roottaxon.delete()
-        self.assertEqual(models.Taxon.objects.filter(id__in=(animal.id, plant.id)).count(), 0)
+        self.assertEqual(models.Taxon.objects.filter(
+            id__in=(animal.id, plant.id)).count(), 0)
 
     @skip("not clear if this is correct.")
     def test_accepted_children_acceptedparent_set_to_null_on_delete(self):

--- a/specifyweb/specify/tree_extras.py
+++ b/specifyweb/specify/tree_extras.py
@@ -701,8 +701,6 @@ class TreeRank(models.Model):
 
     def save(self, *args, **kwargs):
         # pre_save
-        if hasattr(self, 'isaccepted'):
-            self.isaccepted = self.accepted_id == None
         if self.pk is None: # is it a new object?
             pre_tree_rank_init(self)
             verify_rank_parent_chain_integrity(self, RankOperation.CREATED)

--- a/specifyweb/specify/tree_extras.py
+++ b/specifyweb/specify/tree_extras.py
@@ -128,6 +128,43 @@ class Tree(models.Model): # FUTURE: class Tree(SpTimestampedModel):
     def accepted_id(self, value):
         setattr(self, self.accepted_id_attr(), value)
 
+class TreeRank(models.Model):
+    class Meta:
+            abstract = True
+
+    def save(self, *args, **kwargs):
+        # pre_save
+        if self.pk is None: # is it a new object?
+            pre_tree_rank_init(self)
+            verify_rank_parent_chain_integrity(self, RankOperation.CREATED)
+        else:
+            verify_rank_parent_chain_integrity(self, RankOperation.UPDATED)
+        
+        # save
+        super(TreeRank, self).save(*args, **kwargs)
+
+        # post_save
+        post_tree_rank_save(self.__class__, self)
+
+    def delete(self, *args, **kwargs):
+        # pre_delete
+        if self.__class__.objects.get(id=self.id).parent is None:
+            raise TreeBusinessRuleException(
+                "cannot delete root level tree definition item",
+                {"tree": self.__class__.__name__,
+                 "localizationKey": 'deletingTreeRoot',
+                 "node": {
+                     "id": self.id
+                 }})
+        pre_tree_rank_deletion(self.__class__, self)
+        verify_rank_parent_chain_integrity(self, RankOperation.DELETED)
+
+        # delete
+        super(TreeRank, self).delete(*args, **kwargs)
+
+        # post_delete
+        post_tree_rank_deletion(self)
+
 
 
 def open_interval(model, parent_node_number, size):
@@ -694,40 +731,3 @@ def is_instance_of_tree_def_item(obj):
         spmodels.Taxontreedefitem,
     ]
     return any(isinstance(obj, cls) for cls in tree_def_item_classes)
-
-class TreeRank(models.Model):
-    class Meta:
-            abstract = True
-
-    def save(self, *args, **kwargs):
-        # pre_save
-        if self.pk is None: # is it a new object?
-            pre_tree_rank_init(self)
-            verify_rank_parent_chain_integrity(self, RankOperation.CREATED)
-        else:
-            verify_rank_parent_chain_integrity(self, RankOperation.UPDATED)
-        
-        # save
-        super(TreeRank, self).save(*args, **kwargs)
-
-        # post_save
-        post_tree_rank_save(self.__class__, self)
-
-    def delete(self, *args, **kwargs):
-        # pre_delete
-        if self.__class__.objects.get(id=self.id).parent is None:
-            raise TreeBusinessRuleException(
-                "cannot delete root level tree definition item",
-                {"tree": self.__class__.__name__,
-                 "localizationKey": 'deletingTreeRoot',
-                 "node": {
-                     "id": self.id
-                 }})
-        pre_tree_rank_deletion(self.__class__, self)
-        verify_rank_parent_chain_integrity(self, RankOperation.DELETED)
-
-        # delete
-        super(TreeRank, self).delete(*args, **kwargs)
-
-        # post_delete
-        post_tree_rank_deletion(self)

--- a/specifyweb/specify/tree_ranks.py
+++ b/specifyweb/specify/tree_ranks.py
@@ -175,7 +175,7 @@ def set_rank_id(new_rank):
 
     # Get tree def item model
     tree_def_item_model_name = (tree + 'treedefitem').lower().title()
-    tree_def_item_model = getattr(spmodels, tree_def_item_model_name.lower().title())
+    tree_def_item_model = getattr(spmodels, tree_def_item_model_name)
 
     # Handle case where the parent rank is not given, and it is not the first rank added.
     # This is happening in the UI workflow of Treeview->Treedef->Treedefitems->Add


### PR DESCRIPTION
Fixes #5027

Caused by #4257
Specifically, the business rule was disabled and the logic was put on the TreeDefItem class `save` method when it should have either remained a business rule or have been put in the Tree class `save` method. 

### Checklist

- [x] Self-review the PR after opening it to make sure the changes look good
      and self-explanatory (or properly documented)
- [x] Add automated tests
- [x] Add relevant issue to release milestone

### Testing instructions
For any Tree Record (Geography, Taxon, Storage, Chronostratigraphy, and/or Lithostratigraphy): 
- Save the record without setting a Preferred Node
- [ ] Ensure the `Is Preferred` (`isAccepted` field) checkbox is checked (True)
- Set a Preferred Node for the record and save
- [ ] Ensure the `Is Preferred` (`isAccepted` field) checkbox is unchecked (False)
