### PR TITLE
Call handleSave only if save was a success

### DIFF
--- a/specifyweb/frontend/js_src/lib/components/Forms/Save.tsx
+++ b/specifyweb/frontend/js_src/lib/components/Forms/Save.tsx
@@ -166,7 +166,8 @@ export function SaveButton<SCHEMA extends AnySchema = AnySchema>({
                 ?.value === hasSaveConflict
                 ? undefined
                 : error(error_)
-            ).then(handleSaved)
+            )
+            .then(handleSaved)
             .finally(() => {
               unsetUnloadProtect();
               setIsSaving(false);

--- a/specifyweb/frontend/js_src/lib/components/Forms/Save.tsx
+++ b/specifyweb/frontend/js_src/lib/components/Forms/Save.tsx
@@ -166,10 +166,9 @@ export function SaveButton<SCHEMA extends AnySchema = AnySchema>({
                 ?.value === hasSaveConflict
                 ? undefined
                 : error(error_)
-            )
+            ).then(handleSaved)
             .finally(() => {
               unsetUnloadProtect();
-              handleSaved?.();
               setIsSaving(false);
             });
         }


### PR DESCRIPTION
Looks like usages assume that save was a success anyways

Fixes https://github.com/specify/specify7/issues/5025



### Checklist

- [ ] Self-review the PR after opening it to make sure the changes look good
      and self-explanatory (or properly documented)
- [ ] Add automated tests
- [ ] Add relevant issue to release milestone

### Testing instructions

1. Open tree definition in the tree viewer
2. Try deleting a tree rank which has associated nodes (by clicking on -)
3. Verify that the error dialog appears, and the page doesn't automatically refresh
4. Make sure save buttons on forms, record sets, attachment gallery, app resource editor, resource dialogs work as expected
<!-- Can part of that be replaced by automated tests? -->
