### PR TITLE
Fix Table Aggregation Separator being set to undefined if it matches default "; "

### DIFF
--- a/specifyweb/frontend/js_src/lib/components/Formatters/spec.ts
+++ b/specifyweb/frontend/js_src/lib/components/Formatters/spec.ts
@@ -147,7 +147,7 @@ const aggregatorSpec = f.store(() =>
     ),
     separator: pipe(
       syncers.xmlAttribute('separator', 'empty', false),
-      syncers.default(localized('; '))
+      syncers.fallback(localized('; '))
     ),
     suffix: syncers.xmlAttribute('ending', 'empty', false),
     limit: pipe(

--- a/specifyweb/stored_queries/format.py
+++ b/specifyweb/stored_queries/format.py
@@ -263,7 +263,7 @@ class ObjectFormatter(object):
         formatter_name = aggregator_formatter_name
         if not self.hasFormatterDef(specify_model, aggregator_formatter_name):
             formatter_name = aggregatorNode.attrib.get('format', None)
-        separator = aggregatorNode.attrib.get('separator', ',')
+        separator = aggregatorNode.attrib.get('separator', '; ')
         order_by = aggregatorNode.attrib.get('orderfieldname', '')
         limit = aggregatorNode.attrib.get('count', '')
         limit = None if limit == '' or int(limit) == 0 else limit


### PR DESCRIPTION
Fixes #5154 

Table Aggregation Separators should no longer be getting set to undefined during serialization if they match the default ("; ").

All previously affected databases will need to have their separators restored separately. Though it is safe to assume all blanks were originally "; ".

### Checklist

- [x] Self-review the PR after opening it to make sure the changes look good
      and self-explanatory (or properly documented)
- [ ] Add automated tests
- [x] Add relevant issue to release milestone

### Testing instructions

<!-- What are the steps to verify the fixes/changes in this PR? -->
<!-- Can part of that be replaced by automated tests? -->

- Go to App Resources -> Record Formatters -> and open any Table Aggregation
- Set the separator to "; "
- Save
- [ ] Verify the separator is still there and isn't blank.
