### PR TITLE
Fix isPrimary for Consolidated COGs

### DIFF
--- a/specifyweb/frontend/js_src/lib/components/DataModel/businessRuleDefs.ts
+++ b/specifyweb/frontend/js_src/lib/components/DataModel/businessRuleDefs.ts
@@ -287,19 +287,25 @@ export const businessRuleDefs: MappedBusinessRuleDefs = {
         };
       },
     },
-    onAdded: (CollectionObjectGroupJoin) => {
+    onAdded: (cojo, collection) => {
       if (
-        CollectionObjectGroupJoin.get('childCog') ===
-          CollectionObjectGroupJoin.get('parentCog') &&
-        typeof CollectionObjectGroupJoin.get('childCog') === 'string' &&
-        typeof CollectionObjectGroupJoin.get('parentCog') === 'string'
+        cojo.get('childCog') === cojo.get('parentCog') &&
+        typeof cojo.get('childCog') === 'string' &&
+        typeof cojo.get('parentCog') === 'string'
       ) {
         setSaveBlockers(
-          CollectionObjectGroupJoin,
-          CollectionObjectGroupJoin.specifyTable.field.childCog,
+          cojo,
+          cojo.specifyTable.field.childCog,
           [resourcesText.cogAddedToItself()],
           COG_TOITSELF
         );
+      }
+
+      // Trigger Consolidated COGs field check when a child is added
+      if (collection?.related?.specifyTable === tables.CollectionObjectGroup) {
+        const cog =
+          collection.related as SpecifyResource<CollectionObjectGroup>;
+        cog.businessRuleManager?.checkField('cogType');
       }
     },
     onRemoved(_, collection) {


### PR DESCRIPTION
Fixes #5458

<!--
⚠️ **Note:** This PR affects database migrations. See [migration testing instructions](https://specify.github.io/testing/pull_requests.html#prs-tagged-with-label-migration).
-->

### Checklist

- [x] Self-review the PR after opening it to make sure the changes look good
      and self-explanatory (or properly documented)
- [] Add automated tests
- [x] Add relevant issue to release milestone

### Testing instructions

<!-- What are the steps to verify the fixes/changes in this PR? -->
<!-- Can part of that be replaced by automated tests? -->
- Create a COG with a consolidated type
-Add childCO
- Mark as 'isPrimary'
- Save
- Delete childCO
- Save
- Add childCO
- [ ] Verify save is blocked as no primary CO exists