### PR TITLE
Handle case where tree definition doesn't exist for a tree

### DIFF
--- a/specifyweb/frontend/js_src/lib/components/Toolbar/TreeRepair.tsx
+++ b/specifyweb/frontend/js_src/lib/components/Toolbar/TreeRepair.tsx
@@ -75,10 +75,12 @@ export function TreeSelectDialog({
                 : hasTreeAccess(treeName, 'read')
             )
             .map((treeName) => {
-              const treeDefinition = deserializeResource(
-                getTreeDefinitions(treeName)[0].definition
-              );
-              return [treeName, treeDefinition] as const;
+              const treeDefinitions = getTreeDefinitions(treeName);
+              const defaultTreeDefinition =
+                treeDefinitions.length > 0
+                  ? deserializeResource(treeDefinitions[0].definition)
+                  : undefined;
+              return [treeName, defaultTreeDefinition] as const;
             })
         : undefined,
     [permissionName, treeRanks]

--- a/specifyweb/frontend/js_src/lib/components/Toolbar/TreeRepair.tsx
+++ b/specifyweb/frontend/js_src/lib/components/Toolbar/TreeRepair.tsx
@@ -76,10 +76,14 @@ export function TreeSelectDialog({
             )
             .map((treeName) => {
               const treeDefinitions = getTreeDefinitions(treeName);
-              const defaultTreeDefinition =
-                treeDefinitions.length > 0
-                  ? deserializeResource(treeDefinitions[0].definition)
-                  : undefined;
+              if (treeDefinitions.length === 0) {
+                console.warn(`No tree definitions exist for ${treeName}`);
+                return [treeName, undefined] as const;
+              }
+
+              const defaultTreeDefinition = deserializeResource(
+                treeDefinitions[0].definition
+              );
               return [treeName, defaultTreeDefinition] as const;
             })
         : undefined,

--- a/specifyweb/frontend/js_src/lib/components/Toolbar/TreeRepair.tsx
+++ b/specifyweb/frontend/js_src/lib/components/Toolbar/TreeRepair.tsx
@@ -108,11 +108,7 @@ export function TreeSelectDialog({
                   <Link.Default
                     className="flex-1"
                     href={getLink(treeName)}
-                    title={
-                      (treeDefinition?.get('remarks') as
-                        | LocalizedString
-                        | undefined) ?? undefined
-                    }
+                    title={treeDefinition?.get('remarks') ?? undefined}
                     onClick={(event): void => {
                       if (handleClick === undefined) return;
                       event.preventDefault();


### PR DESCRIPTION
Fixes #5264

The frontend assumed that each tree has at least one tree definition. It looks like some dbs haven't been migrated correctly due to which their Storage trees do not have a tree definition anymore. This caused the frontend to read undefined for Storage trees and leads to the error found in the issue. This PR allows the tree selection dialog to still open even when a tree does not have a definition and avoid the error. However, we would have to manually fix the migration for the dbs where this error occurs to fix Storage trees for that db


### Checklist

- [ ] Self-review the PR after opening it to make sure the changes look good
      and self-explanatory (or properly documented)
- [ ] Add automated tests
- [ ] Add relevant issue to release milestone

### Testing instructions

<!-- What are the steps to verify the fixes/changes in this PR? -->
<!-- Can part of that be replaced by automated tests? -->
- Use a db where the issue occurred (`um_herb_1_10_24`, `ojsmnh11024`)
- Click on trees in the nav bar
- [ ] Verify the tree selection dialog opens and there is no error