### PR TITLE
Fine tune read/write locks when locking tables

### DIFF
--- a/specifyweb/specify/autonumbering.py
+++ b/specifyweb/specify/autonumbering.py
@@ -59,7 +59,7 @@ def get_tables_to_read_lock(collection, obj, field_names: List[str]) -> Set[str]
     tables = set([scope_table._meta.db_table, *get_uniqueness_rule_tables(collection, obj_table, field_names)])
 
     if is_treetable(obj): 
-        tables.update(get_tree_tables_to_lock())
+        tables.update(get_tree_tables_to_lock(obj_table))
 
     return tables
 

--- a/specifyweb/specify/lock_tables.py
+++ b/specifyweb/specify/lock_tables.py
@@ -1,20 +1,29 @@
-from django.db import connection
-from contextlib import contextmanager
 import logging
+
+from typing import Set
+from contextlib import contextmanager
+
+from django.db import connection
 
 logger = logging.getLogger(__name__)
 
 
 @contextmanager
-def lock_tables(*tables):
+def lock_tables(read_tables: Set[str], write_tables: Set[str]):
     cursor = connection.cursor()
     if cursor.db.vendor != 'mysql':
         logger.warning("unable to lock tables")
         yield
     else:
         try:
-            cursor.execute('lock tables %s' %
-                           ' write, '.join(tables) + ' write')
+            # If a table is present in in both read and write arguments,
+            # remove the table from the read set
+            final_read_tables = read_tables.difference(write_tables)
+            write_statement = ','.join(
+                [table + ' write' for table in write_tables]) + ',' if len(write_tables) > 0 else ''
+            read_statement = ','.join(
+                [table + ' read' for table in final_read_tables])
+            cursor.execute(f'lock tables {write_statement}{read_statement};')
             yield
         finally:
             cursor.execute('unlock tables')

--- a/specifyweb/specify/tree_extras.py
+++ b/specifyweb/specify/tree_extras.py
@@ -9,11 +9,9 @@ logger = logging.getLogger(__name__)
 
 
 from django.db import models, connection
-from django.db.models import F, Q, ProtectedError
-from django.conf import settings
+from django.db.models import F, ProtectedError
 
 from specifyweb.businessrules.exceptions import TreeBusinessRuleException
-import specifyweb.specify.models as spmodels
 
 from  .auditcodes import TREE_BULK_MOVE, TREE_MERGE, TREE_SYNONYMIZE, TREE_DESYNONYMIZE
 
@@ -722,11 +720,7 @@ def renumber_tree(table):
     Sptasksemaphore.objects.filter(taskname__in=tasknames).update(islocked=False)
 
 def is_treedefitem(obj):
-    return issubclass(obj.__class__, TreeRank) or bool(
-        re.search(r"treedefitem'>$", str(obj.__class__), re.IGNORECASE)
-    )
+    return issubclass(obj.__class__, TreeRank) or obj._meta.db_table.lower().endswith("treedefitem")
 
-def is_treedef(obj):
-    return issubclass(obj.__class__, Tree) or bool(
-        re.search(r"treedef'>$", str(obj.__class__), re.IGNORECASE)
-    )
+def is_treetable(obj): 
+    return issubclass(obj.__class__, Tree) or hasattr(obj, "definitionitem")


### PR DESCRIPTION
Addresses part of #5337
Fixes #4148

> Some raw ideas:
> 
> Make this accept two args: one for read and one for writes.
> 
> https://github.com/specify/specify7/blob/dfe5887c006551322759ea5ada539036f5a68d57/specifyweb/specify/lock_tables.py#L9
> 
> Make this return 2 sets, one for read and one for writes. Repetition isn't allowed, so if a table is in both, elevate it to a write (just remove it from read). Put all the discipline, collection, and uniqueness rule tables, and the scope_table in the read set (basically, everything we know we won't write to)
> 
> https://github.com/specify/specify7/blob/dfe5887c006551322759ea5ada539036f5a68d57/specifyweb/specify/autonumbering.py#L52

From https://github.com/specify/specify7/issues/5337#issue-2603788372

Now when autonumbering, Specify will only issue a write lock on the table which will be updated, read-locking all other tables. This will allow other users of Specify to read from common tables (collection,  discipline, etc.) while some other user is in the process of autonumbering one or more records.
Previously, these tables would be inaccessible to other users until the autonumbering process completed. This created a massive problem when using the WorkBench and relying on autonumbering: a WorkBench validation or upload could take a significant amount of time to complete, meaning Specify would not be usable for other users. 

In the future, we can extend the capability further and leverage [Row Locks](https://dev.mysql.com/doc/refman/5.7/en/innodb-locking-reads.html) for even more fine-tuned control for some tables. 

### Checklist

- [ ] Self-review the PR after opening it to make sure the changes look good
      and self-explanatory (or properly documented)
- [ ] Add automated tests
- [ ] Add relevant issue to release milestone

### Testing instructions
_Coming Soon_
