### PR TITLE
Block save when ExportFeed has invalid user id

### DIFF
--- a/specifyweb/frontend/js_src/lib/localization/resources.ts
+++ b/specifyweb/frontend/js_src/lib/localization/resources.ts
@@ -840,6 +840,6 @@ export const resourcesText = createDictionary({
     'uk-ua': 'Потрібне поточне визначення.',
   },
   invalidSpecifyUser: {
-    'en-us': 'Invalid specify user'
-  }
+    'en-us': 'Invalid specify user',
+  },
 } as const);

--- a/specifyweb/frontend/js_src/lib/localization/resources.ts
+++ b/specifyweb/frontend/js_src/lib/localization/resources.ts
@@ -839,4 +839,7 @@ export const resourcesText = createDictionary({
     'ru-ru': 'Требуется текущее определение.',
     'uk-ua': 'Потрібне поточне визначення.',
   },
+  invalidSpecifyUser: {
+    'en-us': 'Invalid specify user'
+  }
 } as const);


### PR DESCRIPTION
Fixes #4955 

NOTES:
The 404 page occurs due to the way our ajax fetch is written. The QCBX in `UserPicker` fetches the resource at the specified resource url. When the url is invalid, ajax receives a 404 error which is handled by rendering a 404 page in production
https://github.com/specify/specify7/blob/013f81295c9e83cd6bd86a565d9b21950b5a76da/specifyweb/frontend/js_src/lib/components/Errors/FormatError.tsx#L152-L162

My workaround for this is to fetch the resource in `UserPicker` using `fetchResource` with `strict = false` (to avoid a 404 page) and if the url is invalid, we clear the QCBX and block save.

### Checklist

- [ ] Self-review the PR after opening it to make sure the changes look good
      and self-explanatory (or properly documented)
- [ ] Add automated tests
- [ ] Add relevant issue to release milestone

### Testing instructions

<!-- What are the steps to verify the fixes/changes in this PR? -->
<!-- Can part of that be replaced by automated tests? -->
- Go to App Resources -> Create a new/open an RSS Export Feed -> Switch to XML Editor.
- Change the userId or notifyUser values to an invalid one (one that does not match any Specify User) and save.
- [ ] Verify RSS Export Feed can be opened and there is no 404 page
- [ ] Verify userId/notifyUserId QCBX is cleared and save is blocked in the visual editor
- [ ] Verify the user can be changed and the Export Feed config can be saved