### PR TITLE
Unblock save when no current determinations exist

### DIFF
--- a/specifyweb/frontend/js_src/lib/components/DataModel/businessRuleDefs.ts
+++ b/specifyweb/frontend/js_src/lib/components/DataModel/businessRuleDefs.ts
@@ -53,12 +53,11 @@ type MappedBusinessRuleDefs = {
 const CURRENT_DETERMINATION_KEY = 'determination-isCurrent';
 const DETERMINATION_TAXON_KEY = 'determination-taxon';
 
-const hasNoCurrentDetermination = (collection: Collection<Determination>) => {
-  return collection.models.length > 0 && !collection.models.some(
-    (determination: SpecifyResource<Determination>) =>
-      determination.get('isCurrent')
+const hasNoCurrentDetermination = (collection: Collection<Determination>) =>
+  collection.models.length > 0 &&
+  !collection.models.some((determination: SpecifyResource<Determination>) =>
+    determination.get('isCurrent')
   );
-};
 
 export const businessRuleDefs: MappedBusinessRuleDefs = {
   Address: {
@@ -266,8 +265,10 @@ export const businessRuleDefs: MappedBusinessRuleDefs = {
       isCurrent: async (
         determination: SpecifyResource<Determination>
       ): Promise<BusinessRuleResult> => {
-        // Disallow multiple determinations being checked as current
-        // Unchecks other determination when one of them gets checked
+        /*
+         * Disallow multiple determinations being checked as current
+         * Unchecks other determination when one of them gets checked
+         */
         if (
           determination.get('isCurrent') &&
           determination.collection !== undefined
@@ -308,8 +309,8 @@ export const businessRuleDefs: MappedBusinessRuleDefs = {
           [resourcesText.currentDeterminationRequired()],
           CURRENT_DETERMINATION_KEY
         );
+      // Unblock save when all determinations are removed
       else
-        // Unblock save when all determinations are removed
         setSaveBlockers(
           collection.related ?? determination,
           determination.specifyTable.field.isCurrent,


### PR DESCRIPTION
Fixes #5189 



### Checklist

- [x] Self-review the PR after opening it to make sure the changes look good
      and self-explanatory (or properly documented)
- [x] Add automated tests
- [x] Add relevant issue to release milestone

### Testing instructions

<!-- What are the steps to verify the fixes/changes in this PR? -->
<!-- Can part of that be replaced by automated tests? -->
- Create a CollectionObject / Open an existing one
- Add determinations
- Remove all determinations manually or by changing CollectionObjectType
- [ ] Verify save does not get blocked due to having no current determination
