### PR TITLE
Adjust notification timing for development mode

### DIFF
--- a/specifyweb/frontend/js_src/lib/components/Notifications/hooks.tsx
+++ b/specifyweb/frontend/js_src/lib/components/Notifications/hooks.tsx
@@ -8,7 +8,7 @@ import { sortFunction } from '../../utils/utils';
 import { formatUrl } from '../Router/queryString';
 import type { GenericNotification } from './NotificationRenderers';
 
-let INITIAL_INTERVAL = (process.env.NODE_ENV === 'development') ? 60000 : 5000;
+const INITIAL_INTERVAL = (process.env.NODE_ENV === 'development') ? 60000 : 5000;
 const INTERVAL_MULTIPLIER = 1.1;
 
 export function useNotificationsFetch({

--- a/specifyweb/frontend/js_src/lib/components/Notifications/hooks.tsx
+++ b/specifyweb/frontend/js_src/lib/components/Notifications/hooks.tsx
@@ -8,7 +8,7 @@ import { sortFunction } from '../../utils/utils';
 import { formatUrl } from '../Router/queryString';
 import type { GenericNotification } from './NotificationRenderers';
 
-const INITIAL_INTERVAL = 5000;
+let INITIAL_INTERVAL = (process.env.NODE_ENV === 'development') ? 60000 : 5000;
 const INTERVAL_MULTIPLIER = 1.1;
 
 export function useNotificationsFetch({

--- a/specifyweb/frontend/js_src/lib/components/Notifications/hooks.tsx
+++ b/specifyweb/frontend/js_src/lib/components/Notifications/hooks.tsx
@@ -5,11 +5,12 @@ import { ajax } from '../../utils/ajax';
 import { formatDateForBackEnd } from '../../utils/parser/dateFormat';
 import type { IR, RA } from '../../utils/types';
 import { sortFunction } from '../../utils/utils';
+import { MINUTE, SECOND } from '../Atoms/timeUnits';
 import { formatUrl } from '../Router/queryString';
-import { SECOND, MINUTE } from '../Atoms/timeUnits'
 import type { GenericNotification } from './NotificationRenderers';
 
-const INITIAL_INTERVAL = process.env.NODE_ENV === 'development' ? 1 * MINUTE : 5 * SECOND;
+const INITIAL_INTERVAL =
+  process.env.NODE_ENV === 'development' ? Number(MINUTE) : 5 * SECOND;
 const INTERVAL_MULTIPLIER = 1.1;
 
 export function useNotificationsFetch({

--- a/specifyweb/frontend/js_src/lib/components/Notifications/hooks.tsx
+++ b/specifyweb/frontend/js_src/lib/components/Notifications/hooks.tsx
@@ -6,9 +6,10 @@ import { formatDateForBackEnd } from '../../utils/parser/dateFormat';
 import type { IR, RA } from '../../utils/types';
 import { sortFunction } from '../../utils/utils';
 import { formatUrl } from '../Router/queryString';
+import { SECOND, MINUTE } from '../Atoms/timeUnits'
 import type { GenericNotification } from './NotificationRenderers';
 
-const INITIAL_INTERVAL = process.env.NODE_ENV === 'development' ? 60_000 : 5000;
+const INITIAL_INTERVAL = process.env.NODE_ENV === 'development' ? 1 * MINUTE : 5 * SECOND;
 const INTERVAL_MULTIPLIER = 1.1;
 
 export function useNotificationsFetch({


### PR DESCRIPTION
This PR adjusts the interval for when notifications are fetched in development mode, to make it easier to filter through requests in the debug console while testing/debugging/etc.

I set the development time interval to 1 minute, but that can be adjusted easily if needed.

### Checklist

- [X] Self-review the PR after opening it to make sure the changes look good
      and self-explanatory (or properly documented)
- [ ] Add automated tests
- [ ] Add relevant issue to release milestone

### Testing instructions

- [ ] Check that production mode still has requests about every 5 seconds.
- [ ]  Check that development mode has requests about every minute.