### PR TITLE
Hide tectonic tree for non paleo or geo disciplines

### DIFF
--- a/specifyweb/specify/model_extras.py
+++ b/specifyweb/specify/model_extras.py
@@ -145,10 +145,17 @@ class Preparation(models.Model):
         abstract = True
 
 PALEO_DISCIPLINES = {'paleobotany', 'invertpaleo', 'vertpaleo'}
+GEOLOGY_DISCIPLINES = {'geology'}
 
 class Discipline(models.Model):
     def is_paleo(self):
          return self.type.lower() in PALEO_DISCIPLINES
+    
+    def is_geo(self):
+         return self.type.lower() in GEOLOGY_DISCIPLINES
+    
+    def is_paleo_geo(self): 
+        return self.is_paleo() or self.is_geo()
     
     class Meta:
         abstract = True

--- a/specifyweb/specify/tree_views.py
+++ b/specifyweb/specify/tree_views.py
@@ -31,10 +31,10 @@ TREE_TABLE = Literal['Taxon', 'Storage',
 GEO_TREES: Tuple[TREE_TABLE, ...] = ['Tectonicunit']
 
 COMMON_TREES: Tuple[TREE_TABLE, ...] = ['Taxon', 'Storage',
-                                        'Geography', *GEO_TREES]
+                                        'Geography']
 
 ALL_TRESS: Tuple[TREE_TABLE, ...] = [
-    *COMMON_TREES, 'Geologictimeperiod', 'Lithostrat']
+    *COMMON_TREES, 'Geologictimeperiod', 'Lithostrat', *GEO_TREES]
 
 
 def tree_mutation(mutation):
@@ -456,10 +456,10 @@ def all_tree_information(request):
         return has_table_permission(
             request.specify_collection.id, request.specify_user.id, tree, 'read')
 
-    is_paleo_discipline = request.specify_collection.discipline.is_paleo()
+    is_paleo_or_geo_discipline = request.specify_collection.discipline.is_paleo_geo()
 
     accessible_trees = tuple(filter(
-        has_tree_read_permission, ALL_TRESS if is_paleo_discipline else COMMON_TREES))
+        has_tree_read_permission, ALL_TRESS if is_paleo_or_geo_discipline else COMMON_TREES))
 
     result = {}
 


### PR DESCRIPTION
Fixes #5334

### Checklist

- [ ] Self-review the PR after opening it to make sure the changes look good
      and self-explanatory (or properly documented)
- [ ] Add relevant issue to release milestone

### Testing instructions

- [ ]  Verify Tectonic Tree is hidden unless the discipline is vertpaleo, invertpaleo, or geology (or any number of sub-geology disciplines we define)
