### PR TITLE
Fix Tectonic tree rank deletion

### DIFF
--- a/specifyweb/specify/migrations/0004_stratigraphy_age.py
+++ b/specifyweb/specify/migrations/0004_stratigraphy_age.py
@@ -207,7 +207,7 @@ class Migration(migrations.Migration):
                 #relationships
                 ('createdbyagent', models.ForeignKey(db_column='CreatedByAgentID', null=True, on_delete=protect_with_blockers, related_name='+', to='specify.agent')),
                 ('modifiedbyagent', models.ForeignKey(db_column='ModifiedByAgentID', null=True, on_delete=protect_with_blockers, related_name='+', to='specify.agent')),
-                ('parentitem', models.ForeignKey(db_column='ParentItemID', null=True, on_delete=protect_with_blockers, related_name='children', to='specify.tectonicunittreedefitem')),
+                ('parentitem', models.ForeignKey(db_column='ParentItemID', null=True, on_delete=models.DO_NOTHING, related_name='children', to='specify.tectonicunittreedefitem')),
                 ('tectonicunittreedef', models.ForeignKey(db_column='TectonicUnitTreeDefID', on_delete=protect_with_blockers, related_name='tectonicunittreedefitems', to='specify.tectonicunittreedef')),
             ],
             options={

--- a/specifyweb/specify/models.py
+++ b/specifyweb/specify/models.py
@@ -7858,7 +7858,7 @@ class Tectonicunittreedefitem(model_extras.Tectonicunittreedefitem):
     # Relationships: Many-to-One
     createdbyagent = models.ForeignKey('Agent', db_column='CreatedByAgentID', related_name='+', null=True, on_delete=protect_with_blockers)
     modifiedbyagent = models.ForeignKey('Agent', db_column='ModifiedByAgentID', related_name='+', null=True, on_delete=protect_with_blockers)
-    parent = models.ForeignKey('TectonicUnitTreeDefItem', db_column='ParentItemID', related_name='children', null=True, on_delete=protect_with_blockers)
+    parent = models.ForeignKey('TectonicUnitTreeDefItem', db_column='ParentItemID', related_name='children', null=True, on_delete=models.DO_NOTHING)
     treedef = models.ForeignKey('TectonicUnitTreeDef', db_column='TectonicUnitTreeDefID', related_name='treedefitems', null=True, on_delete=protect_with_blockers)
     
     class Meta:

--- a/specifyweb/specify/tree_extras.py
+++ b/specifyweb/specify/tree_extras.py
@@ -722,4 +722,11 @@ def renumber_tree(table):
     Sptasksemaphore.objects.filter(taskname__in=tasknames).update(islocked=False)
 
 def is_treedefitem(obj):
-    return issubclass(obj.__class__, TreeRank)
+    return issubclass(obj.__class__, TreeRank) or bool(
+        re.search(r"treedefitem'>$", str(obj.__class__), re.IGNORECASE)
+    )
+
+def is_treedef(obj):
+    return issubclass(obj.__class__, Tree) or bool(
+        re.search(r"treedef'>$", str(obj.__class__), re.IGNORECASE)
+    )

--- a/specifyweb/specify/tree_utils.py
+++ b/specifyweb/specify/tree_utils.py
@@ -13,7 +13,7 @@ TREE_MODELS = {
     spmodels.Storagetreedef,
     spmodels.Geologictimeperiodtreedef,
     spmodels.Lithostrattreedef,
-    spmodels.Tectonictreedef
+    spmodels.Tectonicunittreedef
 }
 
 def get_search_filters(collection: spmodels.Collection, tree: str):

--- a/specifyweb/specify/tree_utils.py
+++ b/specifyweb/specify/tree_utils.py
@@ -12,7 +12,8 @@ TREE_MODELS = {
     spmodels.Geographytreedef,
     spmodels.Storagetreedef,
     spmodels.Geologictimeperiodtreedef,
-    spmodels.Lithostrattreedef
+    spmodels.Lithostrattreedef,
+    spmodels.Tectonictreedef
 }
 
 def get_search_filters(collection: spmodels.Collection, tree: str):

--- a/specifyweb/specify/tree_utils.py
+++ b/specifyweb/specify/tree_utils.py
@@ -13,7 +13,23 @@ TREE_MODELS = {
     spmodels.Storagetreedef,
     spmodels.Geologictimeperiodtreedef,
     spmodels.Lithostrattreedef,
-    spmodels.Tectonicunittreedef
+    spmodels.Tectonicunittreedef,
+}
+TREE_RANK_MODELS = {
+    spmodels.Taxontreedefitem,
+    spmodels.Geographytreedefitem,
+    spmodels.Storagetreedefitem,
+    spmodels.Geologictimeperiodtreedefitem,
+    spmodels.Lithostrattreedefitem,
+    spmodels.Tectonicunittreedefitem,
+}
+TREE_ITEM_MODELS = {
+    spmodels.Taxon,
+    spmodels.Geography,
+    spmodels.Storage,
+    spmodels.Geologictimeperiod,
+    spmodels.Lithostrat,
+    spmodels.Tectonicunit,
 }
 
 def get_search_filters(collection: spmodels.Collection, tree: str):


### PR DESCRIPTION
Fixes #5381

Fix the problem of Tectonic tree rank deletion by adding Tectonictreedef to the TREE_MODEL in the tree_utils.py file

### Checklist

- [ ] Self-review the PR after opening it to make sure the changes look good
      and self-explanatory (or properly documented)
- [ ] Add automated tests
- [ ] Add relevant issue to release milestone

### Testing instructions

1. Open Tectonic Tree
2. Create a new rank 
3. Try to delete the rank 
4. See that the rank is gone
