### PR TITLE
Use a backend solution for synonym concat

### DIFF
--- a/specifyweb/frontend/js_src/lib/components/TreeView/Row.tsx
+++ b/specifyweb/frontend/js_src/lib/components/TreeView/Row.tsx
@@ -230,7 +230,7 @@ export function TreeRow<SCHEMA extends AnyTree>({
                       ? treeText.acceptedName({
                           name: row.acceptedName ?? row.acceptedId.toString(),
                         })
-                      :typeof row.synonyms === 'string'
+                      : typeof row.synonyms === 'string'
                       ? treeText.synonyms({
                           names: row.synonyms,
                         })

--- a/specifyweb/frontend/js_src/lib/components/TreeView/Row.tsx
+++ b/specifyweb/frontend/js_src/lib/components/TreeView/Row.tsx
@@ -231,11 +231,11 @@ export function TreeRow<SCHEMA extends AnyTree>({
                           name: row.acceptedName ?? row.acceptedId.toString(),
                         })
                       : // Backend will never return undefined...
-                      row.synonymConcat === null
-                      ? undefined
-                      : treeText.synonyms({
-                          names: row.synonymConcat,
+                      typeof row.synonyms === 'string'
+                      ? treeText.synonyms({
+                          names: row.synonyms,
                         })
+                      : undefined
                   }
                 >
                   {doIncludeAuthorPref &&

--- a/specifyweb/frontend/js_src/lib/components/TreeView/Row.tsx
+++ b/specifyweb/frontend/js_src/lib/components/TreeView/Row.tsx
@@ -230,8 +230,7 @@ export function TreeRow<SCHEMA extends AnyTree>({
                       ? treeText.acceptedName({
                           name: row.acceptedName ?? row.acceptedId.toString(),
                         })
-                      : // Backend will never return undefined...
-                      typeof row.synonyms === 'string'
+                      :typeof row.synonyms === 'string'
                       ? treeText.synonyms({
                           names: row.synonyms,
                         })

--- a/specifyweb/frontend/js_src/lib/components/TreeView/Row.tsx
+++ b/specifyweb/frontend/js_src/lib/components/TreeView/Row.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 
-import { useAsyncState } from '../../hooks/useAsyncState';
 import { useId } from '../../hooks/useId';
 import { commonText } from '../../localization/common';
 import { treeText } from '../../localization/tree';
@@ -8,7 +7,6 @@ import type { RA } from '../../utils/types';
 import { Button } from '../Atoms/Button';
 import { className } from '../Atoms/className';
 import { icons } from '../Atoms/Icons';
-import { fetchRows } from '../DataModel/collection';
 import type { AnyTree } from '../DataModel/helperTypes';
 import { getPref } from '../InitialContext/remotePrefs';
 import { userPreferences } from '../Preferences/userPreferences';

--- a/specifyweb/frontend/js_src/lib/components/TreeView/Row.tsx
+++ b/specifyweb/frontend/js_src/lib/components/TreeView/Row.tsx
@@ -150,21 +150,6 @@ export function TreeRow<SCHEMA extends AnyTree>({
   const hasNoChildrenNodes =
     nodeStats?.directCount === 0 && nodeStats.childCount === 0;
 
-  const acceptedChildrenKey = `accepted${treeName.toLowerCase()}`;
-  const [synonymsNames] = useAsyncState(
-    React.useCallback(
-      async () =>
-        fetchRows(treeName as 'Taxon', {
-          fields: { name: ['string'] },
-          limit: 0,
-          [acceptedChildrenKey]: row.nodeId,
-          domainFilter: false,
-        }).then((rows) => rows.map(({ name }) => name)),
-      [acceptedChildrenKey, treeName, row.nodeId]
-    ),
-    false
-  );
-
   return hideEmptyNodes && hasNoChildrenNodes ? null : (
     <li role="treeitem row">
       {ranks.map((rankId) => {
@@ -247,11 +232,11 @@ export function TreeRow<SCHEMA extends AnyTree>({
                       ? treeText.acceptedName({
                           name: row.acceptedName ?? row.acceptedId.toString(),
                         })
-                      : synonymsNames === undefined ||
-                        synonymsNames.length === 0
+                        // backend will never return undefined...
+                      : row.synonymConcat === null
                       ? undefined
                       : treeText.synonyms({
-                          names: synonymsNames.join(', '),
+                          names: row.synonymConcat,
                         })
                   }
                 >

--- a/specifyweb/frontend/js_src/lib/components/TreeView/Row.tsx
+++ b/specifyweb/frontend/js_src/lib/components/TreeView/Row.tsx
@@ -230,8 +230,8 @@ export function TreeRow<SCHEMA extends AnyTree>({
                       ? treeText.acceptedName({
                           name: row.acceptedName ?? row.acceptedId.toString(),
                         })
-                        // backend will never return undefined...
-                      : row.synonymConcat === null
+                      : // Backend will never return undefined...
+                      row.synonymConcat === null
                       ? undefined
                       : treeText.synonyms({
                           names: row.synonymConcat,

--- a/specifyweb/frontend/js_src/lib/components/TreeView/helpers.ts
+++ b/specifyweb/frontend/js_src/lib/components/TreeView/helpers.ts
@@ -24,9 +24,9 @@ export const fetchRows = async (fetchUrl: string) =>
         number,
         number | null,
         string | null,
-        string,
+        string | null,
         number,
-        string
+        string | null
       ]
     >
   >(fetchUrl, {

--- a/specifyweb/frontend/js_src/lib/components/TreeView/helpers.ts
+++ b/specifyweb/frontend/js_src/lib/components/TreeView/helpers.ts
@@ -45,7 +45,7 @@ export const fetchRows = async (fetchUrl: string) =>
           acceptedName = undefined,
           author = undefined,
           children,
-          synonymConcat
+          synonyms = undefined
         ],
         index,
         { length }
@@ -61,7 +61,7 @@ export const fetchRows = async (fetchUrl: string) =>
         author,
         children,
         isLastChild: index + 1 === length,
-        synonymConcat
+        synonyms
       })
     )
   );

--- a/specifyweb/frontend/js_src/lib/components/TreeView/helpers.ts
+++ b/specifyweb/frontend/js_src/lib/components/TreeView/helpers.ts
@@ -45,7 +45,7 @@ export const fetchRows = async (fetchUrl: string) =>
           acceptedName = undefined,
           author = undefined,
           children,
-          synonyms = undefined
+          synonyms = undefined,
         ],
         index,
         { length }
@@ -61,7 +61,7 @@ export const fetchRows = async (fetchUrl: string) =>
         author,
         children,
         isLastChild: index + 1 === length,
-        synonyms
+        synonyms,
       })
     )
   );

--- a/specifyweb/frontend/js_src/lib/components/TreeView/helpers.ts
+++ b/specifyweb/frontend/js_src/lib/components/TreeView/helpers.ts
@@ -25,7 +25,8 @@ export const fetchRows = async (fetchUrl: string) =>
         number | null,
         string | null,
         string,
-        number
+        number,
+        string
       ]
     >
   >(fetchUrl, {
@@ -44,6 +45,7 @@ export const fetchRows = async (fetchUrl: string) =>
           acceptedName = undefined,
           author = undefined,
           children,
+          synonymConcat
         ],
         index,
         { length }
@@ -59,6 +61,7 @@ export const fetchRows = async (fetchUrl: string) =>
         author,
         children,
         isLastChild: index + 1 === length,
+        synonymConcat
       })
     )
   );

--- a/specifyweb/specify/tests/test_trees.py
+++ b/specifyweb/specify/tests/test_trees.py
@@ -4,7 +4,11 @@ from specifyweb.specify import api, models
 from specifyweb.specify.tests.test_api import ApiTests, get_table
 from specifyweb.specify.tree_stats import get_tree_stats
 from specifyweb.specify.tree_extras import set_fullnames
+from specifyweb.specify.tree_views import get_tree_rows
+from specifyweb.stored_queries.execution import set_group_concat_max_len
 from specifyweb.stored_queries.tests import SQLAlchemySetup
+from contextlib import contextmanager
+from django.db import connection
 
 class TestTreeSetup(ApiTests):
     def setUp(self) -> None:
@@ -30,103 +34,42 @@ class TestTreeSetup(ApiTests):
         self.taxontreedef.treedefitems.create(name='Subspecies', rankid=230)
 
 class TestTree:
+
     def setUp(self)->None:
         super().setUp()
-        self.earth = get_table('Geography').objects.create(
-            name="Earth",
-            definitionitem=get_table('Geographytreedefitem').objects.get(name="Planet"),
-            definition=self.geographytreedef,
-        )
+    
+        self.earth = self.make_geotree("Earth", "Planet")
 
-        self.na = get_table('Geography').objects.create(
-            name="North America",
-            definitionitem=get_table('Geographytreedefitem').objects.get(name="Continent"),
-            definition=self.geographytreedef,
-            parent=self.earth,
-        )
+        self.na = self.make_geotree("North America", "Continent", parent=self.earth)
 
-        self.usa = get_table('Geography').objects.create(
-            name="USA",
-            definitionitem=get_table('Geographytreedefitem').objects.get(name="Country"),
-            definition=self.geographytreedef,
-            parent=self.na,
-        )
+        self.usa = self.make_geotree("USA", "Country", parent=self.na)
 
-        self.kansas = get_table('Geography').objects.create(
-            name="Kansas",
-            definitionitem=get_table('Geographytreedefitem').objects.get(name="State"),
-            definition=self.geographytreedef,
-            parent=self.usa,
-        )
+        self.kansas = self.make_geotree("Kansas", "State", parent=self.usa)
+        self.mo = self.make_geotree("Missouri", "State", parent=self.usa)
+        self.ohio = self.make_geotree("Ohio", "State", parent=self.usa)
+        self.ill = self.make_geotree("Illinois", "State", parent=self.usa)
 
-        self.mo = get_table('Geography').objects.create(
-            name="Missouri",
-            definitionitem=get_table('Geographytreedefitem').objects.get(name="State"),
-            definition=self.geographytreedef,
-            parent=self.usa,
-        )
+        self.doug = self.make_geotree("Douglas", "County", parent=self.kansas)
+        self.greene = self.make_geotree("Greene", "County", parent=self.mo)
+        self.greeneoh = self.make_geotree("Greene", "County", parent=self.ohio)
+        self.sangomon = self.make_geotree("Sangamon", "County", parent=self.ill)
 
-        self.ohio = get_table('Geography').objects.create(
-            name="Ohio",
-            definitionitem=get_table('Geographytreedefitem').objects.get(name="State"),
-            definition=self.geographytreedef,
-            parent=self.usa,
-        )
+        self.springmo = self.make_geotree("Springfield", "City", parent=self.greene)
+        self.springill = self.make_geotree("Springfield", "City", parent=self.sangomon)
 
-        self.ill = get_table('Geography').objects.create(
-            name="Illinois",
-            definitionitem=get_table('Geographytreedefitem').objects.get(name="State"),
+    def make_geotree(self, name, rank_name, **extra_kwargs):
+        return get_table("Geography").objects.create(
+            name=name,
+            definitionitem=get_table('Geographytreedefitem').objects.get(name=rank_name),
             definition=self.geographytreedef,
-            parent=self.usa,
+            **extra_kwargs
         )
-
-        self.doug = get_table('Geography').objects.create(
-            name="Douglas",
-            definitionitem=get_table('Geographytreedefitem').objects.get(name="County"),
-            definition=self.geographytreedef,
-            parent=self.kansas,
-        )
-
-        self.greene = get_table('Geography').objects.create(
-            name="Greene",
-            definitionitem=get_table('Geographytreedefitem').objects.get(name="County"),
-            definition=self.geographytreedef,
-            parent=self.mo,
-        )
-
-        self.greeneoh = get_table('Geography').objects.create(
-            name="Greene",
-            definitionitem=get_table('Geographytreedefitem').objects.get(name="County"),
-            definition=self.geographytreedef,
-            parent=self.ohio,
-        )
-
-        self.sangomon = get_table('Geography').objects.create(
-            name="Sangamon",
-            definitionitem=get_table('Geographytreedefitem').objects.get(name="County"),
-            definition=self.geographytreedef,
-            parent=self.ill,
-        )
-
-        self.springmo = get_table('Geography').objects.create(
-            name="Springfield",
-            definitionitem=get_table('Geographytreedefitem').objects.get(name="City"),
-            definition=self.geographytreedef,
-            parent=self.greene,
-        )
-
-        self.springill = get_table('Geography').objects.create(
-            name="Springfield",
-            definitionitem=get_table('Geographytreedefitem').objects.get(name="City"),
-            definition=self.geographytreedef,
-            parent=self.sangomon,
-        )
-
+    
 class GeographyTree(TestTree, TestTreeSetup): pass
 
 class SqlTreeSetup(SQLAlchemySetup, GeographyTree): pass
 
-class TreeStatsTest(SqlTreeSetup):
+class TreeViewsTest(SqlTreeSetup):
 
     def setUp(self):
         super().setUp()
@@ -180,13 +123,14 @@ class TreeStatsTest(SqlTreeSetup):
         )
 
         def _run_nn_and_cte(*args, **kwargs):
-            cte_results = get_tree_stats(*args, **kwargs, session_context=TreeStatsTest.test_session_context, using_cte=True)
-            node_number_results = get_tree_stats(*args, **kwargs, session_context=TreeStatsTest.test_session_context, using_cte=False)
+            cte_results = get_tree_stats(*args, **kwargs, session_context=TreeViewsTest.test_session_context, using_cte=True)
+            node_number_results = get_tree_stats(*args, **kwargs, session_context=TreeViewsTest.test_session_context, using_cte=False)
             self.assertCountEqual(cte_results, node_number_results)
             return cte_results
 
         self.validate_tree_stats = lambda *args, **kwargs: (
             lambda true_results: self.assertCountEqual(_run_nn_and_cte(*args, **kwargs), true_results))
+        
 
     def test_counts_correctness(self):
         correct_results = {
@@ -204,12 +148,77 @@ class TreeStatsTest(SqlTreeSetup):
             self.sangomon.id: [
                 (self.springill.id, 1, 1)
             ]
-        }
+        } 
 
         _results = [
             self.validate_tree_stats(self.geographytreedef.id, 'geography', parent_id, self.collection)(correct)
             for parent_id, correct in correct_results.items()
         ]
+    
+    def test_test_synonyms_concat(self):
+        self.maxDiff = None
+        na_syn_0 = self.make_geotree("NA Syn 0", "Continent",
+                                     acceptedgeography=self.na, 
+                                     # fullname is not set by default for not-accepted
+                                     fullname="NA Syn 0",
+                                     parent=self.earth
+                                     )
+        na_syn_1 = self.make_geotree("NA Syn 1", "Continent", acceptedgeography=self.na, fullname="NA Syn 1", parent=self.earth)
+
+        usa_syn_0 = self.make_geotree("USA Syn 0", "Country", acceptedgeography=self.usa, parent=self.na, fullname="USA Syn 0")
+        usa_syn_1 = self.make_geotree("USA Syn 1", "Country", acceptedgeography=self.usa, parent=self.na, fullname="USA Syn 1")
+        usa_syn_2 = self.make_geotree("USA Syn 2", "Country", acceptedgeography=self.usa, parent=self.na, fullname="USA Syn 2")
+
+        # need to refresh _some_ nodes (but not all)
+        # just the immediate parents and siblings inserted before us
+        # to be safe, we could refresh all, but I'm not going to, so that bug in those sections can be caught here
+        self.earth.refresh_from_db()
+        self.na.refresh_from_db()
+        self.usa.refresh_from_db()
+
+        na_syn_0.refresh_from_db()
+        na_syn_1.refresh_from_db()
+
+        usa_syn_1.refresh_from_db()
+        usa_syn_0.refresh_from_db()
+
+        @contextmanager
+        def _run_for_row():
+            with TreeViewsTest.test_session_context() as session:
+                # this needs to be run via django, but not directly via test_session_context
+                set_group_concat_max_len(connection.cursor())
+                yield session
+
+        with _run_for_row() as session:
+            results = get_tree_rows(
+                self.geographytreedef.id, "Geography", self.earth.id, "geographyid", False, session
+            )
+            expected = [
+                    (self.na.id, self.na.name, self.na.fullname, self.na.nodenumber, self.na.highestchildnodenumber, self.na.rankid, None, None, 'NULL', self.na.children.count(), 'NA Syn 0, NA Syn 1'),
+                    (na_syn_0.id, na_syn_0.name, na_syn_0.fullname, na_syn_0.nodenumber, na_syn_0.highestchildnodenumber, na_syn_0.rankid, self.na.id, self.na.fullname, 'NULL', na_syn_0.children.count(), None),
+                    (na_syn_1.id, na_syn_1.name, na_syn_1.fullname, na_syn_1.nodenumber, na_syn_1.highestchildnodenumber, na_syn_1.rankid, self.na.id, self.na.fullname, 'NULL', na_syn_1.children.count(), None),
+                ]
+
+            self.assertCountEqual(
+                results,
+                expected
+            )
+        
+        with _run_for_row() as session:
+            results = get_tree_rows(
+                self.geographytreedef.id, "Geography", self.na.id, "name", False, session
+            )
+            expected = [
+                    (self.usa.id, self.usa.name, self.usa.fullname, self.usa.nodenumber, self.usa.highestchildnodenumber, self.usa.rankid, None, None, 'NULL', self.usa.children.count(), 'USA Syn 0, USA Syn 1, USA Syn 2'),
+                    (usa_syn_0.id, usa_syn_0.name, usa_syn_0.fullname, usa_syn_0.nodenumber, usa_syn_0.highestchildnodenumber, usa_syn_0.rankid, self.usa.id, self.usa.fullname, 'NULL', 0, None),
+                    (usa_syn_1.id, usa_syn_1.name, usa_syn_1.fullname, usa_syn_1.nodenumber, usa_syn_1.highestchildnodenumber, usa_syn_1.rankid, self.usa.id, self.usa.fullname, 'NULL', 0, None),
+                    (usa_syn_2.id, usa_syn_2. name, usa_syn_2.fullname, usa_syn_2.nodenumber, usa_syn_2.highestchildnodenumber, usa_syn_2.rankid, self.usa.id, self.usa.fullname, 'NULL', 0, None)
+
+                ]
+            self.assertCountEqual(
+                results,
+                expected
+            )
 
 class AddDeleteRankResourcesTest(ApiTests):
     def test_add_ranks_without_defaults(self):

--- a/specifyweb/specify/tree_extras.py
+++ b/specifyweb/specify/tree_extras.py
@@ -91,7 +91,7 @@ class Tree(models.Model): # FUTURE: class Tree(SpTimestampedModel):
                     "rankid" : self.parent.rankid,
                     "fullName": self.parent.fullname,
                     "parentid": self.parent.parent.id,
-                    "children": list(self.parent.children.values('id', 'fullName'))
+                    "children": list(self.parent.children.values('id', 'fullname'))
                  }
                  })
 

