### PR TITLE
Disable bulk carry for alphanumeric catalogNumber fields

### DIFF
--- a/specifyweb/frontend/js_src/lib/components/FormMeta/CarryForward.tsx
+++ b/specifyweb/frontend/js_src/lib/components/FormMeta/CarryForward.tsx
@@ -207,6 +207,7 @@ export const tableValidForBulkClone = (table: SpecifyTable): boolean =>
       ?.fields.some(
         (field) =>
           field.type === 'regex' ||
+          field.type === 'alphanumeric' ||
           (field.type === 'numeric' && !field.canAutonumber())
       ) ?? false
   );


### PR DESCRIPTION
Fixes #5226 

`sdnhmherps_2_8_24` (Herp-PC collection) has an alphanumeric catalogNumber formatter and so bulk carry was not disabled.

### Checklist

- [x] Self-review the PR after opening it to make sure the changes look good
      and self-explanatory (or properly documented)
- [ ] Add automated tests
- [x] Add relevant issue to release milestone

### Testing instructions

<!-- What are the steps to verify the fixes/changes in this PR? -->
<!-- Can part of that be replaced by automated tests? -->
- Go to `sdnhmherps_2_8_24` - HerpPC collection
- [ ] Verify bulk carry is disabled