### PR TITLE
Filter Taxon QCBX by CollectionObjectType tree

### DIFF
--- a/specifyweb/frontend/js_src/lib/components/DataModel/__tests__/businessRules.test.ts
+++ b/specifyweb/frontend/js_src/lib/components/DataModel/__tests__/businessRules.test.ts
@@ -118,25 +118,6 @@ describe('Collection Object business rules', () => {
     expect(collectionObject.get('collectingEvent')).toBeDefined();
   });
 
-  test('Save blocked when CollectionObjectType of a CollectionObject does not have same tree definition as its associated Determination -> taxon', async () => {
-    const collectionObject = getBaseCollectionObject();
-
-    const determination =
-      collectionObject.getDependentResource('determinations')?.models[0];
-
-    const { result } = renderHook(() =>
-      useSaveBlockers(determination, tables.Determination.getField('taxon'))
-    );
-
-    await act(async () => {
-      await determination?.businessRuleManager?.checkField('taxon');
-    });
-
-    expect(result.current[0]).toStrictEqual([
-      'Taxon does not belong to the same tree as this Object Type',
-    ]);
-  });
-
   const otherCollectionObjectTypeUrl = getResourceApiUrl(
     'CollectionObjectType',
     2

--- a/specifyweb/frontend/js_src/lib/components/DataModel/businessRuleDefs.ts
+++ b/specifyweb/frontend/js_src/lib/components/DataModel/businessRuleDefs.ts
@@ -1,4 +1,3 @@
-import { formsText } from '../../localization/forms';
 import { resourcesText } from '../../localization/resources';
 import { f } from '../../utils/functools';
 import type { BusinessRuleResult } from './businessRules';

--- a/specifyweb/frontend/js_src/lib/components/DataModel/businessRuleDefs.ts
+++ b/specifyweb/frontend/js_src/lib/components/DataModel/businessRuleDefs.ts
@@ -219,57 +219,6 @@ export const businessRuleDefs: MappedBusinessRuleDefs = {
                   accepted === null ? taxon : getLastAccepted(accepted)
                 );
 
-            const related = determination.collection?.related;
-            if (
-              related !== undefined &&
-              related.specifyTable.name === 'CollectionObject'
-            ) {
-              const collectionObject =
-                related as SpecifyResource<CollectionObject>;
-              void f
-                .all({
-                  defaultType:
-                    collectionObject.get('collectionObjectType') === undefined
-                      ? collectionObject
-                          .rgetPromise('collection')
-                          .then(async (collection) =>
-                            collection.rgetPromise('collectionObjectType')
-                          )
-                          .then((coType) => coType ?? undefined)
-                      : undefined,
-                  coType: collectionObject.rgetPromise(
-                    'collectionObjectType',
-                    true
-                  ),
-                })
-                .then(({ defaultType, coType }) => {
-                  const resolvedCoType = coType ?? defaultType;
-                  /*
-                   * Have to set save blockers directly here to get this working.
-                   * Since following code has to wait for above rgetPromise to resolve, returning a Promise<BusinessRuleResult> for validation here is too slow and
-                   * does not get captured by business rules.
-                   */
-                  if (
-                    resolvedCoType?.get('taxonTreeDef') ===
-                    (taxon?.get('definition') ?? '')
-                  ) {
-                    setSaveBlockers(
-                      determination as SpecifyResource<AnySchema>,
-                      determination.specifyTable.field.taxon,
-                      [],
-                      DETERMINATION_TAXON_KEY
-                    );
-                  } else {
-                    setSaveBlockers(
-                      determination as SpecifyResource<AnySchema>,
-                      determination.specifyTable.field.taxon,
-                      [formsText.invalidTree()],
-                      DETERMINATION_TAXON_KEY
-                    );
-                  }
-                });
-            }
-
             return taxon === null
               ? {
                   isValid: true,

--- a/specifyweb/frontend/js_src/lib/components/DataModel/businessRuleDefs.ts
+++ b/specifyweb/frontend/js_src/lib/components/DataModel/businessRuleDefs.ts
@@ -50,7 +50,6 @@ type MappedBusinessRuleDefs = {
 };
 
 const CURRENT_DETERMINATION_KEY = 'determination-isCurrent';
-const DETERMINATION_TAXON_KEY = 'determination-taxon';
 
 const hasNoCurrentDetermination = (collection: Collection<Determination>) =>
   collection.models.length > 0 &&
@@ -185,14 +184,8 @@ export const businessRuleDefs: MappedBusinessRuleDefs = {
               const taxonTreeDefinition = fetchedTaxon.definition;
               const COTypeTreeDefinition = fetchedCOType.taxonTreeDef;
 
-              return taxonTreeDefinition === COTypeTreeDefinition
-                ? void setSaveBlockers(
-                    currentDetermination as SpecifyResource<AnySchema>,
-                    currentDetermination.specifyTable.field.taxon,
-                    [],
-                    DETERMINATION_TAXON_KEY
-                  )
-                : resource.set('determinations', []);
+              if (taxonTreeDefinition !== COTypeTreeDefinition)
+                resource.set('determinations', []);
             })
             .catch((error) => {
               console.error('Error fetching resources:', error);

--- a/specifyweb/frontend/js_src/lib/components/QueryComboBox/helpers.ts
+++ b/specifyweb/frontend/js_src/lib/components/QueryComboBox/helpers.ts
@@ -2,7 +2,7 @@ import type { RA, WritableArray } from '../../utils/types';
 import { toTable, toTreeTable } from '../DataModel/helpers';
 import type { AnySchema } from '../DataModel/helperTypes';
 import type { SpecifyResource } from '../DataModel/legacyTypes';
-import { idFromUrl } from '../DataModel/resource';
+import { idFromUrl, strictIdFromUrl } from '../DataModel/resource';
 import type { Relationship } from '../DataModel/specifyField';
 import type { SpecifyTable } from '../DataModel/specifyTable';
 import { tables } from '../DataModel/tables';
@@ -73,6 +73,7 @@ export function getQueryComboBoxConditions({
   treeData,
   subViewRelationship,
   relatedTable,
+  treeDefinition
 }: {
   readonly resource: SpecifyResource<AnySchema>;
   readonly fieldName: string;
@@ -80,6 +81,7 @@ export function getQueryComboBoxConditions({
   readonly collectionRelationships: CollectionRelationships | undefined;
   readonly relatedTable: SpecifyTable;
   readonly subViewRelationship: Relationship | undefined;
+  readonly treeDefinition: string | undefined;
 }): RA<SpecifyResource<SpQueryField>> {
   const fields: WritableArray<SpecifyResource<SpQueryField>> = [];
   const treeResource = toTreeTable(resource);
@@ -139,6 +141,16 @@ export function getQueryComboBoxConditions({
     } else if (fieldName === 'hybridParent1' || fieldName === 'hybridParent2') {
       // Nothing to do
     }
+  }
+
+  if (resource.specifyTable === tables.Determination && fieldName === 'fullName' && treeDefinition !== undefined) {
+    fields.push(
+      QueryFieldSpec.fromPath(tables.Taxon.name, ['definition', 'id'])
+        .toSpQueryField()
+        .set('isDisplay', false)
+        .set('startValue', strictIdFromUrl(treeDefinition).toString())
+        .set('operStart', queryFieldFilters.equal.id)
+    )
   }
 
   if (

--- a/specifyweb/frontend/js_src/lib/components/QueryComboBox/helpers.ts
+++ b/specifyweb/frontend/js_src/lib/components/QueryComboBox/helpers.ts
@@ -73,7 +73,7 @@ export function getQueryComboBoxConditions({
   treeData,
   subViewRelationship,
   relatedTable,
-  treeDefinition
+  treeDefinition,
 }: {
   readonly resource: SpecifyResource<AnySchema>;
   readonly fieldName: string;
@@ -143,14 +143,18 @@ export function getQueryComboBoxConditions({
     }
   }
 
-  if (resource.specifyTable === tables.Determination && fieldName === 'fullName' && treeDefinition !== undefined) {
+  if (
+    resource.specifyTable === tables.Determination &&
+    fieldName === 'fullName' &&
+    treeDefinition !== undefined
+  ) {
     fields.push(
       QueryFieldSpec.fromPath(tables.Taxon.name, ['definition', 'id'])
         .toSpQueryField()
         .set('isDisplay', false)
         .set('startValue', strictIdFromUrl(treeDefinition).toString())
         .set('operStart', queryFieldFilters.equal.id)
-    )
+    );
   }
 
   if (

--- a/specifyweb/frontend/js_src/lib/components/QueryComboBox/index.tsx
+++ b/specifyweb/frontend/js_src/lib/components/QueryComboBox/index.tsx
@@ -24,7 +24,10 @@ import { serializeResource } from '../DataModel/serializers';
 import type { Relationship } from '../DataModel/specifyField';
 import type { SpecifyTable } from '../DataModel/specifyTable';
 import { tables } from '../DataModel/tables';
-import { CollectionObject, CollectionObjectType } from '../DataModel/types';
+import type {
+  CollectionObject,
+  CollectionObjectType,
+} from '../DataModel/types';
 import { format, naiveFormatter } from '../Formatters/formatters';
 import type { FormType } from '../FormParse';
 import { ResourceView, RESTRICT_ADDING } from '../Forms/ResourceView';

--- a/specifyweb/frontend/js_src/lib/components/QueryComboBox/index.tsx
+++ b/specifyweb/frontend/js_src/lib/components/QueryComboBox/index.tsx
@@ -23,6 +23,8 @@ import {
 import { serializeResource } from '../DataModel/serializers';
 import type { Relationship } from '../DataModel/specifyField';
 import type { SpecifyTable } from '../DataModel/specifyTable';
+import { tables } from '../DataModel/tables';
+import { CollectionObject, CollectionObjectType } from '../DataModel/types';
 import { format, naiveFormatter } from '../Formatters/formatters';
 import type { FormType } from '../FormParse';
 import { ResourceView, RESTRICT_ADDING } from '../Forms/ResourceView';
@@ -247,6 +249,26 @@ export function QueryComboBox({
     (typeof typeSearch === 'object' ? typeSearch?.table : undefined) ??
     field.relatedTable;
 
+  const [treeDefinition] = useAsyncState(
+    React.useCallback(
+      async () =>
+        resource?.specifyTable === tables.Determination &&
+        resource.collection?.related?.specifyTable === tables.CollectionObject
+          ? (resource.collection?.related as SpecifyResource<CollectionObject>)
+              .rgetPromise('collectionObjectType')
+              .then(
+                (
+                  collectionObjectType:
+                    | SpecifyResource<CollectionObjectType>
+                    | undefined
+                ) => collectionObjectType?.get('taxonTreeDef')
+              )
+          : undefined,
+      [resource, resource?.collection?.related?.get('collectionObjectType')]
+    ),
+    false
+  );
+
   // FEATURE: use main table field if type search is not defined
   const fetchSource = React.useCallback(
     async (value: string): Promise<RA<AutoCompleteItem<string>>> =>
@@ -274,6 +296,7 @@ export function QueryComboBox({
                       typeof treeData === 'object' ? treeData : undefined,
                     relatedTable,
                     subViewRelationship,
+                    treeDefinition,
                   }),
                 })
               )
@@ -322,6 +345,7 @@ export function QueryComboBox({
       relatedCollectionId,
       resource,
       treeData,
+      treeDefinition,
     ]
   );
 
@@ -473,6 +497,7 @@ export function QueryComboBox({
                                   : undefined,
                               relatedTable,
                               subViewRelationship,
+                              treeDefinition,
                             })
                               .map(serializeResource)
                               .map(({ fieldName, startValue }) =>

--- a/specifyweb/frontend/js_src/lib/localization/forms.ts
+++ b/specifyweb/frontend/js_src/lib/localization/forms.ts
@@ -1159,7 +1159,4 @@ export const formsText = createDictionary({
     'ru-ru': 'Номер по каталогу Числовой',
     'uk-ua': 'Каталожний номер Числовий',
   },
-  invalidTree: {
-    'en-us': 'Taxon does not belong to the same tree as this Object Type',
-  },
 } as const);


### PR DESCRIPTION
Fixes #5213
Fixes #4982

The cotype -> treedef value can be retrieved from the Determination resource used by the Taxon QCBX, which will be used to filter Taxon values

### Checklist

- [ ] Self-review the PR after opening it to make sure the changes look good
      and self-explanatory (or properly documented)
- [ ] Add automated tests
- [ ] Add relevant issue to release milestone

### Testing instructions

<!-- What are the steps to verify the fixes/changes in this PR? -->
<!-- Can part of that be replaced by automated tests? -->
- Use a db with multiple trees in the same collection
- Go to Data Entry > Collection Object
- Enter a CollectionObjectType
- Add a determination
- [ ] Verify Taxon field of the determination gets filtered by the selected COType's tree definition