### PR TITLE
Restore build-args BUILD_VERSION and GIT_SHA

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -82,6 +82,9 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           platforms: ${{ matrix.platform }}
+          build-args: |
+            BUILD_VERSION=${{ steps.prep.outputs.version }}
+            GIT_SHA=${{ github.sha }}
           tags: ${{ steps.prep.outputs.tags }}
           push: true
 


### PR DESCRIPTION
Fixes #5297

Should restore Specify 7 version number in User-Tools -> About Specify 7 and elsewhere.

<!--
⚠️ **Note:** This PR affects database migrations. See [migration testing instructions](https://specify.github.io/testing/pull_requests.html#prs-tagged-with-label-migration).
-->

### Checklist

- [x] Self-review the PR after opening it to make sure the changes look good
      and self-explanatory (or properly documented)
- [ ] Add automated tests
- [ ] Add relevant issue to release milestone

### Testing instructions

<!-- What are the steps to verify the fixes/changes in this PR? -->
<!-- Can part of that be replaced by automated tests? -->

 **Note:** This PR involves changes to the dockerize workflow
- Open User-Tools
- Go to About Specify 7
- [ ] Check the Specify 7 Version is not blank or just `(debug)`
