### PR TITLE
Disable select button when no row selected in QB

### DIFF
--- a/specifyweb/frontend/js_src/lib/components/QueryBuilder/Results.tsx
+++ b/specifyweb/frontend/js_src/lib/components/QueryBuilder/Results.tsx
@@ -202,7 +202,12 @@ export function QueryResults(props: QueryResultsProps): JSX.Element {
           })}
         </H3>
         {selectedRows.size > 0 && (
-          <Button.Small onClick={(): void => setSelectedRows(new Set())}>
+          <Button.Small
+            onClick={(): void => {
+              setSelectedRows(new Set());
+              handleSelected?.([]);
+            }}
+          >
             {interactionsText.deselectAll()}
           </Button.Small>
         )}

--- a/specifyweb/frontend/js_src/lib/components/Syncer/__tests__/index.test.ts
+++ b/specifyweb/frontend/js_src/lib/components/Syncer/__tests__/index.test.ts
@@ -94,8 +94,8 @@ test('Editing Data Object Formatter', () => {
         </switch>
       </format>
       <aggregators>
-        <aggregator name='AccessionAgent' title='AccessionAgent' class='edu.ku.brc.specify.datamodel.Agent' default='true' separator='' ending='' format='AccessionAgent'/>
-        <aggregator name='AccessionAgent' title='AccessionAgent' class='edu.ku.brc.specify.datamodel.AccessionAgent' default='true' separator='' ending='' format='AccessionAgent'/>
+        <aggregator name='AccessionAgent' title='AccessionAgent' class='edu.ku.brc.specify.datamodel.Agent' default='true' separator='; ' ending='' format='AccessionAgent'/>
+        <aggregator name='AccessionAgent' title='AccessionAgent' class='edu.ku.brc.specify.datamodel.AccessionAgent' default='true' separator='; ' ending='' format='AccessionAgent'/>
       </aggregators>
     </formatters>"
   `);


### PR DESCRIPTION
Fixes #5259

Fixes #



### Checklist

- [ ] Self-review the PR after opening it to make sure the changes look good
      and self-explanatory (or properly documented)
- [ ] Add automated tests
- [ ] Add relevant issue to release milestone

### Testing instructions

Go to Data Entry and create a new CO record
Click the Search button on a query combo box
Click Query Builder and query for a record
Click on a record
Click Deselect All and see that it appears to have been deselected
- [ ] verify select is disabled 

