### PR TITLE
Add dialog box to pick a tree definition when creating a Taxon/Determination record

### DIFF
--- a/specifyweb/frontend/js_src/lib/components/Atoms/Link.tsx
+++ b/specifyweb/frontend/js_src/lib/components/Atoms/Link.tsx
@@ -23,7 +23,7 @@ const linkComponent = <EXTRA_PROPS extends IR<unknown> = RR<never, never>>(
   wrap<
     'a',
     EXTRA_PROPS & {
-      readonly href: string;
+      readonly href: string | undefined;
       readonly children?:
         | JSX.Element
         | LocalizedString

--- a/specifyweb/frontend/js_src/lib/components/DataEntryTables/index.tsx
+++ b/specifyweb/frontend/js_src/lib/components/DataEntryTables/index.tsx
@@ -1,21 +1,29 @@
 import React from 'react';
 
+import { usePromise } from '../../hooks/useAsyncState';
 import { useBooleanState } from '../../hooks/useBooleanState';
 import { commonText } from '../../localization/common';
 import { headerText } from '../../localization/header';
+import { wbText } from '../../localization/workbench';
+import { caseInsensitiveHash } from '../../utils/utils';
 import { Ul } from '../Atoms';
+import { Button } from '../Atoms/Button';
 import { DataEntry } from '../Atoms/DataEntry';
 import { icons } from '../Atoms/Icons';
 import { Link } from '../Atoms/Link';
 import { getResourceViewUrl } from '../DataModel/resource';
 import type { SpecifyTable } from '../DataModel/specifyTable';
 import { strictGetTable } from '../DataModel/tables';
+import { treeRanksPromise } from '../InitialContext/treeRanks';
 import { Dialog, dialogClassNames } from '../Molecules/Dialog';
 import { TableIcon } from '../Molecules/TableIcon';
 import { hasTablePermission } from '../Permissions/helpers';
 import { OverlayContext } from '../Router/Router';
 import { EditFormTables } from './Edit';
 import { useDataEntryTables } from './fetchTables';
+import { localized } from '../../utils/types';
+import { f } from '../../utils/functools';
+import { setCache } from '../../utils/cache';
 
 export function FormsDialogOverlay(): JSX.Element {
   const handleClose = React.useContext(OverlayContext);
@@ -35,6 +43,12 @@ export function FormsDialog({
   const tables = useDataEntryTables('form');
   const [isEditing, handleEditing] = useBooleanState();
 
+  const [showTreeDefsDialog, openTreeDefsDialog, closeTreeDefsDialog] =
+    useBooleanState();
+  const [treeDefsTable, setTreeDefsTable] = React.useState<
+    'Taxon' | 'Determination'
+  >();
+
   return isEditing ? (
     <EditFormTables type="form" onClose={handleClose} />
   ) : Array.isArray(tables) ? (
@@ -53,9 +67,20 @@ export function FormsDialog({
             .map((table, index) => (
               <li className="contents" key={index}>
                 <Link.Default
-                  href={getResourceViewUrl(table.name)}
+                  href={
+                    f.includes(['Taxon', 'Determination'], table.name)
+                      ? undefined
+                      : getResourceViewUrl(table.name)
+                  }
                   onClick={
-                    typeof handleSelected === 'function'
+                    f.includes(['Taxon', 'Determination'], table.name)
+                      ? () => {
+                          setTreeDefsTable(
+                            table.name as 'Taxon' | 'Determination'
+                          );
+                          openTreeDefsDialog();
+                        }
+                      : typeof handleSelected === 'function'
                       ? (event): void => {
                           event.preventDefault();
                           handleSelected(strictGetTable(table.name));
@@ -70,6 +95,51 @@ export function FormsDialog({
             ))}
         </Ul>
       </nav>
+      {showTreeDefsDialog && treeDefsTable !== undefined ? (
+        <TreeDefinitionsDialog
+          onClose={closeTreeDefsDialog}
+          onClick={(treeName: string) => {
+            handleSelected?.(strictGetTable(treeDefsTable));
+            setCache('dataEntry', 'treeDef', treeName);
+            globalThis.location.assign(getResourceViewUrl(treeDefsTable));
+          }}
+        />
+      ) : undefined}
     </Dialog>
   ) : null;
+}
+
+// REFACTOR: Consider if this component can be used/replaced with the dialog in PR #5091
+function TreeDefinitionsDialog({
+  onClose: handleClose,
+  onClick: handleClick,
+}: {
+  readonly onClose: () => void;
+  readonly onClick: (treeName: string) => void;
+}): JSX.Element {
+  const [treeDefinitions] = usePromise(treeRanksPromise, true);
+  const definitionsForTreeTaxon = treeDefinitions
+    ? caseInsensitiveHash(treeDefinitions, 'Taxon')
+    : undefined;
+  const definitions = definitionsForTreeTaxon?.map(
+    ({ definition }) => definition
+  );
+
+  return (
+    <Dialog
+      buttons={<Button.DialogClose>{commonText.close()}</Button.DialogClose>}
+      header={wbText.selectTree()}
+      onClose={handleClose}
+    >
+      <Ul>
+        {definitions?.map(({ name }) => (
+          <li key={name} value={name}>
+            <Button.LikeLink onClick={() => handleClick(name)}>
+              {localized(name)}
+            </Button.LikeLink>
+          </li>
+        ))}
+      </Ul>
+    </Dialog>
+  );
 }

--- a/specifyweb/frontend/js_src/lib/utils/cache/definitions.ts
+++ b/specifyweb/frontend/js_src/lib/utils/cache/definitions.ts
@@ -159,12 +159,14 @@ export type CacheDefinitions = {
     readonly showMatchingFields: boolean;
     readonly warningDialog: boolean;
   };
-
   readonly statistics: {
     readonly statsValue: RA<
       RA<RA<{ readonly itemName: string; readonly value: number | string }>>
     >;
   };
+  readonly dataEntry: {
+    readonly treeDef: string;
+  }
 };
 
 export type SortConfigs = {


### PR DESCRIPTION
Fixes #5107

- Selected tree definition is cached and will be used to scope QCBX to only show parent/taxon names for that tree definition (will be implemented in #5111)



### Checklist

- [ ] Self-review the PR after opening it to make sure the changes look good
      and self-explanatory (or properly documented)
- [ ] Add automated tests
- [ ] Add relevant issue to release milestone

### Testing instructions

<!-- What are the steps to verify the fixes/changes in this PR? -->
<!-- Can part of that be replaced by automated tests? -->
