### PR TITLE
Make default catalogNumber uniqueness rule editable

### DIFF
--- a/specifyweb/businessrules/migrations/0002_default_unique_rules.py
+++ b/specifyweb/businessrules/migrations/0002_default_unique_rules.py
@@ -7,7 +7,7 @@ from specifyweb.businessrules.uniqueness_rules import apply_default_uniqueness_r
 def apply_default_rules(apps, schema_editor):
     Discipline = apps.get_model('specify', 'Discipline')
     for disp in Discipline.objects.all():
-        apply_default_uniqueness_rules(disp)
+        apply_default_uniqueness_rules(disp, registry=apps)
 
 
 def remove_default_rules(apps, schema_editor):

--- a/specifyweb/businessrules/migrations/0003_catnum_constraint.py
+++ b/specifyweb/businessrules/migrations/0003_catnum_constraint.py
@@ -1,0 +1,57 @@
+from typing import Optional, Tuple
+from django.db import migrations
+from django.db.models import UniqueConstraint
+
+
+DEFAULT_INDEX_NAME = 'CollectionID'
+
+def get_index_names(connection) -> Tuple[str]:
+    db_name = connection.settings_dict['NAME']
+    cursor = connection.cursor()
+    sql = """
+        SELECT stat.INDEX_NAME
+        FROM information_schema.statistics stat
+        WHERE stat.TABLE_SCHEMA = %s
+            AND stat.TABLE_NAME = 'collectionobject'
+            AND stat.NON_UNIQUE = 0
+        GROUP BY stat.INDEX_NAME
+        HAVING MAX(stat.SEQ_IN_INDEX) = 2
+            AND SUM(
+                stat.COLUMN_NAME IN ('catalognumber', 'collectionid')
+            ) = 2;
+        """
+    args = [db_name]
+    cursor.execute(sql, args)
+    rows: Tuple[Tuple[str], ...] = cursor.fetchall()
+    return [row[0] for row in rows]
+
+def remove_constraint(apps, schema_editor): 
+    connection = schema_editor.connection
+    index_names = get_index_names(connection)
+    CollectionObject = apps.get_model('specify', 'Collectionobject')
+    in_atomic_block = connection.in_atomic_block
+    connection.in_atomic_block = False
+    for index_name in index_names: 
+        schema_editor.remove_constraint(CollectionObject, UniqueConstraint(fields=["catalognumber", 'collection'], name=index_name))
+    connection.in_atomic_block = in_atomic_block
+
+
+def add_constraint(apps, schema_editor): 
+    connection = schema_editor.connection
+    CollectionObject = apps.get_model('specify', 'Collectionobject')
+    index_names = get_index_names(connection)
+    if len(index_names) == 0:
+        in_atomic_block = connection.in_atomic_block
+        connection.in_atomic_block = False
+        schema_editor.add_constraint(CollectionObject, UniqueConstraint(fields=['catalognumber', 'collection'], name=DEFAULT_INDEX_NAME))
+        connection.in_atomic_block = in_atomic_block
+
+
+class Migration(migrations.Migration): 
+    dependencies = [
+        ('businessrules', '0002_default_unique_rules')
+    ]
+
+    operations = [
+        migrations.RunPython(remove_constraint, add_constraint, atomic=True)
+    ]

