### PR TITLE
Prevent adding a cog to itself

### DIFF
--- a/specifyweb/businessrules/rules/cojo_rules.py
+++ b/specifyweb/businessrules/rules/cojo_rules.py
@@ -37,6 +37,9 @@ def cojo_pre_save(cojo):
         and not is_running_tests()
     ):
         raise BusinessRuleException('ChildCog is already in use as a child in another COG.')
+    
+    if (cojo.childcog_id == cojo.parentcog_id): 
+        raise BusinessRuleException(f"Cannot add a COG to itself. COG name: {cojo.childcog.name}")
 
 @orm_signal_handler('post_save', 'Collectionobjectgroupjoin')
 def cojo_post_save(cojo):


### PR DESCRIPTION
Fixes #5401

### Checklist

- [ ] Self-review the PR after opening it to make sure the changes look good
      and self-explanatory (or properly documented)
- [ ] Add relevant issue to release milestone

### Testing instructions

- open collection object group form 
- give it a name and a type
- save form 
- add child cog using the QB 
- select the cog you just created (itself) 
- save 
- [ ] verify there is a warning error saying you cannot add a cog to itself 
