### PR TITLE
Implement searching across all trees of a discipline

### DIFF
--- a/specifyweb/barvis/views.py
+++ b/specifyweb/barvis/views.py
@@ -31,17 +31,11 @@ def taxon_bar(request):
     # Implementing the previous SQL query in Django ORM:
     taxon_tree_defs = get_taxon_treedefs(request.specify_collection)
     taxons = (
-        Taxon.objects.filter(definition__in=taxon_tree_defs)
+        Taxon.objects.filter(definition_id__in=taxon_tree_defs)
         .annotate(
-            current_determination_count=Subquery(
-                Determination.objects.filter(taxon_id=OuterRef("id"), iscurrent=True)
-                .values("taxon_id")
-                .annotate(count=Count("*"))
-                .values("count"),
-                output_field=IntegerField(),
-            )
+            current_determination_count=Count('determinations', filter=Q(determinations__iscurrent=True))
         )
-        .values("id", "rankid", "parent_id", "name", "current_determination_count")
+        .values_list("id", "rankid", "parent_id", "name", "current_determination_count")
     )
     result = toJson(list(taxons))
 

--- a/specifyweb/frontend/js_src/lib/utils/cache/definitions.ts
+++ b/specifyweb/frontend/js_src/lib/utils/cache/definitions.ts
@@ -73,6 +73,8 @@ export type CacheDefinitions = {
     readonly applyAll: boolean;
   };
   readonly tree: {
+    readonly [key in `definition${AnyTree['tableName']}`]: number;
+  } & {
     readonly [key in `focusPath${AnyTree['tableName']}`]: RA<number>;
   } & {
     readonly /** Collapsed ranks in a given tree */
@@ -80,8 +82,6 @@ export type CacheDefinitions = {
   } & {
     readonly /** Open nodes in a given tree */
     [key in `conformations${AnyTree['tableName']}`]: Conformations;
-  } & {
-    readonly [key in `definition${AnyTree['tableName']}`]: number;
   } & {
     readonly hideEmptyNodes: boolean;
     readonly isSplit: boolean;

--- a/specifyweb/specify/filter_by_col.py
+++ b/specifyweb/specify/filter_by_col.py
@@ -31,7 +31,7 @@ def filter_by_collection(queryset, collection, strict=True):
 
     if queryset.model is Taxon:
         taxon_tree_defs = get_taxon_treedefs(collection)
-        return queryset.filter(definition__in=taxon_tree_defs)
+        return queryset.filter(definition_id_in=taxon_tree_defs)
 
     if queryset.model is Storage:
         return queryset.filter(definition__institutions=collection.discipline.division.institution.id)

--- a/specifyweb/stored_queries/execution.py
+++ b/specifyweb/stored_queries/execution.py
@@ -13,7 +13,7 @@ from django.db import transaction
 from sqlalchemy import sql, orm, func, select
 from sqlalchemy.sql.expression import asc, desc, insert, literal
 
-from specifyweb.specify.tree_utils import get_taxon_treedef_ids
+from specifyweb.specify.tree_utils import get_taxon_treedefs
 from specifyweb.stored_queries.group_concat import group_by_displayed_fields
 
 from . import models
@@ -52,12 +52,12 @@ def filter_by_collection(model, query, collection):
         return query
 
     if model is models.Taxon:
-        taxon_treedef_ids = get_taxon_treedef_ids(collection)
+        taxon_treedef_ids = get_taxon_treedefs(collection).values_list('id', flat=True)
         logger.info("filtering taxon to collection's collection object types: %s", collection.collectionname)
         return query.filter(model.TaxonTreeDefID.in_(taxon_treedef_ids))
 
     if model is models.TaxonTreeDefItem:
-        taxon_treedef_ids = get_taxon_treedef_ids(collection)
+        taxon_treedef_ids = get_taxon_treedefs(collection).values_list('id', flat=True)
         logger.info("filtering taxon rank to collection's collection object types: %s", collection.collectionname)
         return query.filter(model.TaxonTreeDefID.in_(taxon_treedef_ids))
 
@@ -643,5 +643,5 @@ def build_query(session, collection, user, tableid, field_specs,
     if distinct:
         query = group_by_displayed_fields(query, selected_fields)
 
-    logger.debug("query: %s", query.query)
+    logger.warning("query: %s", query.query)
     return query.query, order_by_exprs

--- a/specifyweb/stored_queries/execution.py
+++ b/specifyweb/stored_queries/execution.py
@@ -52,12 +52,12 @@ def filter_by_collection(model, query, collection):
         return query
 
     if model is models.Taxon:
-        taxon_treedef_ids = get_taxon_treedefs(collection).values_list('id', flat=True)
+        taxon_treedef_ids = get_taxon_treedefs(collection)
         logger.info("filtering taxon to collection's collection object types: %s", collection.collectionname)
         return query.filter(model.TaxonTreeDefID.in_(taxon_treedef_ids))
 
     if model is models.TaxonTreeDefItem:
-        taxon_treedef_ids = get_taxon_treedefs(collection).values_list('id', flat=True)
+        taxon_treedef_ids = get_taxon_treedefs(collection)
         logger.info("filtering taxon rank to collection's collection object types: %s", collection.collectionname)
         return query.filter(model.TaxonTreeDefID.in_(taxon_treedef_ids))
 
@@ -642,6 +642,9 @@ def build_query(session, collection, user, tableid, field_specs,
 
     if distinct:
         query = group_by_displayed_fields(query, selected_fields)
+
+    internal_predicate = query.get_internal_filters(model)
+    query = query.filter(internal_predicate)
 
     logger.warning("query: %s", query.query)
     return query.query, order_by_exprs

--- a/specifyweb/stored_queries/query_construct.py
+++ b/specifyweb/stored_queries/query_construct.py
@@ -1,14 +1,21 @@
 import logging
 from collections import namedtuple, deque
+from typing import Tuple, List
 
 from sqlalchemy import orm, sql
 
-from specifyweb.specify.models import datamodel
+import specifyweb.specify.models as spmodels
 from specifyweb.specify.tree_utils import get_treedef
 
 from specifyweb.stored_queries import models
 
 logger = logging.getLogger(__name__)
+
+def _safe_filter(query):
+    count = query.count()
+    if count <= 1:
+        return query.first()
+    raise Exception(f"Got more than one matching: {list(query)}")
 
 class QueryConstruct(namedtuple('QueryConstruct', 'collection objectformatter query join_cache param_count tree_rank_count')):
 
@@ -29,35 +36,57 @@ class QueryConstruct(namedtuple('QueryConstruct', 'collection objectformatter qu
         logger.info('handling treefield %s rank: %s field: %s', table, tree_rank, tree_field)
 
         treedefitem_column = table.name + 'TreeDefItemID'
+        treedef_column = table.name + 'TreeDefID'
 
         if (table, 'TreeRanks') in query.join_cache:
             logger.debug("using join cache for %r tree ranks.", table)
-            ancestors, treedef = query.join_cache[(table, 'TreeRanks')]
+            ancestors, treedefs = query.join_cache[(table, 'TreeRanks')]
         else:
-            treedef = get_treedef(query.collection, table.name)
-            rank_count = treedef.treedefitems.count()
-
+            
+            treedefs = get_treedef(query.collection, table.name)
+            max_depth = max(depth for _, depth in treedefs)
+            
+            
             ancestors = [node]
-            for i in range(rank_count-1):
+            for i in range(max_depth-1):
                 ancestor = orm.aliased(node)
                 query = query.outerjoin(ancestor, ancestors[-1].ParentID == getattr(ancestor, ancestor._id))
                 ancestors.append(ancestor)
+        
 
             logger.debug("adding to join cache for %r tree ranks.", table)
             query = query._replace(join_cache=query.join_cache.copy())
-            query.join_cache[(table, 'TreeRanks')] = (ancestors, treedef)
+            query.join_cache[(table, 'TreeRanks')] = (ancestors, treedefs)
+
+        item_model = getattr(spmodels, table.name + "treedefitem")
+
+        # TODO: optimize out the ranks that appear? cache them
+        treedefs_with_ranks: List[Tuple[int, int]] = [tup for tup in [
+            (treedef_id, _safe_filter(item_model.objects.filter(treedef_id=treedef_id, name=tree_rank).values_list('id', flat=True)))
+            for treedef_id, _ in treedefs
+            ] if tup[1] is not None]
+
+        assert len(treedefs_with_ranks) >= 1, "Didn't find the tree rank across any tree"
 
         query = query._replace(param_count=self.param_count+1)
-        treedefitem_param = sql.bindparam('tdi_%s' % query.param_count, value=treedef.treedefitems.get(name=tree_rank).id)
 
         column_name = 'name' if tree_field is None else \
                       node._id if tree_field == 'ID' else \
                       table.get_field(tree_field.lower()).name
 
-        column = sql.case([
-            (getattr(ancestor, treedefitem_column) == treedefitem_param, getattr(ancestor, column_name))
+        def _predicates_for_node(_node):
+            return [
+                # TEST: consider taking the treedef_id comparison just to the first node, if it speeds things up (matching for higher is redundant..)
+                (sql.and_(getattr(_node, treedef_column)==treedef_id, getattr(_node, treedefitem_column)==treedefitem_id), getattr(_node, column_name))
+                for (treedef_id, treedefitem_id) in treedefs_with_ranks
+            ]
+        
+        cases_per_ancestor = [
+            _predicates_for_node(ancestor)
             for ancestor in ancestors
-        ])
+            ]
+        
+        column = sql.case([case for per_ancestor in cases_per_ancestor for case in per_ancestor])
 
         return query, column
 
@@ -72,7 +101,7 @@ class QueryConstruct(namedtuple('QueryConstruct', 'collection objectformatter qu
             if not field.is_relationship:
                 break
 
-            tables.append(datamodel.get_table(field.relatedModelName, strict=True))
+            tables.append(spmodels.datamodel.get_table(field.relatedModelName, strict=True))
         return tables
 
     def build_join(self, table, model, join_path):
@@ -86,7 +115,7 @@ class QueryConstruct(namedtuple('QueryConstruct', 'collection objectformatter qu
 
             if not field.is_relationship:
                 break
-            next_table = datamodel.get_table(field.relatedModelName, strict=True)
+            next_table = spmodels.datamodel.get_table(field.relatedModelName, strict=True)
             logger.debug("joining: %r to %r via %r", table, next_table, field)
             if (model, field.name) in query.join_cache:
                 aliased = query.join_cache[(model, field.name)]


### PR DESCRIPTION
Fixes #(something??)

Implements the backend part behind https://github.com/specify/specify7/pull/5036. 

In the current implementation, it queries for a rank (say, Species) across all treedefs in a discipline. So, if you do `Species`, and `Fineral` and `Mossil` both contain `Species`, they both trees will be searched, along with any field to them. If say `Mossil` did not contain the rank Species, then it would not be included in the query result (this is done to avoid the case where ALL nodes from `Mossil` would have been otherwise included). However, it is smart enough to include `Mossil` if any tree rank from `Mossil` is added. @grantfitzsimmons, @CarolineDenis is that what the requirement is? 

EDIT: This does handle geography and other trees just like before

### Checklist

- [ ] Self-review the PR after opening it to make sure the changes look good
      and self-explanatory (or properly documented)
- [ ] Add automated tests
- [ ] Add relevant issue to release milestone

### Testing instructions

<!-- What are the steps to verify the fixes/changes in this PR? -->
<!-- Can part of that be replaced by automated tests? -->
