### PR TITLE
Add preference to add UTF-8 BOM to CSV exports (For Excel)

### DIFF
--- a/specifyweb/frontend/js_src/lib/components/Preferences/UserDefinitions.tsx
+++ b/specifyweb/frontend/js_src/lib/components/Preferences/UserDefinitions.tsx
@@ -1572,10 +1572,10 @@ export const userPreferenceDefinitions = {
               },
             ],
           }),
-          exportCSVutf8BOM: definePref<boolean>({
-            title: preferencesText.exportCSVutf8BOM(),
+          exportCsvUtf8Bom: definePref<boolean>({
+            title: preferencesText.exportCsvUtf8Bom(),
             description: (
-              <span>{preferencesText.exportCSVutf8BOMDescription()}</span>
+              <span>{preferencesText.exportCsvUtf8BomDescription()}</span>
             ),
             requiresReload: false,
             visible: true,

--- a/specifyweb/frontend/js_src/lib/components/Preferences/UserDefinitions.tsx
+++ b/specifyweb/frontend/js_src/lib/components/Preferences/UserDefinitions.tsx
@@ -1575,9 +1575,7 @@ export const userPreferenceDefinitions = {
           exportCSVutf8BOM: definePref<boolean>({
             title: preferencesText.exportCSVutf8BOM(),
             description: (
-              <span>
-                {preferencesText.exportCSVutf8BOMDescription()}
-              </span>
+              <span>{preferencesText.exportCSVutf8BOMDescription()}</span>
             ),
             requiresReload: false,
             visible: true,

--- a/specifyweb/frontend/js_src/lib/components/Preferences/UserDefinitions.tsx
+++ b/specifyweb/frontend/js_src/lib/components/Preferences/UserDefinitions.tsx
@@ -1579,7 +1579,7 @@ export const userPreferenceDefinitions = {
             ),
             requiresReload: false,
             visible: true,
-            defaultValue: false,
+            defaultValue: true,
             type: 'java.lang.Boolean',
           }),
           displayBasicView: definePref<boolean>({

--- a/specifyweb/frontend/js_src/lib/components/Preferences/UserDefinitions.tsx
+++ b/specifyweb/frontend/js_src/lib/components/Preferences/UserDefinitions.tsx
@@ -1572,6 +1572,18 @@ export const userPreferenceDefinitions = {
               },
             ],
           }),
+          exportCSVutf8BOM: definePref<boolean>({
+            title: preferencesText.exportCSVutf8BOM(),
+            description: (
+              <span>
+                {preferencesText.exportCSVutf8BOMDescription()}
+              </span>
+            ),
+            requiresReload: false,
+            visible: true,
+            defaultValue: false,
+            type: 'java.lang.Boolean',
+          }),
           displayBasicView: definePref<boolean>({
             title: preferencesText.displayBasicView(),
             requiresReload: false,

--- a/specifyweb/frontend/js_src/lib/components/QueryBuilder/Export.tsx
+++ b/specifyweb/frontend/js_src/lib/components/QueryBuilder/Export.tsx
@@ -83,10 +83,10 @@ export function QueryExportButtons({
     'exportFileDelimiter'
   );
 
-  const [utf8BOM] = userPreferences.use(
+  const [utf8Bom] = userPreferences.use(
     'queryBuilder',
     'behavior',
-    'exportCSVutf8BOM'
+    'exportCsvUtf8Bom'
   );
 
   /*
@@ -116,7 +116,7 @@ export function QueryExportButtons({
         generateMappingPathPreview(baseTableName, field.mappingPath)
       );
 
-    return downloadDataSet(name, filteredResults, columnsName, separator, utf8BOM);
+    return downloadDataSet(name, filteredResults, columnsName, separator, utf8Bom);
   }
 
   const containsResults = results.current?.some((row) => row !== undefined);
@@ -155,7 +155,7 @@ export function QueryExportButtons({
               ? doQueryExport(
                   '/stored_query/exportcsv/',
                   separator,
-                  utf8BOM
+                  utf8Bom
                 )
               : exportSelected().catch(softFail);
           }}

--- a/specifyweb/frontend/js_src/lib/components/QueryBuilder/Export.tsx
+++ b/specifyweb/frontend/js_src/lib/components/QueryBuilder/Export.tsx
@@ -153,7 +153,11 @@ export function QueryExportButtons({
           showConfirmation={showConfirmation}
           onClick={(): void => {
             selectedRows.size === 0
-              ? doQueryExport('/stored_query/exportcsv/', separator, csvEncoding)
+              ? doQueryExport(
+                  '/stored_query/exportcsv/',
+                  separator,
+                  csvEncoding
+                )
               : exportSelected().catch(softFail);
           }}
         >

--- a/specifyweb/frontend/js_src/lib/components/QueryBuilder/Export.tsx
+++ b/specifyweb/frontend/js_src/lib/components/QueryBuilder/Export.tsx
@@ -51,7 +51,7 @@ export function QueryExportButtons({
     undefined
   );
 
-  function doQueryExport(url: string, delimiter: string | undefined): void {
+  function doQueryExport(url: string, delimiter: string | undefined, encoding: string | undefined): void {
     if (typeof getQueryFieldRecords === 'function')
       queryResource.set('fields', getQueryFieldRecords());
     const serialized = queryResource.toJSON();
@@ -67,6 +67,7 @@ export function QueryExportButtons({
           ),
         recordSetId,
         delimiter,
+        encoding,
       }),
       errorMode: 'dismissible',
     });
@@ -141,11 +142,24 @@ export function QueryExportButtons({
           showConfirmation={showConfirmation}
           onClick={(): void => {
             selectedRows.size === 0
-              ? doQueryExport('/stored_query/exportcsv/', separator)
+              ? doQueryExport('/stored_query/exportcsv/', separator, 'utf-8')
               : exportSelected().catch(softFail);
           }}
         >
           {queryText.createCsv()}
+        </QueryButton>
+      )}
+      {containsResults && hasPermission('/querybuilder/query', 'export_csv') && (
+        <QueryButton
+          disabled={fields.length === 0}
+          showConfirmation={showConfirmation}
+          onClick={(): void => {
+            selectedRows.size === 0
+              ? doQueryExport('/stored_query/exportcsv/', separator, 'utf-8-sig')
+              : exportSelected().catch(softFail);
+          }}
+        >
+          {queryText.createExcelCsv()}
         </QueryButton>
       )}
       {canUseKml && (
@@ -154,7 +168,7 @@ export function QueryExportButtons({
           showConfirmation={showConfirmation}
           onClick={(): void =>
             hasLocalityColumns(fields)
-              ? doQueryExport('/stored_query/exportkml/', undefined)
+              ? doQueryExport('/stored_query/exportkml/', undefined, undefined)
               : setState('warning')
           }
         >

--- a/specifyweb/frontend/js_src/lib/components/QueryBuilder/Export.tsx
+++ b/specifyweb/frontend/js_src/lib/components/QueryBuilder/Export.tsx
@@ -54,7 +54,7 @@ export function QueryExportButtons({
   function doQueryExport(
     url: string,
     delimiter: string | undefined,
-    encoding: string | undefined
+    bom: boolean | undefined
   ): void {
     if (typeof getQueryFieldRecords === 'function')
       queryResource.set('fields', getQueryFieldRecords());
@@ -71,7 +71,7 @@ export function QueryExportButtons({
           ),
         recordSetId,
         delimiter,
-        encoding,
+        bom,
       }),
       errorMode: 'dismissible',
     });
@@ -88,7 +88,6 @@ export function QueryExportButtons({
     'behavior',
     'exportCSVutf8BOM'
   );
-  const csvEncoding = utf8BOM ? 'utf-8-sig' : 'utf-8';
 
   /*
    *Will be only called if query is not distinct,
@@ -117,7 +116,7 @@ export function QueryExportButtons({
         generateMappingPathPreview(baseTableName, field.mappingPath)
       );
 
-    return downloadDataSet(name, filteredResults, columnsName, separator);
+    return downloadDataSet(name, filteredResults, columnsName, separator, utf8BOM);
   }
 
   const containsResults = results.current?.some((row) => row !== undefined);
@@ -156,7 +155,7 @@ export function QueryExportButtons({
               ? doQueryExport(
                   '/stored_query/exportcsv/',
                   separator,
-                  csvEncoding
+                  utf8BOM
                 )
               : exportSelected().catch(softFail);
           }}

--- a/specifyweb/frontend/js_src/lib/components/QueryBuilder/Export.tsx
+++ b/specifyweb/frontend/js_src/lib/components/QueryBuilder/Export.tsx
@@ -116,7 +116,13 @@ export function QueryExportButtons({
         generateMappingPathPreview(baseTableName, field.mappingPath)
       );
 
-    return downloadDataSet(name, filteredResults, columnsName, separator, utf8Bom);
+    return downloadDataSet(
+      name,
+      filteredResults,
+      columnsName,
+      separator,
+      utf8Bom
+    );
   }
 
   const containsResults = results.current?.some((row) => row !== undefined);
@@ -152,11 +158,7 @@ export function QueryExportButtons({
           showConfirmation={showConfirmation}
           onClick={(): void => {
             selectedRows.size === 0
-              ? doQueryExport(
-                  '/stored_query/exportcsv/',
-                  separator,
-                  utf8Bom
-                )
+              ? doQueryExport('/stored_query/exportcsv/', separator, utf8Bom)
               : exportSelected().catch(softFail);
           }}
         >

--- a/specifyweb/frontend/js_src/lib/components/QueryBuilder/Export.tsx
+++ b/specifyweb/frontend/js_src/lib/components/QueryBuilder/Export.tsx
@@ -79,6 +79,13 @@ export function QueryExportButtons({
     'exportFileDelimiter'
   );
 
+  const [utf8BOM] = userPreferences.use(
+    'queryBuilder',
+    'behavior',
+    'exportCSVutf8BOM'
+  );
+  const csvEncoding = utf8BOM ? 'utf-8-sig' : 'utf-8';
+
   /*
    *Will be only called if query is not distinct,
    *selection not enabled when distinct selected
@@ -142,24 +149,11 @@ export function QueryExportButtons({
           showConfirmation={showConfirmation}
           onClick={(): void => {
             selectedRows.size === 0
-              ? doQueryExport('/stored_query/exportcsv/', separator, 'utf-8')
+              ? doQueryExport('/stored_query/exportcsv/', separator, csvEncoding)
               : exportSelected().catch(softFail);
           }}
         >
           {queryText.createCsv()}
-        </QueryButton>
-      )}
-      {containsResults && hasPermission('/querybuilder/query', 'export_csv') && (
-        <QueryButton
-          disabled={fields.length === 0}
-          showConfirmation={showConfirmation}
-          onClick={(): void => {
-            selectedRows.size === 0
-              ? doQueryExport('/stored_query/exportcsv/', separator, 'utf-8-sig')
-              : exportSelected().catch(softFail);
-          }}
-        >
-          {queryText.createExcelCsv()}
         </QueryButton>
       )}
       {canUseKml && (

--- a/specifyweb/frontend/js_src/lib/components/WorkBench/helpers.ts
+++ b/specifyweb/frontend/js_src/lib/components/WorkBench/helpers.ts
@@ -7,13 +7,15 @@ export const downloadDataSet = async (
   name: string,
   rows: RA<RA<string>>,
   columns: RA<string>,
-  delimiter: string
+  delimiter: string,
+  bom: boolean = false
 ): Promise<void> =>
   new Promise((resolve, reject) =>
     stringify(
       [columns, ...rows],
       {
         delimiter,
+        bom,
       },
       (error, output) => {
         if (error === undefined)

--- a/specifyweb/frontend/js_src/lib/localization/preferences.ts
+++ b/specifyweb/frontend/js_src/lib/localization/preferences.ts
@@ -1060,6 +1060,22 @@ export const preferencesText = createDictionary({
     'uk-ua': 'Роздільник файлу експорту',
     'de-ch': 'Trennzeichen für Exportdateien',
   },
+  exportCSVutf8BOM: {
+    'en-us': 'Add UTF-8 BOM to CSV file exports',
+    'ru-ru': 'Добавить UTF-8 BOM в экспорт CSV-файла',
+    'es-es': 'Agregar BOM UTF-8 a las exportaciones de archivos CSV',
+    'fr-fr': "Ajouter UTF-8 BOM aux exportations de fichiers CSV",
+    'uk-ua': 'Додайте специфікацію UTF-8 до експорту файлу CSVу',
+    'de-ch': 'UTF-8 BOM zum CSV-Dateiexport hinzufügen',
+  },
+  exportCSVutf8BOMDescription: {
+    'en-us': 'Makes CSV file exports display correctly in Excel.',
+    'ru-ru': 'Корректное отображение экспортированных CSV-файлов в Excel.',
+    'es-es': 'Hace que las exportaciones de archivos CSV se muestren correctamente en Excel.',
+    'fr-fr': "Permet aux exportations de fichiers CSV de s'afficher correctement dans Excel.",
+    'uk-ua': 'Змушує експорт файлів CSV правильно відображатися в Excel.',
+    'de-ch': 'Sorgt dafür, dass CSV-Dateiexporte in Excel korrekt angezeigt werden.',
+  },
   caseSensitive: {
     'en-us': 'Case-sensitive',
     'ru-ru': 'С учетом регистра',

--- a/specifyweb/frontend/js_src/lib/localization/preferences.ts
+++ b/specifyweb/frontend/js_src/lib/localization/preferences.ts
@@ -1069,7 +1069,7 @@ export const preferencesText = createDictionary({
     'de-ch': 'UTF-8 BOM zum CSV-Dateiexport hinzufügen',
   },
   exportCSVutf8BOMDescription: {
-    'en-us': 'Makes CSV file exports display correctly in Excel.',
+    'en-us': 'Adds a BOM (Byte Order Mark) to exported CSV files to ensure that the file is correctly recognized and displayed by various programs (Excel, OpenRefine, etc.), preventing issues with special characters and formatting.',
     'ru-ru': 'Корректное отображение экспортированных CSV-файлов в Excel.',
     'es-es':
       'Hace que las exportaciones de archivos CSV se muestren correctamente en Excel.',

--- a/specifyweb/frontend/js_src/lib/localization/preferences.ts
+++ b/specifyweb/frontend/js_src/lib/localization/preferences.ts
@@ -1064,17 +1064,20 @@ export const preferencesText = createDictionary({
     'en-us': 'Add UTF-8 BOM to CSV file exports',
     'ru-ru': 'Добавить UTF-8 BOM в экспорт CSV-файла',
     'es-es': 'Agregar BOM UTF-8 a las exportaciones de archivos CSV',
-    'fr-fr': "Ajouter UTF-8 BOM aux exportations de fichiers CSV",
+    'fr-fr': 'Ajouter UTF-8 BOM aux exportations de fichiers CSV',
     'uk-ua': 'Додайте специфікацію UTF-8 до експорту файлу CSVу',
     'de-ch': 'UTF-8 BOM zum CSV-Dateiexport hinzufügen',
   },
   exportCSVutf8BOMDescription: {
     'en-us': 'Makes CSV file exports display correctly in Excel.',
     'ru-ru': 'Корректное отображение экспортированных CSV-файлов в Excel.',
-    'es-es': 'Hace que las exportaciones de archivos CSV se muestren correctamente en Excel.',
-    'fr-fr': "Permet aux exportations de fichiers CSV de s'afficher correctement dans Excel.",
+    'es-es':
+      'Hace que las exportaciones de archivos CSV se muestren correctamente en Excel.',
+    'fr-fr':
+      "Permet aux exportations de fichiers CSV de s'afficher correctement dans Excel.",
     'uk-ua': 'Змушує експорт файлів CSV правильно відображатися в Excel.',
-    'de-ch': 'Sorgt dafür, dass CSV-Dateiexporte in Excel korrekt angezeigt werden.',
+    'de-ch':
+      'Sorgt dafür, dass CSV-Dateiexporte in Excel korrekt angezeigt werden.',
   },
   caseSensitive: {
     'en-us': 'Case-sensitive',

--- a/specifyweb/frontend/js_src/lib/localization/preferences.ts
+++ b/specifyweb/frontend/js_src/lib/localization/preferences.ts
@@ -1060,7 +1060,7 @@ export const preferencesText = createDictionary({
     'uk-ua': 'Роздільник файлу експорту',
     'de-ch': 'Trennzeichen für Exportdateien',
   },
-  exportCSVutf8BOM: {
+  exportCsvUtf8Bom: {
     'en-us': 'Add UTF-8 BOM to CSV file exports',
     'ru-ru': 'Добавить UTF-8 BOM в экспорт CSV-файла',
     'es-es': 'Agregar BOM UTF-8 a las exportaciones de archivos CSV',
@@ -1068,7 +1068,7 @@ export const preferencesText = createDictionary({
     'uk-ua': 'Додайте специфікацію UTF-8 до експорту файлу CSVу',
     'de-ch': 'UTF-8 BOM zum CSV-Dateiexport hinzufügen',
   },
-  exportCSVutf8BOMDescription: {
+  exportCsvUtf8BomDescription: {
     'en-us': 'Adds a BOM (Byte Order Mark) to exported CSV files to ensure that the file is correctly recognized and displayed by various programs (Excel, OpenRefine, etc.), preventing issues with special characters and formatting.',
     'ru-ru': 'Корректное отображение экспортированных CSV-файлов в Excel.',
     'es-es':

--- a/specifyweb/frontend/js_src/lib/localization/query.ts
+++ b/specifyweb/frontend/js_src/lib/localization/query.ts
@@ -311,6 +311,14 @@ export const queryText = createDictionary({
     'uk-ua': 'Створити CSV',
     'de-ch': 'CSV erstellen',
   },
+  createExcelCsv: {
+    'en-us': 'Create Excel CSV',
+    'ru-ru': 'Создать файл Excel CSV',
+    'es-es': 'Crear CSV de Excel',
+    'fr-fr': 'Créer un CSV Excel',
+    'uk-ua': 'Створіть Excel CSV',
+    'de-ch': 'Excel-CSV erstellen',
+  },
   createKml: {
     'en-us': 'Create KML',
     'ru-ru': 'Создать KML',

--- a/specifyweb/frontend/js_src/lib/localization/query.ts
+++ b/specifyweb/frontend/js_src/lib/localization/query.ts
@@ -311,14 +311,6 @@ export const queryText = createDictionary({
     'uk-ua': 'Створити CSV',
     'de-ch': 'CSV erstellen',
   },
-  createExcelCsv: {
-    'en-us': 'Create Excel CSV',
-    'ru-ru': 'Создать файл Excel CSV',
-    'es-es': 'Crear CSV de Excel',
-    'fr-fr': 'Créer un CSV Excel',
-    'uk-ua': 'Створіть Excel CSV',
-    'de-ch': 'Excel-CSV erstellen',
-  },
   createKml: {
     'en-us': 'Create KML',
     'ru-ru': 'Создать KML',

--- a/specifyweb/stored_queries/execution.py
+++ b/specifyweb/stored_queries/execution.py
@@ -158,7 +158,7 @@ def do_export(spquery, collection, user, filename, exporttype, host):
             query_to_csv(session, collection, user, tableid, field_specs, path,
                          recordsetid=recordsetid, 
                          captions=spquery['captions'], strip_id=True,
-                         distinct=spquery['selectdistinct'], delimiter=spquery['delimiter'], encoding=spquery['encoding'])
+                         distinct=spquery['selectdistinct'], delimiter=spquery['delimiter'], bom=spquery['bom'])
         elif exporttype == 'kml':
             query_to_kml(session, collection, user, tableid, field_specs, path, spquery['captions'], host,
                          recordsetid=recordsetid, strip_id=False)
@@ -186,7 +186,7 @@ def stored_query_to_csv(query_id, collection, user, path):
 
 def query_to_csv(session, collection, user, tableid, field_specs, path,
                  recordsetid=None, captions=False, strip_id=False, row_filter=None,
-                 distinct=False, delimiter=',', encoding='utf-8'):
+                 distinct=False, delimiter=',', bom=False):
     """Build a sqlalchemy query using the QueryField objects given by
     field_specs and send the results to a CSV file at the given
     file path.
@@ -197,6 +197,10 @@ def query_to_csv(session, collection, user, tableid, field_specs, path,
     query, __ = build_query(session, collection, user, tableid, field_specs, recordsetid, replace_nulls=True, distinct=distinct)
 
     logger.debug('query_to_csv starting')
+
+    encoding = 'utf-8'
+    if bom:
+        encoding = 'utf-8-sig'
 
     with open(path, 'w', newline='', encoding=encoding) as f:
         csv_writer = csv.writer(f, delimiter=delimiter)

--- a/specifyweb/stored_queries/execution.py
+++ b/specifyweb/stored_queries/execution.py
@@ -158,7 +158,7 @@ def do_export(spquery, collection, user, filename, exporttype, host):
             query_to_csv(session, collection, user, tableid, field_specs, path,
                          recordsetid=recordsetid, 
                          captions=spquery['captions'], strip_id=True,
-                         distinct=spquery['selectdistinct'], delimiter=spquery['delimiter'],)
+                         distinct=spquery['selectdistinct'], delimiter=spquery['delimiter'], encoding=spquery['encoding'])
         elif exporttype == 'kml':
             query_to_kml(session, collection, user, tableid, field_specs, path, spquery['captions'], host,
                          recordsetid=recordsetid, strip_id=False)
@@ -186,7 +186,7 @@ def stored_query_to_csv(query_id, collection, user, path):
 
 def query_to_csv(session, collection, user, tableid, field_specs, path,
                  recordsetid=None, captions=False, strip_id=False, row_filter=None,
-                 distinct=False, delimiter=','):
+                 distinct=False, delimiter=',', encoding='utf-8'):
     """Build a sqlalchemy query using the QueryField objects given by
     field_specs and send the results to a CSV file at the given
     file path.
@@ -198,7 +198,7 @@ def query_to_csv(session, collection, user, tableid, field_specs, path,
 
     logger.debug('query_to_csv starting')
 
-    with open(path, 'w', newline='', encoding='utf-8') as f:
+    with open(path, 'w', newline='', encoding=encoding) as f:
         csv_writer = csv.writer(f, delimiter=delimiter)
         if captions:
             header = captions


### PR DESCRIPTION
Adds a user preference to add [UTF-8 BOM](https://en.wikipedia.org/wiki/Byte_order_mark#UTF-8) to Query CSV exports. Makes special UTF-8 characters display correctly on Excel specifically.


![image](https://github.com/user-attachments/assets/cebe793b-4723-421e-9a40-e4450d99575f)


Fixes #2959


### Checklist

- [x] Self-review the PR after opening it to make sure the changes look good
      and self-explanatory (or properly documented)
- [ ] Add automated tests
- [x] Add relevant issue to release milestone

### Testing instructions

- Create a Query that gives results with special utf-8 characters, like accented letters or the degree symbol °.
- Create CSV of the query results
- [ ] Verify that those characters appear broken in Excel
- Go to Preferences -> Query Builder and enable "Add UTF-8 BOM to CSV file exports"
- Create CSV of the query results
- [ ] Verify that those characters now appear correctly in Excel

After fix <- Before fix
![EXCEL_IuttFCSQgZ](https://github.com/user-attachments/assets/31dde4d8-5f39-43e0-a531-c8fc3715169d)

