### PR TITLE
Prevent focused node state recalculation on table change

### DIFF
--- a/specifyweb/frontend/js_src/lib/components/TreeView/Actions.tsx
+++ b/specifyweb/frontend/js_src/lib/components/TreeView/Actions.tsx
@@ -255,7 +255,7 @@ function EditRecordDialog<SCHEMA extends AnyTree>({
         node.set('parent', parentNode.url());
       }
       return node;
-    }, [nodeId, tableName, addNew])
+    }, [nodeId, addNew])
   );
 
   const isViewMode = !hasTablePermission(tableName, 'update');


### PR DESCRIPTION
Fixes #5277

The `tableName` dependency on the resource state leads to the creation of an invalid resource (eg: a Taxon resource that with a `nodeId` of a Geography resource) leading to the 404 error.
<!--
⚠️ **Note:** This PR affects database migrations. See [migration testing instructions](https://specify.github.io/testing/pull_requests.html#prs-tagged-with-label-migration).
-->

### Checklist

- [x] Self-review the PR after opening it to make sure the changes look good
      and self-explanatory (or properly documented)
- [ ] Add automated tests
- [x] Add relevant issue to release milestone

### Testing instructions

<!-- What are the steps to verify the fixes/changes in this PR? -->
<!-- Can part of that be replaced by automated tests? -->
- Open any tree
- Click on a node
- Open a different tree
- [ ] Verify there's no 404 error
- [ ] Verify editing and adding a node still works like it used to