### PR TITLE
Add get_spmodel_class to replace getattr for Specify models

### DIFF
--- a/specifyweb/specify/tree_utils.py
+++ b/specifyweb/specify/tree_utils.py
@@ -2,6 +2,7 @@ from typing import Tuple, List
 from django.db.models import Q, Count, Model
 import specifyweb.specify.models as spmodels
 from specifyweb.specify.datamodel import datamodel
+from specifyweb.specify.utils import get_spmodel_class
 
 lookup = lambda tree: (tree.lower() + 'treedef')
 
@@ -32,7 +33,7 @@ def get_treedefs(collection: spmodels.Collection, tree_name: str) ->  List[Tuple
 
     lookup_tree = lookup(tree_name)
     tree_table = datamodel.get_table_strict(lookup_tree)
-    tree_model: Model = getattr(spmodels, tree_table.django_name)
+    tree_model: Model = get_spmodel_class(tree_table.django_name)
 
     # Get all the treedefids, and the count of item in each, corresponding to our search predicates
     search_query = _limit(

--- a/specifyweb/specify/utils.py
+++ b/specifyweb/specify/utils.py
@@ -1,4 +1,5 @@
 import sys
+import logging
 from specifyweb.accounts import models as acccounts_models
 from specifyweb.attachment_gw import models as attachment_gw_models
 from specifyweb.businessrules import models as businessrules_models
@@ -10,6 +11,8 @@ from specifyweb.workbench import models as workbench_models
 from specifyweb.specify import models as spmodels
 from django.conf import settings
 
+logger = logging.getLogger(__name__)
+
 APP_MODELS = [spmodels, acccounts_models, attachment_gw_models, businessrules_models, context_models,
               notifications_models, permissions_models, interactions_models, workbench_models]
 
@@ -18,3 +21,23 @@ def get_app_model(model_name: str):
         if hasattr(app, model_name):
             return getattr(app, model_name)
     return None
+
+def get_spmodel_class(model_name: str):
+    try:
+        return getattr(spmodels, model_name.capitalize())
+    except AttributeError:
+        pass
+    # Iterate over all attributes in the models module
+    for attr_name in dir(spmodels):
+        # Check if the attribute name matches the model name case-insensitively
+        if attr_name.lower() == model_name.lower():
+            return getattr(spmodels, attr_name)
+    raise AttributeError(f"Model '{model_name}' not found in models module.")
+
+def log_sqlalchemy_query(query):
+    from sqlalchemy.dialects import mysql
+    compiled_query = query.statement.compile(dialect=mysql.dialect(), compile_kwargs={"literal_binds": True})
+    raw_sql = str(compiled_query)
+    logger.debug(raw_sql)
+    # Run in the storred_queries.execute file, in the execute function, right before the return statement, line 546
+    # from specifyweb.specify.utils import log_sqlalchemy_query; log_sqlalchemy_query(query)

--- a/specifyweb/specify/views.py
+++ b/specifyweb/specify/views.py
@@ -23,6 +23,7 @@ from specifyweb.permissions.permissions import PermissionTarget, \
 from specifyweb.celery_tasks import app, CELERY_TASK_STATE
 from specifyweb.specify.record_merging import record_merge_fx, record_merge_task, resolve_record_merge_response
 from specifyweb.specify.update_locality import localityupdate_parse_success, localityupdate_parse_error, parse_locality_set as _parse_locality_set, upload_locality_set as _upload_locality_set, create_localityupdate_recordset, update_locality_task, parse_locality_task, LocalityUpdateStatus
+from specifyweb.specify.utils import get_spmodel_class
 from . import api, models as spmodels
 from .specify_jar import specify_jar
 
@@ -499,7 +500,7 @@ def record_merge(
     """Replaces all the foreign keys referencing the old record IDs
     with the new record ID, and deletes the old records.
     """
-    record_version = getattr(spmodels, model_name.title()).objects.get(
+    record_version = get_spmodel_class(model_name.title()).objects.get(
         id=new_model_id).version
     get_version = request.GET.get('version', record_version)
     version = get_version if isinstance(get_version, int) else 0

--- a/specifyweb/stored_queries/query_construct.py
+++ b/specifyweb/stored_queries/query_construct.py
@@ -7,6 +7,7 @@ from sqlalchemy import orm, sql
 import specifyweb.specify.models as spmodels
 from specifyweb.specify.tree_utils import get_treedefs
 
+from specifyweb.specify.utils import get_spmodel_class
 from specifyweb.stored_queries import models
 
 logger = logging.getLogger(__name__)
@@ -60,7 +61,7 @@ class QueryConstruct(namedtuple('QueryConstruct', 'collection objectformatter qu
             query = query._replace(join_cache=query.join_cache.copy())
             query.join_cache[(table, 'TreeRanks')] = (ancestors, treedefs)
 
-        item_model = getattr(spmodels, table.django_name + "treedefitem")
+        item_model = get_spmodel_class(table.django_name + "treedefitem")
 
         # TODO: optimize out the ranks that appear? cache them
         treedefs_with_ranks: List[Tuple[int, int]] = [tup for tup in [


### PR DESCRIPTION
Fixes #5349

Avoid problems with `getattr` when getting model class names from Specify models due to capitalization differences.  In order to maintain python class name readability, we create a utility function that can handling getting the class by name, even if the capitalization in the names don't match.

### Checklist

- [ ] Self-review the PR after opening it to make sure the changes look good
      and self-explanatory (or properly documented)
- [ ] Add automated tests
- [ ] Add relevant issue to release milestone

### Testing instructions

TBD