--- a/specifyweb/specify/tree_stats.py
+++ b/specifyweb/specify/tree_stats.py
@@ -75,8 +75,9 @@ def get_tree_stats(treedef, tree, parentid, specify_collection, session_context,
         # I don't even want to use depth, but some pathological tree might have cycles, and CTE depth
         # might be in millions as a custom setting..
 
-        depth = session.query(sql.func.count(getattr(tree_def_item, tree_def_item._id))).filter(
-            getattr(tree_def_item, treedef_col) == int(treedef)).as_scalar()
+        depth_query = session.query(sql.func.count(getattr(tree_def_item, tree_def_item._id))).filter(
+            getattr(tree_def_item, treedef_col) == int(treedef))
+        depth, = list(depth_query)[0]
         query = None
         try:
             if using_cte:

--- a/specifyweb/specify/tree_stats.py
+++ b/specifyweb/specify/tree_stats.py
@@ -12,6 +12,7 @@ logger = logging.getLogger(__name__)
 
 def get_tree_stats(treedef, tree, parentid, specify_collection, session_context, using_cte):
     tree_table = datamodel.get_table(tree)
+    tree_def_item = getattr(models, tree_table.name + 'TreeDefItem')
     parentid = None if parentid == 'null' else int(parentid)
     treedef_col = tree_table.name + "TreeDefID"
 
@@ -62,19 +63,20 @@ def get_tree_stats(treedef, tree, parentid, specify_collection, session_context,
 
 
     results = None
-
     with session_context() as session:
         # The join depth only needs to be enough to reach the bottom of the tree.
-        # That will be the number of distinct rankID values not less than
-        # the rankIDs of the children of parentid.
+        # "correct" depth is depth based on actual tree
+        # "incorrect" depth > "correct" is naively based on item-table
+        # If we use "correct" depth, we will make less joins in CTE (so CTE will be faster)
+        # but, "correct" depth takes too long to compute (needs to look at main tree table)
+        # As a compromise, we look at defitem table for "incorrect" depth, will be higher than "correct"
+        # depth. So yes, technicallly CTE will take "more" time, but experimentation reveals that
+        # CTE's "more" time, is still very much low than time taken to compute "correct" depth.
+        # I don't even want to use depth, but some pathological tree might have cycles, and CTE depth
+        # might be in millions as a custom setting..
 
-        # Also used in Recursive CTE to make sure cycles don't cause crash (very rare)
-
-        highest_rank = session.query(sql.func.min(tree_node.rankId)).filter(
-            tree_node.ParentID == parentid).as_scalar()
-        depth, = \
-            session.query(sql.func.count(distinct(tree_node.rankId))).filter(
-                tree_node.rankId >= highest_rank)[0]
+        depth = session.query(sql.func.count(getattr(tree_def_item, tree_def_item._id))).filter(
+            getattr(tree_def_item, treedef_col) == int(treedef)).as_scalar()
         query = None
         try:
             if using_cte:

--- a/specifyweb/stored_queries/execution.py
+++ b/specifyweb/stored_queries/execution.py
@@ -30,12 +30,12 @@ logger = logging.getLogger(__name__)
 
 SORT_TYPES = [None, asc, desc]
 
-def set_group_concat_max_len(session):
+def set_group_concat_max_len(connection):
     """The default limit on MySQL group concat function is quite
     small. This function increases it for the database connection for
     the given session.
     """
-    session.connection().execute('SET group_concat_max_len = 1024 * 1024 * 1024')
+    connection.execute('SET group_concat_max_len = 1024 * 1024 * 1024')
 
 def filter_by_collection(model, query, collection):
     """Add predicates to the given query to filter result to items scoped
@@ -190,7 +190,7 @@ def query_to_csv(session, collection, user, tableid, field_specs, path,
 
     See build_query for details of the other accepted arguments.
     """
-    set_group_concat_max_len(session)
+    set_group_concat_max_len(session.connection())
     query, __ = build_query(session, collection, user, tableid, field_specs, recordsetid, replace_nulls=True, distinct=distinct)
 
     logger.debug('query_to_csv starting')
@@ -227,7 +227,7 @@ def query_to_kml(session, collection, user, tableid, field_specs, path, captions
 
     See build_query for details of the other accepted arguments.
     """
-    set_group_concat_max_len(session)
+    set_group_concat_max_len(session.connection())
     query, __ = build_query(session, collection, user, tableid, field_specs, recordsetid, replace_nulls=True)
 
     logger.debug('query_to_kml starting')
@@ -529,7 +529,7 @@ def return_loan_preps(collection, user, agent, data):
 def execute(session, collection, user, tableid, distinct, count_only, field_specs, limit, offset, recordsetid=None, formatauditobjs=False):
     "Build and execute a query, returning the results as a data structure for json serialization"
 
-    set_group_concat_max_len(session)
+    set_group_concat_max_len(session.connection())
     query, order_by_exprs = build_query(session, collection, user, tableid, field_specs, recordsetid=recordsetid, formatauditobjs=formatauditobjs, distinct=distinct)
 
     if count_only:

--- a/specifyweb/stored_queries/tests.py
+++ b/specifyweb/stored_queries/tests.py
@@ -55,7 +55,6 @@ with session.context() as session:
 
 """
 
-
 class SQLAlchemySetup(ApiTests):
 
     test_sa_url = None
@@ -85,7 +84,7 @@ class SQLAlchemySetup(ApiTests):
             columns = django_cursor.description
             django_cursor.close()
             # SqlAlchemy needs to find columns back in the rows, hence adding label to columns
-            selects = [sqlalchemy.select([sqlalchemy.literal(column).label(columns[idx][0]) for idx, column in enumerate(row)]) for row
+            selects = [sqlalchemy.select([sqlalchemy.literal(sqlalchemy.null() if column is None else column).label(columns[idx][0]) for idx, column in enumerate(row)]) for row
                        in result_set]
             # union all instead of union because rows can be duplicated in the original query,
             # but still need to preserve the duplication
@@ -93,7 +92,6 @@ class SQLAlchemySetup(ApiTests):
             # Tests will fail when migrated to different background. TODO: Auto-detect dialects
             final_query = str(unioned.compile(compile_kwargs={"literal_binds": True, }, dialect=mysql.dialect()))
             return final_query, ()
-
 
 
 class SQLAlchemySetupTest(SQLAlchemySetup):


### PR DESCRIPTION
Fixes #5067 

Moves the logic for concatenating syn's full names on the backend rather than the frontend. 

### Checklist

- [x] Self-review the PR after opening it to make sure the changes look good
      and self-explanatory (or properly documented)
- [x] Add automated tests
- [x] Add relevant issue to release milestone

### Testing instructions

**Synonyms**
Same for https://github.com/specify/specify7/pull/4704.
go to any tree
hover over a node that has synonyms

**Tree stats**
Same as in https://github.com/specify/specify7/pull/3613#issuecomment-1792814457
1. go to any tree node
2. tree stats should appear faster than they do in producton