### PR TITLE
Add valid chronostrat filter to geo_time relativeage and paleocontext queries

### DIFF
--- a/specifyweb/specify/geo_time.py
+++ b/specifyweb/specify/geo_time.py
@@ -99,13 +99,22 @@ def search_co_ids_in_time_range(
         """
         start_field = f'{field_name}__startperiod'
         end_field = f'{field_name}__endperiod'
-        end_isnull_field = f'{field_name}end__isnull'
         end_start_field = f'{field_name}end__startperiod'
         end_end_field = f'{field_name}end__endperiod'
         
-        return Q(**{f'{start_field}__gte': F(end_field)}) & (
-            Q(**{end_isnull_field: True}) | Q(**{f'{end_start_field}__gte': F(end_end_field)})
-        )
+        start_period_isnull = f'{field_name}__startperiod__isnull'
+        end_period_isnull = f'{field_name}__endperiod__isnull'
+        end_isnull_field = f'{field_name}end__isnull'
+        end_start_period_isnull = f'{field_name}end__startperiod__isnull'
+        end_end_period_isnull = f'{field_name}end__endperiod__isnull'
+        
+        return Q(**{start_period_isnull: False}) \
+            & Q(**{end_period_isnull: False}) \
+            & Q(**{f'{start_field}__gte': F(end_field)}) \
+            & (
+                (Q(**{end_isnull_field: True}) | Q(**{f'{end_start_field}__gte': F(end_end_field)})) | 
+                (Q(**{end_start_period_isnull: False}) & Q(**{end_end_period_isnull: False}))
+            )
 
     valid_relative_age_chronostrat_filter = get_valid_chronostrat_filter('agename')
     valid_paleocontext_chronostrat_filter = get_valid_chronostrat_filter('chronosstrat')

--- a/specifyweb/specify/geo_time.py
+++ b/specifyweb/specify/geo_time.py
@@ -48,7 +48,6 @@ def assert_valid_time_range(start_time: float, end_time: float):
     """
     assert start_time >= end_time, "Start time must be greater than or equal to end time."
 
-
 def search_co_ids_in_time_range(
     start_time: float, end_time: float, require_full_overlap: bool = False
 ) -> Set[int]:
@@ -310,6 +309,10 @@ def search_co_ids_in_time_period(
         return set()
     start_time = time_period.startperiod
     end_time = time_period.endperiod
+    if start_time is None:
+        start_time = 13800
+    if end_time is None:
+        end_time = 0
     return search_co_ids_in_time_range(start_time, end_time, require_full_overlap)
 
 def query_co_in_time_range_with_joins(

--- a/specifyweb/specify/tests/test_geotime.py
+++ b/specifyweb/specify/tests/test_geotime.py
@@ -22,32 +22,32 @@ class GeoTimeTests(ApiTests):
     def setUp(self):
         super().setUp()
 
-        root_rank, _ = Geologictimeperiodtreedefitem.objects.get_or_create(
+        self.root_rank, _ = Geologictimeperiodtreedefitem.objects.get_or_create(
             name='Root',
             rankid=0,
             treedef=self.geologictimeperiodtreedef,
         )
-        erathem_rank, _ = Geologictimeperiodtreedefitem.objects.get_or_create(
+        self.erathem_rank, _ = Geologictimeperiodtreedefitem.objects.get_or_create(
             name='Erathem',
-            parent=root_rank,
+            parent=self.root_rank,
             rankid=100,
             treedef=self.geologictimeperiodtreedef,
         )
-        period_rank, _ = Geologictimeperiodtreedefitem.objects.get_or_create(
+        self.period_rank, _ = Geologictimeperiodtreedefitem.objects.get_or_create(
             name='Period',
-            parent=erathem_rank,
+            parent=self.erathem_rank,
             rankid=200,
             treedef=self.geologictimeperiodtreedef,
         )
-        epoch_rank, _ = Geologictimeperiodtreedefitem.objects.get_or_create(
+        self.epoch_rank, _ = Geologictimeperiodtreedefitem.objects.get_or_create(
             name='Series/Epoch',
-            parent=period_rank,
+            parent=self.period_rank,
             rankid=300,
             treedef=self.geologictimeperiodtreedef,
         )
-        stage_rank, _ = Geologictimeperiodtreedefitem.objects.get_or_create(
+        self.stage_rank, _ = Geologictimeperiodtreedefitem.objects.get_or_create(
             name='Stage/Age',
-            parent=epoch_rank,
+            parent=self.epoch_rank,
             rankid=400,
             treedef=self.geologictimeperiodtreedef,
         )
@@ -55,7 +55,7 @@ class GeoTimeTests(ApiTests):
         root_chronostrat = Geologictimeperiod.objects.create(
             name='Root',
             rankid=0,
-            definitionitem=root_rank,
+            definitionitem=self.root_rank,
             definition=self.geologictimeperiodtreedef,
             startperiod=100000,
             endperiod=0,
@@ -63,7 +63,7 @@ class GeoTimeTests(ApiTests):
         cenozoic_erathem_chronostrat = Geologictimeperiod.objects.create(
             name='Cenozoic',
             rankid=100,
-            definitionitem=erathem_rank,
+            definitionitem=self.erathem_rank,
             definition=self.geologictimeperiodtreedef,
             startperiod=None,
             startuncertainty=None,
@@ -73,7 +73,7 @@ class GeoTimeTests(ApiTests):
         paelozoic_erathem_chronostrat = Geologictimeperiod.objects.create(
             name='Paleozoic',
             rankid=100,
-            definitionitem=erathem_rank,
+            definitionitem=self.erathem_rank,
             definition=self.geologictimeperiodtreedef,
             startperiod=570,
             startuncertainty=None,
@@ -83,7 +83,7 @@ class GeoTimeTests(ApiTests):
         null_erathem_chronostrat = Geologictimeperiod.objects.create(
             name='Null',
             rankid=100,
-            definitionitem=erathem_rank,
+            definitionitem=self.erathem_rank,
             definition=self.geologictimeperiodtreedef,
             startperiod=None,
             startuncertainty=None,
@@ -93,7 +93,7 @@ class GeoTimeTests(ApiTests):
         paleogene_period_chronostrat = Geologictimeperiod.objects.create(
             name='Paleogene',
             rankid=200,
-            definitionitem=period_rank,
+            definitionitem=self.period_rank,
             definition=self.geologictimeperiodtreedef,
             startperiod=66,
             startuncertainty=None,
@@ -103,7 +103,7 @@ class GeoTimeTests(ApiTests):
         devonian_period_chronostrat = Geologictimeperiod.objects.create(
             name='Devonian',
             rankid=200,
-            definitionitem=period_rank,
+            definitionitem=self.period_rank,
             definition=self.geologictimeperiodtreedef,
             startperiod=419.2,
             startuncertainty=None,
@@ -113,7 +113,7 @@ class GeoTimeTests(ApiTests):
         jurassic_period_chronostrat = Geologictimeperiod.objects.create(
             name='Jurassic',
             rankid=200,
-            definitionitem=period_rank,
+            definitionitem=self.period_rank,
             definition=self.geologictimeperiodtreedef,
             startperiod=208,
             startuncertainty=18,
@@ -123,7 +123,7 @@ class GeoTimeTests(ApiTests):
         paleocene_epoch_chronostrat = Geologictimeperiod.objects.create(
             name='Paleocene',
             rankid=300,
-            definitionitem=epoch_rank,
+            definitionitem=self.epoch_rank,
             definition=self.geologictimeperiodtreedef,
             startperiod=66,
             startuncertainty=None,
@@ -133,7 +133,7 @@ class GeoTimeTests(ApiTests):
         eocene_epoch_chronostrat = Geologictimeperiod.objects.create(
             name='Eocene',
             rankid=300,
-            definitionitem=epoch_rank,
+            definitionitem=self.epoch_rank,
             definition=self.geologictimeperiodtreedef,
             startperiod=56,
             startuncertainty=None,
@@ -143,7 +143,7 @@ class GeoTimeTests(ApiTests):
         test_epoch_chronostrat = Geologictimeperiod.objects.create(
             name='Test Epoch',
             rankid=300,
-            definitionitem=epoch_rank,
+            definitionitem=self.epoch_rank,
             definition=self.geologictimeperiodtreedef,
             startperiod=100,
             startuncertainty=11,
@@ -153,7 +153,7 @@ class GeoTimeTests(ApiTests):
         late_jurassic_epoch_chronostrat = Geologictimeperiod.objects.create(
             name='Late Jurassic',
             rankid=300,
-            definitionitem=epoch_rank,
+            definitionitem=self.epoch_rank,
             definition=self.geologictimeperiodtreedef,
             startperiod=163,
             startuncertainty=15,
@@ -163,7 +163,7 @@ class GeoTimeTests(ApiTests):
         selandian_stage_chronostrat = Geologictimeperiod.objects.create(
             name='Selandian',
             rankid=400,
-            definitionitem=stage_rank,
+            definitionitem=self.stage_rank,
             definition=self.geologictimeperiodtreedef,
             startperiod=61.6,
             startuncertainty=None,
@@ -173,7 +173,7 @@ class GeoTimeTests(ApiTests):
         franconian_stage_chronostrat = Geologictimeperiod.objects.create(
             name='Franconian',
             rankid=400,
-            definitionitem=stage_rank,
+            definitionitem=self.stage_rank,
             definition=self.geologictimeperiodtreedef,
             startperiod=523,
             startuncertainty=36,
@@ -183,7 +183,7 @@ class GeoTimeTests(ApiTests):
         oxfordian_stage_chronostrat = Geologictimeperiod.objects.create(
             name='Oxfordian',
             rankid=400,
-            definitionitem=stage_rank,
+            definitionitem=self.stage_rank,
             definition=self.geologictimeperiodtreedef,
             startperiod=163,
             startuncertainty=15,
@@ -423,6 +423,30 @@ class GeoTimeTests(ApiTests):
         collecting_event_2 = Collectingevent.objects.create(locality=locality_1, discipline=self.discipline)
         co_6 = Collectionobject.objects.create(collection=self.collection, collectingevent=collecting_event_2)
 
+    def test_invalid_chronostrat(self):
+        bad_chronostrat = Geologictimeperiod.objects.create(
+            name='BadBoyz',
+            rankid=100,
+            definitionitem=self.erathem_rank,
+            definition=self.geologictimeperiodtreedef,
+            startperiod=10,
+            endperiod=90,
+            parent=self.geo_time_period_dict['root']
+        )
+        co_1 = Collectionobject.objects.create(collection=self.collection)
+        relative_age = Relativeage.objects.create(
+            agename=bad_chronostrat,
+            collectionobject=co_1
+        )
+
+        self.assertFalse(co_1.id in geo_time.search_co_ids_in_time_range(200, 10))
+
+        bad_chronostrat.startperiod = 100
+        bad_chronostrat.name = 'GoodBoyz' # important, don't change this :)
+        bad_chronostrat.save()
+
+        self.assertTrue(co_1.id in geo_time.search_co_ids_in_time_range(200, 10))
+    
     @skip('Fix API test call')
     def test_geotime_any(self):
         c = Client()

--- a/specifyweb/specify/tree_views.py
+++ b/specifyweb/specify/tree_views.py
@@ -16,7 +16,7 @@ from specifyweb.stored_queries import models as sqlmodels
 from specifyweb.stored_queries.execution import set_group_concat_max_len
 from specifyweb.stored_queries.group_concat import group_concat
 from specifyweb.specify.tree_utils import get_search_filters
-from specifyweb.specify import spmodels
+from specifyweb.specify import models as spmodels
 from specifyweb.specify.tree_ranks import tree_rank_count
 from . import tree_extras
 from .api import get_object_or_404, obj_to_data, toJson
@@ -516,33 +516,6 @@ def all_tree_information(request):
             })
 
     return HttpResponse(toJson(result), content_type='application/json')
-
-@login_maybe_required
-@require_GET
-def get_valid_chronostrat_ids(request):
-    """Returns a list of valid chronostrat names for a given geologictimeperiod node."""
-
-    # Filter goelogictimeperiod nodes where the startperiod and endperiod are not null,
-    # and the startperiod is greater than equal to the endperiod
-    valid_chronostrat_names = spmodels.Geologictimeperiod.objects.filter(
-        startperiod__isnull=False,
-        endperiod__isnull=False,
-        startperiod__gte=F("endperiod"),
-    ).values_list("id", flat=True)
-
-    return HttpResponse(toJson(valid_chronostrat_names), content_type='application/json')
-    
-@login_maybe_required
-@require_GET
-def get_invalid_chronostrat_ids(request):
-    """Returns a list of invalid chronostrat names for a given geologictimeperiod node."""
-
-    # Filter goelogictimeperiod nodes where the startperiod or endperiod are null
-    invalid_chronostrat_names = spmodels.Geologictimeperiod.objects.filter(
-        Q(startperiod__isnull=True) | Q(endperiod__isnull=True) | Q(startperiod__lt=F("endperiod"))
-    ).values_list("id", flat=True)
-
-    return HttpResponse(toJson(invalid_chronostrat_names), content_type='application/json')
 
 class TaxonMutationPT(PermissionTarget):
     resource = "/tree/edit/taxon"

--- a/specifyweb/specify/urls.py
+++ b/specifyweb/specify/urls.py
@@ -43,8 +43,6 @@ urlpatterns = [
         url(r'^(?P<treeid>\w+)/add_root/$', tree_views.add_root),
         url(r'^(?P<treedef>\d+)/(?P<parentid>\w+)/(?P<sortfield>\w+)/$', tree_views.tree_view),
         url(r'^repair/$', tree_views.repair_tree),
-        url(r'^valid_chronostrats/$', tree_views.get_valid_chronostrat_ids),
-        url(r'^invalid_chronostrats/$', tree_views.get_valid_chronostrat_ids),
     ])),
 
     # locality set import endpoints

--- a/specifyweb/specify/urls.py
+++ b/specifyweb/specify/urls.py
@@ -43,6 +43,8 @@ urlpatterns = [
         url(r'^(?P<treeid>\w+)/add_root/$', tree_views.add_root),
         url(r'^(?P<treedef>\d+)/(?P<parentid>\w+)/(?P<sortfield>\w+)/$', tree_views.tree_view),
         url(r'^repair/$', tree_views.repair_tree),
+        url(r'^valid_chronostrats/$', tree_views.get_valid_chronostrat_ids),
+        url(r'^invalid_chronostrats/$', tree_views.get_valid_chronostrat_ids),
     ])),
 
     # locality set import endpoints


### PR DESCRIPTION
Fixes #5410

Add a filter to the 'specify_row' API so that the age names in the extended age query's picklist will not include invalid Chronostrat records. 

Also, Add valid Chronostrat filter to RelativeAge and PaleoContext queries.  This done to filter Chronostrat names in the extended age filter to remove all names that have a start period smaller than the end period.

Address comment https://github.com/specify/specify7/pull/5272#pullrequestreview-2445957145

### Checklist

- [x] Self-review the PR after opening it to make sure the changes look good
      and self-explanatory (or properly documented)
- [x] Add automated tests
- [x] Add relevant issue to release milestone

### Testing instructions

The first part of testing this PR is to make sure that all the values in the age name picklist are valid Choronostrats.  A valid Chronostrat/GeologicTimePeriod needs to have a StartPeriod and EndPeriod that are not null, also the StartPeriod value needs to be larger than the EndPeriod.

Use any database on the test-panel that has values in the GeologicTimePeriod table.

1. [x] Open a new QB on the Chronostratigraphy table.  Select '(any rank)', and then add the following fields: ID, Name, Start Period, End Period.  Run the query.  In the query results note down some of the Name values that are invalid due to either the start period or end period being null.  Also, if there are any rows where the End Time is larger than the start time, then note down that name as well for being invalid.  We'll check some of those names in the next step.
<img width="1137" alt="image" src="https://github.com/user-attachments/assets/5abb62a1-8fff-40f0-9040-e08aac1e3068">
<img width="1099" alt="image" src="https://github.com/user-attachments/assets/6a107089-6042-4926-8fc7-57a156a83c5a">

2. [x] Open a new QB on the CollectionObject table.  Select the Age field.  Instead of 'Any', select 'Name' in the options.  In the picklist that appears next to 'Name', verify that each of the names present are valid Chronostratigraphy records.  Review the query results from the Chronostratigraphy query in the previous step to verify that the names in the picklist are valid.  Verify that the names noted down in the previous step do not appear in this picklist.
<img width="1144" alt="image" src="https://github.com/user-attachments/assets/30b28720-c99f-4f83-9200-31e5a1ab8d38">


This next part of the testing will need to show that COs associated with an invalid Chronostrat, which is where the StartPeriod is less than the EndPeriod, does not show up in an extended age query.

Use the `ciscollections_age_qb` database on the test-panel.

1. [x] Create a Collection Object Query. Select the 'Age' field. Select the 'Range' filter. Set the 'start_time' to 1000 and set the 'end_time' to 0. Make sure that for this query, that the value 40064 is NOT present in the query results of the 'Age' column.  This is because the CO with ID 40046 points to a GeologicTimePeriod with a start period of 10 and an end period of 90, this is invalid and thus shouldn't appear in the results.