--- a/specifyweb/businessrules/migrations/0004_catnum_uniquerule.py
+++ b/specifyweb/businessrules/migrations/0004_catnum_uniquerule.py
@@ -1,0 +1,42 @@
+from typing import Tuple
+
+from django.db import migrations
+
+from specifyweb.businessrules.uniqueness_rules import create_uniqueness_rule
+
+
+def catnum_rule_editable(apps, schema_editor):
+    UniquenessRule = apps.get_model('businessrules', 'UniquenessRule')
+    UniquenessRuleField = apps.get_model('businessrules', 'UniquenessRuleField')
+
+    candidate_rules_with_field: Tuple[int] = tuple(UniquenessRuleField.objects.filter(uniquenessrule__modelName__iexact='collectionobject', uniquenessrule__isDatabaseConstraint=True, fieldPath__iexact='catalognumber', isScope=False).values_list('uniquenessrule_id', flat=True))
+
+    candidate_rules_with_scope: Tuple[int] = tuple(UniquenessRuleField.objects.filter(uniquenessrule_id__in=candidate_rules_with_field, fieldPath__iexact='collection', isScope=True).values_list('uniquenessrule_id', flat=True))
+
+    candidate_rules = UniquenessRule.objects.filter(id__in=candidate_rules_with_scope)
+    candidate_rules.update(isDatabaseConstraint=False)
+
+def catnum_rule_uneditable(apps, schema_editor):
+    Discipline = apps.get_model('specify', 'Discipline')
+    UniquenessRule = apps.get_model('businessrules', 'UniquenessRule')
+    UniquenessRuleField = apps.get_model('businessrules', 'UniquenessRuleField')
+
+    for discipline in Discipline.objects.all():
+        candidate_rules_with_field: Tuple[int] = tuple(UniquenessRuleField.objects.filter(uniquenessrule__modelName__iexact='collectionobject', uniquenessrule__discipline=discipline.id, uniquenessrule__isDatabaseConstraint=False, fieldPath__iexact='catalognumber', isScope=False).values_list('uniquenessrule_id', flat=True))
+
+        candidate_rules_with_scope: Tuple[int] = tuple(UniquenessRuleField.objects.filter(uniquenessrule_id__in=candidate_rules_with_field, fieldPath__iexact='collection', isScope=True).values_list('uniquenessrule_id', flat=True))
+
+        candidate_rules = UniquenessRule.objects.filter(id__in=candidate_rules_with_scope)
+        if len(candidate_rules) == 0: 
+            create_uniqueness_rule('Collectionobject', discipline=discipline, is_database_constraint=True, fields=['catalogNumber'], scopes=['collection'], registry=apps)
+        else: 
+            candidate_rules.update(isDatabaseConstraint=True)
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ('businessrules', '0003_catnum_constraint')
+    ]
+
+    operations = [
+        migrations.RunPython(catnum_rule_editable, catnum_rule_uneditable, atomic=True)
+    ]

--- a/specifyweb/interactions/views.py
+++ b/specifyweb/interactions/views.py
@@ -65,7 +65,6 @@ def preps_available_rs(request, recordset_id):
     sql += " GROUP BY 1,2,3,4,5 ORDER BY 1;"
 
     cursor.execute(sql, [request.specify_collection.id, recordset_id])
-
     rows = cursor.fetchall()
 
     return http.HttpResponse(toJson(rows), content_type='application/json')


### PR DESCRIPTION
Fixes #5229 

<!--
⚠️ **Note:** This PR affects database migrations. See [migration testing instructions](https://specify.github.io/testing/pull_requests.html#prs-tagged-with-label-migration).
-->

### Checklist

- [x] Self-review the PR after opening it to make sure the changes look good
      and self-explanatory (or properly documented)
- [ ] Add automated tests
- [x] Add relevant issue to release milestone

### Testing instructions
- Go the SchemaConfig page for the CollectionObject table
- [ ] Ensure the "CatalogNumber must be unique to Collection" Uniqueness Rule which used to be readonly is now editable
- [ ] Modify or delete the Uniqueness Rule
- [ ] Save a CollectionObject with a duplicate catalognumber in the collection


#### For Developers (and/or the technically inclined with local instances)
- This should be tested in both MySQL and MariaDB

- After running/reversing the `0003_catnum_constraint` migration, check the indices/constrains at the database level
  - This can accomplished with `SHOW INDEXES FROM collectionobject;`,  `SHOW CREATE TABLE collectionobject;`, or a more specific query like: `SELECT * FROM information_schema.statistics WHERE table_schema=(SELECT DATABASE()) AND table_name='collectionobject' AND non_unique=0;`

- After running the `0003_catnum_constraint` migration, open Specify 6 and ensure that the basic functionality of 
  
- The reverse side of the `0004_catnum_uniquerule` migration should handle the case where the Uniqueness Rule doesn't exist (i.e., deleted) or has been modified and recreate it. 
  - Try both of the following and verify the state of the Uniqueness Rules: 
    - Adding another field to the rule and reversing the migration
    - Deleting the uniquenessrule and reversing the migration 