### PR TITLE
Fix deaccession total prep count

### DIFF
--- a/specifyweb/specify/calculated_fields.py
+++ b/specifyweb/specify/calculated_fields.py
@@ -24,9 +24,18 @@ from specifyweb.specify.models import (
 logger = logging.getLogger(__name__)
 
 def calculate_totals_deaccession(obj, Model, related_field_name):
-    total_preps = Model.objects.filter(deaccession=obj).count()
-    total_items = Model.objects.filter(deaccession=obj).aggregate(
-        total=Sum(f"{related_field_name}__quantity"))["total"] or 0
+    # TODO: This version commented was implemented based on specify6 code,
+    # but using calc_prep_item_count seems to be the correct way.
+    # total_preps = Model.objects.filter(deaccession=obj).count()
+    # total_items = Model.objects.filter(deaccession=obj).aggregate(
+    #     total=Sum(f"{related_field_name}__quantity"))["total"] or 0
+    total_preps = 0
+    total_items = 0
+    for prep in Model.objects.filter(deaccession=obj):
+        counts = calc_prep_item_count(prep, related_field_name, {})
+        total_preps += counts["totalPreps"]
+        total_items += counts["totalItems"]
+    
     return total_preps, total_items
 
 def calc_prep_item_count(obj, prep_field_name, extra):

--- a/specifyweb/specify/calculated_fields.py
+++ b/specifyweb/specify/calculated_fields.py
@@ -24,11 +24,6 @@ from specifyweb.specify.models import (
 logger = logging.getLogger(__name__)
 
 def calculate_totals_deaccession(obj, Model, related_field_name):
-    # TODO: This version commented was implemented based on specify6 code,
-    # but using calc_prep_item_count seems to be the correct way.
-    # total_preps = Model.objects.filter(deaccession=obj).count()
-    # total_items = Model.objects.filter(deaccession=obj).aggregate(
-    #     total=Sum(f"{related_field_name}__quantity"))["total"] or 0
     total_preps = 0
     total_items = 0
     for prep in Model.objects.filter(deaccession=obj):

--- a/specifyweb/workbench/upload/tests/testschema.py
+++ b/specifyweb/workbench/upload/tests/testschema.py
@@ -70,12 +70,13 @@ class OtherSchemaTests(unittest.TestCase):
         upload_table = UploadTable(name=name, wbcols=wbcols, overrideScope=None, static={}, toOne={}, toMany={})
         validate(upload_table.unparse(), schema)
 
+    @settings(max_examples=100, deadline=None, suppress_health_check=(HealthCheck.too_slow,))
     @given(column_opts=from_schema(schema['definitions']['columnOptions']))
     def test_column_options_parse(self, column_opts: Dict):
         validate(column_opts, schema['definitions']['columnOptions'])
         parse_column_options(column_opts)
 
-    @settings(deadline=None)
+    @settings(max_examples=100, deadline=None, suppress_health_check=(HealthCheck.too_slow,))
     @given(column_opts=infer)
     def test_column_options_to_json(self, column_opts: ColumnOptions):
         j = column_opts.to_json()


### PR DESCRIPTION
Fixes #5037

Fix the deaccesions total prep count by modifying calculate_totals_deaccession to use calc_prep_item_count.  This change gets the total count of associated preps, like gift preparations, rather than just the number of gifts.  Let's be sure to confirm that this is the expected behavior that we want.

### Checklist

- [x] Self-review the PR after opening it to make sure the changes look good
      and self-explanatory (or properly documented)
- [x] Add relevant issue to release milestone

### Testing instructions

1. Create a Deaccession record
2. Go to a Gift, Disposal, or Exchange Out record with more than one preparation and add it to the Deaccession you created using the Deaccession query combo box
3. Return to the Deaccession record
4. See that the Total Preps field displays '3'

![image](https://github.com/specify/specify7/assets/2774057/4b2dce85-f08b-44db-b29a-cb74ff82d90f)

