### PR TITLE
chore: reduce console noise

### DIFF
--- a/specifyweb/frontend/js_src/css/main.css
+++ b/specifyweb/frontend/js_src/css/main.css
@@ -150,7 +150,6 @@
   /* Make spinner buttons larger */
   [type='number']:not([readonly], .no-arrows)::-webkit-outer-spin-button,
   [type='number']:not([readonly], .no-arrows)::-webkit-inner-spin-button {
-    -webkit-appearance: inner-spin-button !important;
     @apply absolute right-0 top-0 h-full w-2;
   }
 

--- a/specifyweb/frontend/js_src/lib/components/Core/Entrypoint.tsx
+++ b/specifyweb/frontend/js_src/lib/components/Core/Entrypoint.tsx
@@ -16,8 +16,8 @@ function entrypoint(): void {
 
   interceptLogs();
 
-  console.group('Specify App Starting');
   if (process.env.NODE_ENV === 'production') {
+    console.group('Specify App Starting');
     console.log(
       '%cDocumentation for Developers:\n',
       'font-weight: bold',
@@ -27,7 +27,6 @@ function entrypoint(): void {
   const entrypointName =
     parseDjangoDump<ReturnType<typeof getEntrypointName>>('entrypoint-name') ??
     'main';
-  console.log(entrypointName);
   unlockInitialContext(entrypointName);
 
   globalThis.addEventListener?.('load', () => {

--- a/specifyweb/frontend/js_src/lib/components/Errors/interceptLogs.ts
+++ b/specifyweb/frontend/js_src/lib/components/Errors/interceptLogs.ts
@@ -117,6 +117,13 @@ export function interceptLogs(): void {
       const context = getLogContext();
       const hasContext = Object.keys(context).length > 0;
 
+      // Silencing https://github.com/reactjs/react-modal/issues/808
+      if (
+        args[0] ===
+        "React-Modal: Cannot register modal instance that's already open"
+      )
+        return;
+
       /**
        * If actively redirecting log output, don't print to console
        * (printing object to console prevents garbage collection

--- a/specifyweb/frontend/js_src/lib/components/InitialContext/index.ts
+++ b/specifyweb/frontend/js_src/lib/components/InitialContext/index.ts
@@ -3,10 +3,7 @@
  */
 
 import type { MimeType } from '../../utils/ajax';
-import { f } from '../../utils/functools';
 import { defined } from '../../utils/types';
-import { formatNumber } from '../Atoms/Internationalization';
-import { SECOND } from '../Atoms/timeUnits';
 
 /**
  * This belongs to ./components/toolbar/cachebuster.tsx but was moved here
@@ -56,7 +53,6 @@ export const unlockInitialContext = (entrypoint: typeof entrypointName): void =>
 export const load = async <T>(path: string, mimeType: MimeType): Promise<T> =>
   contextUnlockedPromise.then(async (entrypoint) => {
     if (entrypoint !== 'main') return foreverFetch<T>();
-    const startTime = Date.now();
 
     // Doing async import to avoid a circular dependency
     const { ajax } = await import('../../utils/ajax');
@@ -65,21 +61,7 @@ export const load = async <T>(path: string, mimeType: MimeType): Promise<T> =>
       errorMode: 'visible',
       headers: { Accept: mimeType },
     });
-    const endTime = Date.now();
-    const timePassed = endTime - startTime;
-    // A very crude detection mechanism
-    const isCached = timePassed < 100;
 
-    // So as not to spam the tests
-    if (process.env.NODE_ENV !== 'test')
-      console.log(
-        `${path} %c[${
-          isCached
-            ? 'cached'
-            : `${formatNumber(f.round(timePassed / SECOND, 0.01))}s`
-        }]`,
-        `color: ${isCached ? '#9fa' : '#f99'}`
-      );
     return data;
   });
 

--- a/specifyweb/frontend/js_src/lib/components/Permissions/definitions.ts
+++ b/specifyweb/frontend/js_src/lib/components/Permissions/definitions.ts
@@ -1,20 +1,24 @@
 export const tableActions = ['read', 'create', 'update', 'delete'] as const;
 export const collectionAccessResource = '/system/sp7/collection';
 export const operationPolicies = {
-  '/system/sp7/collection': ['access'],
-  '/admin/user/password': ['update'],
   '/admin/user/agents': ['update'],
-  '/admin/user/sp6/is_admin': ['update'],
-  '/record/merge': ['update', 'delete'],
   '/admin/user/invite_link': ['create'],
   '/admin/user/oic_providers': ['read'],
+  '/admin/user/password': ['update'],
   '/admin/user/sp6/collection_access': ['read', 'update'],
-  '/report': ['execute'],
+  '/admin/user/sp6/is_admin': ['update'],
+  '/attachment_import/dataset': [
+    'create',
+    'update',
+    'delete',
+    'upload',
+    'rollback',
+  ],
   '/export/dwca': ['execute'],
   '/export/feed': ['force_update'],
+  '/permissions/library/roles': ['read', 'create', 'update', 'delete'],
   '/permissions/list_admins': ['read'],
   '/permissions/policies/user': ['read', 'update'],
-  '/permissions/user/roles': ['read', 'update'],
   '/permissions/roles': [
     'read',
     'create',
@@ -22,22 +26,22 @@ export const operationPolicies = {
     'delete',
     'copy_from_library',
   ],
-  '/permissions/library/roles': ['read', 'create', 'update', 'delete'],
-  '/tree/edit/taxon': ['merge', 'move', 'synonymize', 'desynonymize', 'repair'],
+  '/permissions/user/roles': ['read', 'update'],
+  '/querybuilder/query': [
+    'execute',
+    'export_csv',
+    'export_kml',
+    'create_recordset',
+  ],
+  '/record/merge': ['update', 'delete'],
+  '/report': ['execute'],
+  '/system/sp7/collection': ['access'],
   '/tree/edit/geography': [
     'merge',
     'move',
     'synonymize',
     'desynonymize',
     'repair',
-  ],
-  '/tree/edit/storage': [
-    'merge',
-    'move',
-    'synonymize',
-    'desynonymize',
-    'repair',
-    'bulk_move',
   ],
   '/tree/edit/geologictimeperiod': [
     'merge',
@@ -53,12 +57,15 @@ export const operationPolicies = {
     'desynonymize',
     'repair',
   ],
-  '/querybuilder/query': [
-    'execute',
-    'export_csv',
-    'export_kml',
-    'create_recordset',
+  '/tree/edit/storage': [
+    'merge',
+    'move',
+    'bulk_move',
+    'synonymize',
+    'desynonymize',
+    'repair',
   ],
+  '/tree/edit/taxon': ['merge', 'move', 'synonymize', 'desynonymize', 'repair'],
   '/workbench/dataset': [
     'create',
     'update',
@@ -68,13 +75,6 @@ export const operationPolicies = {
     'validate',
     'transfer',
     'create_recordset',
-  ],
-  '/attachment_import/dataset': [
-    'create',
-    'update',
-    'delete',
-    'upload',
-    'rollback',
   ],
 } as const;
 

--- a/specifyweb/frontend/js_src/lib/components/Permissions/index.ts
+++ b/specifyweb/frontend/js_src/lib/components/Permissions/index.ts
@@ -87,7 +87,9 @@ const checkRegistry = async (): Promise<void> =>
       ).then((policies) =>
         sortPolicies(policies) === sortPolicies(operationPolicies)
           ? undefined
-          : error('Front-end has outdated list of operation policies')
+          : error(
+              'Front-end list of operation policies is out of date. To resolve this error, please update "operationPolicies" in specifyweb/frontend/js_src/lib/components/Permissions/definitions.ts based on the response from the http://localhost/permissions/registry/ endpoint'
+            )
       );
 
 export type PermissionsQueryItem = {


### PR DESCRIPTION
All of the following log messages are now removed:

![Screenshot 2024-07-25 at 18 32 03](https://github.com/user-attachments/assets/c7f51497-906a-4c56-b779-fca9fd13e8b0)

![Screenshot 2024-07-25 at 18 35 31](https://github.com/user-attachments/assets/69eb7996-b24a-4941-99c5-9e76d626124a)

Besides fixing/silencing those errors/warnings, I removed the logging of how long each entry point took to fetch.
I initially thought that it would be helpful for keeping an eye on performance and caching, but my eyes have just "learned to ignore" these messages, defeating the point.
If you think they are helpful, I can leave them be - otherwise, less noise!

### Checklist

- [x] Self-review the PR after opening it to make sure the changes look good
      and self-explanatory (or properly documented)

### Testing instructions

Verify there is less noise in the console