### PR TITLE
Add get_spmodel_class to replace getattr for Specify models, temp solution

### DIFF
--- a/specifyweb/specify/tree_utils.py
+++ b/specifyweb/specify/tree_utils.py
@@ -22,6 +22,18 @@ def get_search_filters(collection: spmodels.Collection, tree: str):
         discipline_query |= Q(id=tree_at_discipline.id)
     return discipline_query
 
+def get_spmodel_class(model_name: str):
+    try:
+        return getattr(spmodels, model_name.capitalize())
+    except AttributeError:
+        pass
+    # Iterate over all attributes in the models module
+    for attr_name in dir(spmodels):
+        # Check if the attribute name matches the model name case-insensitively
+        if attr_name.lower() == model_name.lower():
+            return getattr(spmodels, attr_name)
+    raise AttributeError(f"Model '{model_name}' not found in models module.")
+
 def get_treedefs(collection: spmodels.Collection, tree_name: str) ->  List[Tuple[int, int]]:
     # Get the appropriate TreeDef based on the Collection and tree_name
 
@@ -32,7 +44,7 @@ def get_treedefs(collection: spmodels.Collection, tree_name: str) ->  List[Tuple
 
     lookup_tree = lookup(tree_name)
     tree_table = datamodel.get_table_strict(lookup_tree)
-    tree_model: Model = getattr(spmodels, tree_table.django_name)
+    tree_model: Model = get_spmodel_class(tree_table.django_name)
 
     # Get all the treedefids, and the count of item in each, corresponding to our search predicates
     search_query = _limit(

--- a/specifyweb/specify/utils.py
+++ b/specifyweb/specify/utils.py
@@ -1,4 +1,5 @@
 import sys
+import logging
 from specifyweb.accounts import models as acccounts_models
 from specifyweb.attachment_gw import models as attachment_gw_models
 from specifyweb.businessrules import models as businessrules_models
@@ -8,7 +9,11 @@ from specifyweb.permissions import models as permissions_models
 from specifyweb.interactions import models as interactions_models
 from specifyweb.workbench import models as workbench_models
 from specifyweb.specify import models as spmodels
+from specifyweb.specify.model_timestamp import save_auto_timestamp_field_with_override
+from specifyweb.businessrules.exceptions import AbortSave
 from django.conf import settings
+
+logger = logging.getLogger(__name__)
 
 APP_MODELS = [spmodels, acccounts_models, attachment_gw_models, businessrules_models, context_models,
               notifications_models, permissions_models, interactions_models, workbench_models]
@@ -18,3 +23,23 @@ def get_app_model(model_name: str):
         if hasattr(app, model_name):
             return getattr(app, model_name)
     return None
+
+def get_spmodel_class(model_name: str):
+    try:
+        return getattr(spmodels, model_name.capitalize())
+    except AttributeError:
+        pass
+    # Iterate over all attributes in the models module
+    for attr_name in dir(spmodels):
+        # Check if the attribute name matches the model name case-insensitively
+        if attr_name.lower() == model_name.lower():
+            return getattr(spmodels, attr_name)
+    raise AttributeError(f"Model '{model_name}' not found in models module.")
+
+def log_sqlalchemy_query(query):
+    from sqlalchemy.dialects import mysql
+    compiled_query = query.statement.compile(dialect=mysql.dialect(), compile_kwargs={"literal_binds": True})
+    raw_sql = str(compiled_query)
+    logger.debug(raw_sql)
+    # Run in the storred_queries.execute file, in the execute function, right before the return statement, line 546
+    # from specifyweb.specify.utils import log_sqlalchemy_query; log_sqlalchemy_query(query)

--- a/specifyweb/specify/views.py
+++ b/specifyweb/specify/views.py
@@ -499,7 +499,7 @@ def record_merge(
     """Replaces all the foreign keys referencing the old record IDs
     with the new record ID, and deletes the old records.
     """
-    record_version = getattr(spmodels, model_name.title()).objects.get(
+    record_version = get_spmodel_class(model_name.title()).objects.get(
         id=new_model_id).version
     get_version = request.GET.get('version', record_version)
     version = get_version if isinstance(get_version, int) else 0
@@ -1367,3 +1367,15 @@ def parse_locality_set_foreground(collection, column_headers: List[str], data: L
         return 422, errors
 
     return 200, parsed
+
+def get_spmodel_class(model_name: str):
+    try:
+        return getattr(spmodels, model_name.capitalize())
+    except AttributeError:
+        pass
+    # Iterate over all attributes in the models module
+    for attr_name in dir(spmodels):
+        # Check if the attribute name matches the model name case-insensitively
+        if attr_name.lower() == model_name.lower():
+            return getattr(spmodels, attr_name)
+    raise AttributeError(f"Model '{model_name}' not found in models module.")


### PR DESCRIPTION
Fixes #5349

Avoid problems with getattr when getting model class names from Specify models due to capitalization differences. In order to maintain python class name readability, we create a utility function that can handling getting the class by name, even if the capitalization in the names don't match.

The get_spmodel_class functions is added in each file it is needed for now in order to avoid circular imports, I will make better in future.

### Checklist

- [ ] Self-review the PR after opening it to make sure the changes look good
      and self-explanatory (or properly documented)
- [ ] Add automated tests
- [ ] Add relevant issue to release milestone

### Testing instructions
Open schema config
Choose one of the age table relativeAge - absoluteAge - absoluteAgeCitation, ...
Open uniqueness rule tool
Click add a rule
See crash
