### PR TITLE
Add cojo to Schema Config

### DIFF
--- a/specifyweb/specify/migrations/0007_schema_config_update.py
+++ b/specifyweb/specify/migrations/0007_schema_config_update.py
@@ -26,6 +26,8 @@ def update_fields(apps):
     Splocalecontaineritem = apps.get_model('specify', 'Splocalecontaineritem')
     Splocaleitemstr = apps.get_model('specify', 'Splocaleitemstr')
 
+    # Revert COG -> children before adding to avoid duplicates
+    revert_table_field_schema_config('CollectionObjectGroup', 'children', apps)
     # Add StorageTreeDef -> institution and COG -> children
     for discipline in Discipline.objects.all():
         update_table_field_schema_config_with_defaults('StorageTreeDef', discipline.id, 'institution', apps)

--- a/specifyweb/specify/migrations/0009_tectonic_ranks.py
+++ b/specifyweb/specify/migrations/0009_tectonic_ranks.py
@@ -7,44 +7,44 @@ def create_default_tectonic_ranks(apps):
     TectonicTreeDef = apps.get_model('specify', 'TectonicUnitTreeDef')
     Discipline = apps.get_model('specify', 'Discipline')
     for discipline in Discipline.objects.all():
-        tectonic_tree_def = TectonicTreeDef.objects.create(name="Tectonic Unit", discipline=discipline)
+        tectonic_tree_def, _ = TectonicTreeDef.objects.get_or_create(name="Tectonic Unit", discipline=discipline)
 
-        root = TectonicUnitTreeDefItem.objects.create(
+        root, _ = TectonicUnitTreeDefItem.objects.get_or_create(
             name="Root",
             title="Root",
             rankid=0,
             parent=None,
             treedef=tectonic_tree_def,
         )
-        superstructure = TectonicUnitTreeDefItem.objects.create(
+        superstructure, _ = TectonicUnitTreeDefItem.objects.get_or_create(
             name="Superstructure",
             title="Superstructure",
             rankid=10,
             parent=root,
             treedef=tectonic_tree_def,
         )
-        tectonic_domain = TectonicUnitTreeDefItem.objects.create(
+        tectonic_domain, _ = TectonicUnitTreeDefItem.objects.get_or_create(
             name="Tectonic Domain",
             title="Tectonic Domain",
             rankid=20,
             parent=superstructure,
             treedef=tectonic_tree_def,
         )
-        tectonic_subdomain = TectonicUnitTreeDefItem.objects.create(
+        tectonic_subdomain, _ = TectonicUnitTreeDefItem.objects.get_or_create(
             name="Tectonic Subdomain",
             title="Tectonic Subdomain",
             rankid=30,
             parent=tectonic_domain,
             treedef=tectonic_tree_def,
         )
-        tectonic_unit = TectonicUnitTreeDefItem.objects.create(
+        tectonic_unit, _ = TectonicUnitTreeDefItem.objects.get_or_create(
             name="Tectonic Unit",
             title="Tectonic Unit",
             rankid=40,
             parent=tectonic_subdomain,
             treedef=tectonic_tree_def,
         )
-        tectonic_subunit = TectonicUnitTreeDefItem.objects.create(
+        tectonic_subunit, _ = TectonicUnitTreeDefItem.objects.get_or_create(
             name="Tectonic Subunit",
             title="Tectonic Subunit",
             rankid=50,
@@ -94,7 +94,7 @@ def create_root_tectonic_node(apps):
             treedef=tectonic_tree_def
         )
 
-        root = TectonicUnit.objects.create(
+        root, _ = TectonicUnit.objects.get_or_create(
             name="Root",
             isaccepted=1,
             nodenumber=1,

--- a/specifyweb/specify/migrations/0012_add_cojo_to_schema_config.py
+++ b/specifyweb/specify/migrations/0012_add_cojo_to_schema_config.py
@@ -1,0 +1,31 @@
+"""
+This migration adds COG -> cojo and CO -> cojo to Schema Config.
+"""
+from django.db import migrations
+from specifyweb.specify.update_schema_config import revert_table_field_schema_config, update_table_field_schema_config_with_defaults
+
+def add_cojo_to_schema_config(apps):
+    Discipline = apps.get_model('specify', 'Discipline')
+    for discipline in Discipline.objects.all():
+        update_table_field_schema_config_with_defaults('CollectionObjectGroup', discipline.id, 'cojo', apps)
+        update_table_field_schema_config_with_defaults('CollectionObject', discipline.id, 'cojo', apps)
+
+def remove_cojo_from_schema_config(apps):
+    revert_table_field_schema_config('CollectionObjectGroup', 'cojo', apps)
+    revert_table_field_schema_config('CollectionObject', 'cojo', apps)
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('specify', '0011_cascading_tree_nodes'),
+    ]
+
+    def apply_migration(apps, schema_editor):
+        add_cojo_to_schema_config(apps)
+
+    def revert_migration(apps, schema_editor):
+        remove_cojo_from_schema_config(apps)
+    
+    operations = [
+        migrations.RunPython(apply_migration, revert_migration, atomic=True),
+    ]


### PR DESCRIPTION
Fixes #5386

The missing relationships were due to COG -> cojo and CO -> cojo not being present in Schema Config. There were some more missing fields like `createdByAgent` and `timestampCreated` but those are from migration issues. If we test this PR with a fresh db, those fields shouldn't be missing

⚠️ **Note:** This PR affects database migrations. See [migration testing instructions](https://specify.github.io/testing/pull_requests.html#prs-tagged-with-label-migration).


### Checklist

- [x] Self-review the PR after opening it to make sure the changes look good
      and self-explanatory (or properly documented)
- [ ] Add automated tests
- [x] Add relevant issue to release milestone

### Testing instructions

<!-- What are the steps to verify the fixes/changes in this PR? -->
<!-- Can part of that be replaced by automated tests? -->
- Go to schema config
- Select COG, COGT, or CO as base table
- Click on uniqueness rules
- Add new rule
- Scroll down to relationships
- [ ] Verify there are no empty fields/relationships