### PR TITLE
Improve schema config migration utils

### DIFF
--- a/specifyweb/specify/migration_utils/update_schema_config.py
+++ b/specifyweb/specify/migration_utils/update_schema_config.py
@@ -6,7 +6,7 @@ import logging
 from django.db.models import Q
 from django.apps import apps
 
-from specifyweb.specify.load_datamodel import Table, FieldDoesNotExistError
+from specifyweb.specify.load_datamodel import Table, FieldDoesNotExistError, TableDoesNotExistError
 from specifyweb.specify.models import (
     datamodel,
 )
@@ -66,7 +66,12 @@ def update_table_schema_config_with_defaults(
     Splocalecontainer = apps.get_model('specify', 'Splocalecontainer')
     Splocaleitemstr = apps.get_model('specify', 'Splocaleitemstr')
 
-    table: Table = datamodel.get_table(table_name)
+    try:
+        table: Table = datamodel.get_table_strict(table_name)
+    except TableDoesNotExistError:
+        logger.warning(f"Table does not exist in latest state of the datamodel, skipping Schema Config entry for: {table_name}")
+        return
+
     table_config = TableSchemaConfig(
         name=table.name,
         discipline_id=discipline_id,
@@ -100,7 +105,12 @@ def update_table_schema_config_with_defaults(
 
 
 def revert_table_schema_config(table_name, apps = apps):
-    table: Table = datamodel.get_table(table_name)
+    try:
+        table: Table = datamodel.get_table_strict(table_name)
+    except TableDoesNotExistError:
+        logger.warning(f"Table does not exist in latest state of the datamodel, skipping Schema Config entry for: {table_name}")
+        return
+    
     table_name = table.name
 
     Splocalecontainer = apps.get_model('specify', 'Splocalecontainer')
@@ -124,7 +134,12 @@ def update_table_field_schema_config_with_defaults(
     field_name: str,
     apps = apps
 ):
-    table: Table = datamodel.get_table(table_name)
+    try:
+        table: Table = datamodel.get_table_strict(table_name)
+    except TableDoesNotExistError:
+        logger.warning(f"Table does not exist in latest state of the datamodel, skipping Schema Config entry for: {table_name}")
+        return
+    
     table_name = table.name
     table_config = TableSchemaConfig(
         name=table_name.lower(),
@@ -180,7 +195,12 @@ def update_table_field_schema_config_with_defaults(
         Splocaleitemstr.objects.get_or_create(**itm_str)
 
 def revert_table_field_schema_config(table_name, field_name, apps = apps):
-    table: Table = datamodel.get_table(table_name)
+    try:
+        table: Table = datamodel.get_table_strict(table_name)
+    except TableDoesNotExistError:
+        logger.warning(f"Table does not exist in latest state of the datamodel, skipping Schema Config entry for: {table_name}")
+        return
+    
     table_name = table.name
 
     Splocalecontainer = apps.get_model('specify', 'Splocalecontainer')

--- a/specifyweb/specify/migration_utils/update_schema_config.py
+++ b/specifyweb/specify/migration_utils/update_schema_config.py
@@ -108,8 +108,7 @@ def revert_table_schema_config(table_name, apps = apps):
     try:
         table: Table = datamodel.get_table_strict(table_name)
     except TableDoesNotExistError:
-        logger.warning(f"Table does not exist in latest state of the datamodel, skipping Schema Config entry for: {table_name}")
-        return
+        logger.warning(f"Table does not exist in latest state of the datamodel, deleting Schema Config entries using table name: {table_name}")
     
     table_name = table.name
 
@@ -198,8 +197,7 @@ def revert_table_field_schema_config(table_name, field_name, apps = apps):
     try:
         table: Table = datamodel.get_table_strict(table_name)
     except TableDoesNotExistError:
-        logger.warning(f"Table does not exist in latest state of the datamodel, skipping Schema Config entry for: {table_name}")
-        return
+        logger.warning(f"Table does not exist in latest state of the datamodel, deleting Schema Config entries using table name: {table_name}")
     
     table_name = table.name
 

--- a/specifyweb/specify/migration_utils/update_schema_config.py
+++ b/specifyweb/specify/migration_utils/update_schema_config.py
@@ -105,13 +105,6 @@ def update_table_schema_config_with_defaults(
 
 
 def revert_table_schema_config(table_name, apps = apps):
-    try:
-        table: Table = datamodel.get_table_strict(table_name)
-    except TableDoesNotExistError:
-        logger.warning(f"Table does not exist in latest state of the datamodel, deleting Schema Config entries using table name: {table_name}")
-    
-    table_name = table.name
-
     Splocalecontainer = apps.get_model('specify', 'Splocalecontainer')
     Splocaleitemstr = apps.get_model('specify', 'Splocaleitemstr')
     Splocalecontaineritem = apps.get_model('specify', 'Splocalecontaineritem')
@@ -194,13 +187,6 @@ def update_table_field_schema_config_with_defaults(
         Splocaleitemstr.objects.get_or_create(**itm_str)
 
 def revert_table_field_schema_config(table_name, field_name, apps = apps):
-    try:
-        table: Table = datamodel.get_table_strict(table_name)
-    except TableDoesNotExistError:
-        logger.warning(f"Table does not exist in latest state of the datamodel, deleting Schema Config entries using table name: {table_name}")
-    
-    table_name = table.name
-
     Splocalecontainer = apps.get_model('specify', 'Splocalecontainer')
     Splocaleitemstr = apps.get_model('specify', 'Splocaleitemstr')
     Splocalecontaineritem = apps.get_model('specify', 'Splocalecontaineritem')

--- a/specifyweb/specify/migration_utils/update_schema_config.py
+++ b/specifyweb/specify/migration_utils/update_schema_config.py
@@ -1,14 +1,17 @@
 import re
 
 from typing import NamedTuple, List
+import logging
 
 from django.db.models import Q
 from django.apps import apps
 
-from specifyweb.specify.load_datamodel import Table
+from specifyweb.specify.load_datamodel import Table, FieldDoesNotExistError
 from specifyweb.specify.models import (
     datamodel,
 )
+
+logger = logging.getLogger(__name__)
 
 HIDDEN_FIELDS = [
     "timestampcreated", "timestampmodified", "version", "createdbyagent", "modifiedbyagent"
@@ -62,7 +65,6 @@ def update_table_schema_config_with_defaults(
 ):
     Splocalecontainer = apps.get_model('specify', 'Splocalecontainer')
     Splocaleitemstr = apps.get_model('specify', 'Splocaleitemstr')
-    Splocalecontaineritem = apps.get_model('specify', 'Splocalecontaineritem')
 
     table: Table = datamodel.get_table(table_name)
     table_config = TableSchemaConfig(
@@ -74,7 +76,7 @@ def update_table_schema_config_with_defaults(
     )
 
     # Create Splocalecontainer for the table
-    sp_local_container = Splocalecontainer.objects.create(
+    sp_local_container, _ = Splocalecontainer.objects.get_or_create(
         name=table_config.name.lower(),
         discipline_id=discipline_id,
         schematype=table_config.schema_type,
@@ -91,32 +93,10 @@ def update_table_schema_config_with_defaults(
             'version': 0,
         }
         item_str[k] = sp_local_container
-        Splocaleitemstr.objects.create(**item_str)
+        Splocaleitemstr.objects.get_or_create(**item_str)
 
     for field in table.all_fields:
-        # Create Splocalecontaineritem for each field
-        sp_local_container_item = Splocalecontaineritem.objects.create(
-            name=field.name,
-            container=sp_local_container,
-            type=datamodel_type_to_schematype(field.type) if field.is_relationship else field.type,
-            ishidden=field.name.lower() in HIDDEN_FIELDS,
-            isrequired=field.required,
-            issystem=table.system,
-            version=0,
-        )
-
-        # Splocaleitemstr for the field name and description
-        for k, text in {
-            "itemname": camel_to_spaced_title_case(field.name),
-            "itemdesc": camel_to_spaced_title_case(field.name),
-        }.items():
-            itm_str = {
-                "text": text,
-                "language": "en",
-                "version": 0,
-            }
-            itm_str[k] = sp_local_container_item
-            Splocaleitemstr.objects.create(**itm_str)
+        update_table_field_schema_config_with_defaults(table_name, discipline_id, field.name, apps)
 
 
 def revert_table_schema_config(table_name, apps = apps):
@@ -157,13 +137,17 @@ def update_table_field_schema_config_with_defaults(
     Splocaleitemstr = apps.get_model('specify', 'Splocaleitemstr')
     Splocalecontaineritem = apps.get_model('specify', 'Splocalecontaineritem')
 
-    sp_local_container = Splocalecontainer.objects.get(
+    sp_local_container, _ = Splocalecontainer.objects.get_or_create(
         name=table.name.lower(),
         discipline_id=discipline_id,
         schematype=table_config.schema_type,
     )
 
-    field = table.get_field(field_name)
+    try:
+        field = table.get_field_strict(field_name)
+    except FieldDoesNotExistError:
+        logger.warning(f"Field does not exist in latest state of the datamodel, skipping Schema Config entry for: {table_name} -> {field_name}")
+        return
 
     field_config = FieldSchemaConfig(
         name=field_name,
@@ -173,7 +157,7 @@ def update_table_field_schema_config_with_defaults(
         language="en"
     )
 
-    sp_local_container_item = Splocalecontaineritem.objects.create(
+    sp_local_container_item, _ = Splocalecontaineritem.objects.get_or_create(
         name=field_config.name,
         container=sp_local_container,
         type=field_config.java_type,
@@ -193,7 +177,7 @@ def update_table_field_schema_config_with_defaults(
             'version': 0,
         }
         itm_str[k] = sp_local_container_item
-        Splocaleitemstr.objects.create(**itm_str)
+        Splocaleitemstr.objects.get_or_create(**itm_str)
 
 def revert_table_field_schema_config(table_name, field_name, apps = apps):
     table: Table = datamodel.get_table(table_name)


### PR DESCRIPTION
Fixes #5469

- Fields that don't exist in the latest state of the datamodel will be skipped when creating Schema Config entries
- Changed the util functions to use `get_or_create()` instead of `create()` to avoid duplicate Schema Config entries. Ideally, we should no longer need to revert an entry before adding it anymore like here: https://github.com/specify/specify7/blob/c75cf54c3e1c8ed39036950c278a52610a3616a7/specifyweb/specify/migrations/0015_add_version_to_ages.py#L6-L13

<!--
⚠️ **Note:** This PR affects database migrations. See [migration testing instructions](https://specify.github.io/testing/pull_requests.html#prs-tagged-with-label-migration).
-->

### Checklist

- [x] Self-review the PR after opening it to make sure the changes look good
      and self-explanatory (or properly documented)
- [ ] Add automated tests
- [x] Add relevant issue to release milestone

### Testing instructions

<!-- What are the steps to verify the fixes/changes in this PR? -->
<!-- Can part of that be replaced by automated tests? -->
#### Dev testing only?
- Try to apply the `0013` migration manually
- [ ] Verify there are no errors (there will be a warning for adding COG -> parentCog)
