### PR TITLE
Prevent save when no CO child is marked as primary in a Consolidated COG

### DIFF
--- a/specifyweb/frontend/js_src/lib/components/DataModel/__tests__/businessRules.test.ts
+++ b/specifyweb/frontend/js_src/lib/components/DataModel/__tests__/businessRules.test.ts
@@ -1,9 +1,11 @@
 import { act, renderHook } from '@testing-library/react';
 
+import { resourcesText } from '../../../localization/resources';
 import { overrideAjax } from '../../../tests/ajax';
 import { mockTime, requireContext } from '../../../tests/helpers';
 import { overwriteReadOnly } from '../../../utils/types';
 import { getPref } from '../../InitialContext/remotePrefs';
+import { cogTypes } from '../helpers';
 import type { SerializedResource } from '../helperTypes';
 import { getResourceApiUrl } from '../resource';
 import { useSaveBlockers } from '../saveBlockers';
@@ -194,6 +196,16 @@ describe('Collection Object business rules', () => {
 });
 
 describe('CollectionObjectGroup business rules', () => {
+  overrideAjax(getResourceApiUrl('CollectionObjectGroupType', 1), {
+    name: 'Discrete type',
+    type: cogTypes.DISCRETE,
+  });
+
+  overrideAjax(getResourceApiUrl('CollectionObjectGroupType', 2), {
+    name: 'Consolidated type',
+    type: cogTypes.CONSOLIDATED,
+  });
+
   const getBaseCog = () => {
     const cog = new tables.CollectionObjectGroup.Resource({
       id: 1,
@@ -232,6 +244,32 @@ describe('CollectionObjectGroup business rules', () => {
 
     expect(cojo1.get('isSubstrate')).toBe(false);
     expect(cojo2.get('isSubstrate')).toBe(true);
+  });
+
+  test('Save blocked when a Consolidated COG has no primary CO child', async () => {
+    const { cog, cojo2 } = getBaseCog();
+    cog.set('cogType', getResourceApiUrl('CollectionObjectGroupType', 2));
+
+    const { result } = renderHook(() =>
+      useSaveBlockers(cog, tables.CollectionObjectGroupJoin.field.isPrimary)
+    );
+
+    await act(async () => {
+      await cog?.businessRuleManager?.checkField('cogType');
+    });
+
+    // Save not blocked initially
+    expect(result.current[0]).toStrictEqual([]);
+
+    cojo2.set('isPrimary', false);
+    await act(async () => {
+      await cog?.businessRuleManager?.checkField('cogType');
+    });
+
+    // Save blocked after second child is marked as not primary
+    expect(result.current[0]).toStrictEqual([
+      resourcesText.primaryCogChildRequired(),
+    ]);
   });
 });
 

--- a/specifyweb/frontend/js_src/lib/components/DataModel/businessRuleDefs.ts
+++ b/specifyweb/frontend/js_src/lib/components/DataModel/businessRuleDefs.ts
@@ -284,6 +284,14 @@ export const businessRuleDefs: MappedBusinessRuleDefs = {
         ensureSingleCollectionObjectCheck(cojo, 'isSubstrate');
       },
     },
+    onRemoved(_, collection) {
+      // Trigger Consolidated COGs field check when a child is deleted
+      if (collection?.related?.specifyTable === tables.CollectionObjectGroup) {
+        const cog =
+          collection.related as SpecifyResource<CollectionObjectGroup>;
+        cog.businessRuleManager?.checkField('cogType');
+      }
+    },
   },
 
   Determination: {

--- a/specifyweb/frontend/js_src/lib/components/DataModel/businessRuleDefs.ts
+++ b/specifyweb/frontend/js_src/lib/components/DataModel/businessRuleDefs.ts
@@ -28,6 +28,7 @@ import type {
   Address,
   BorrowMaterial,
   CollectionObject,
+  CollectionObjectGroup,
   CollectionObjectGroupJoin,
   Determination,
   DNASequence,
@@ -264,6 +265,16 @@ export const businessRuleDefs: MappedBusinessRuleDefs = {
        */
       isPrimary: (cojo: SpecifyResource<CollectionObjectGroupJoin>): void => {
         ensureSingleCollectionObjectCheck(cojo, 'isPrimary');
+
+        // Trigger Consolidated COGs field check when isPrimary changes
+        if (
+          cojo.collection?.related?.specifyTable ===
+          tables.CollectionObjectGroup
+        ) {
+          const cog = cojo.collection
+            .related as SpecifyResource<CollectionObjectGroup>;
+          cog.businessRuleManager?.checkField('cogType');
+        }
       },
       /*
        * Only a single CO in a COG can be set as substrate.

--- a/specifyweb/frontend/js_src/lib/components/DataModel/businessRuleUtils.ts
+++ b/specifyweb/frontend/js_src/lib/components/DataModel/businessRuleUtils.ts
@@ -5,6 +5,7 @@ import type { CollectionObjectGroupJoin, Determination } from './types';
 // Save blocker keys used in businessRuleDefs.ts
 export const CURRENT_DETERMINATION_KEY = 'determination-isCurrent';
 export const PARENTCOG_KEY = 'cog-parentCog';
+export const COG_PRIMARY_KEY = 'cog-isPrimary';
 
 /**
  *

--- a/specifyweb/frontend/js_src/lib/localization/resources.ts
+++ b/specifyweb/frontend/js_src/lib/localization/resources.ts
@@ -842,4 +842,7 @@ export const resourcesText = createDictionary({
   parentCogSameAsChild: {
     'en-us': 'A Collection Object Group cannot be a parent to itself',
   },
+  primaryCogChildRequired: {
+    'en-us': 'A Consolidated Collection Object Group must have a primary Collection Object child'
+  }
 } as const);


### PR DESCRIPTION
Fixes #5427

Automatically setting the first CO child as primary leads to a lot of edge cases and unmaintainable code. Hence we're using a save blocker instead to make things simpler

<!--
⚠️ **Note:** This PR affects database migrations. See [migration testing instructions](https://specify.github.io/testing/pull_requests.html#prs-tagged-with-label-migration).
-->

### Checklist

- [x] Self-review the PR after opening it to make sure the changes look good
      and self-explanatory (or properly documented)
- [x] Add automated tests
- [x] Add relevant issue to release milestone

### Testing instructions

<!-- What are the steps to verify the fixes/changes in this PR? -->
<!-- Can part of that be replaced by automated tests? -->
- Create a COG with a Consolidated type
- Add children
- [ ] Verify save is blocked when no Collection Object children are marked as primary
- [ ] Verify any CO child can be set as primary when the type is Consolidated
- [ ] Verify save is enabled when a CO child is marked as primary or the type is not Consolidated