### PR TITLE
Handle scoping for Picklists based on Field in Table

### DIFF
--- a/specifyweb/frontend/js_src/lib/components/PickLists/fetch.ts
+++ b/specifyweb/frontend/js_src/lib/components/PickLists/fetch.ts
@@ -14,7 +14,7 @@ import {
   deserializeResource,
   serializeResource,
 } from '../DataModel/serializers';
-import { strictGetTable } from '../DataModel/tables';
+import { genericTables, strictGetTable } from '../DataModel/tables';
 import type { PickList, PickListItem, Tables } from '../DataModel/types';
 import { softFail } from '../Errors/Crash';
 import { format } from '../Formatters/formatters';
@@ -154,11 +154,17 @@ async function fetchFromField(
     pickList.get('fieldName') ?? undefined,
     'Unable to fetch pick list items as pick list field is not set'
   );
+
+  const canBeScoped =
+    genericTables[tableName as keyof Tables]?.getScopingRelationship() !==
+      undefined ||
+    !f.includes(Object.keys(schema.domainLevelIds), toLowerCase(tableName));
+
   return fetchRows(tableName as keyof Tables, {
     limit,
     fields: { [fieldName]: ['string', 'number', 'boolean', 'null'] },
     distinct: true,
-    domainFilter: true,
+    domainFilter: canBeScoped,
   }).then((rows) =>
     rows
       .map((row) => row[fieldName] ?? '')


### PR DESCRIPTION
Fixes #4989

The Issue here was that for Picklists based on field values for a table, the frontend was always trying to enforce scoping for for records of the table the "fictitious" Picklist Items were based off of. 

See https://github.com/specify/specify7/issues/4989#issuecomment-2151059896
Related:  #3564

### Checklist

- [ ] Self-review the PR after opening it to make sure the changes look good
      and self-explanatory (or properly documented)
- [ ] Add automated tests
- [ ] Add relevant issue to release milestone

### Testing instructions
- Create a PickList with type "Field From Table" 
- Choose a Table which can not be scoped
  - Some examples include: 
    - AccessionAuthorization
    - CollectionRelationship
    - CollectionRelType
    - Disposal
    - SpQuery
    - TaxonTreeDefItem  
- Choose any field from the Table
- In any field on any table in the Schema Configuration, assign the PickList to the field
  - [Related Speciforum Docs](https://discourse.specifysoftware.org/t/editing-forms-in-specify-7/1557#combobox-32)  
- [ ] Navigate to any form of the table which contains the field assigned to the PickList and ensure no error is thrown 