### PR TITLE
Support COT catalog number configurations in the Query Builder

### DIFF
--- a/specifyweb/frontend/js_src/lib/components/QueryBuilder/Formatter.tsx
+++ b/specifyweb/frontend/js_src/lib/components/QueryBuilder/Formatter.tsx
@@ -115,9 +115,13 @@ export function CatalogNumberFormatSelection({
       availableFormatters={availableFormatters}
       currentFormat={formatter}
       showSingular={
-        !Object.values(schema.collectionObjectTypeCatalogNumberFormats).some(
-          (format) => format === null || format === schema.catalogNumFormatName
-        )
+        Object.values(schema.collectionObjectTypeCatalogNumberFormats).some(
+          (format) => format !== null && format !== schema.catalogNumFormatName
+        ) ||
+        (formatter !== undefined &&
+          !Object.values(schema.collectionObjectTypeCatalogNumberFormats)
+            .filter((formatName) => formatName !== null)
+            .includes(formatter))
       }
       onChange={handleChange}
     />
@@ -178,6 +182,14 @@ function FormatSelect({
                 {`${title} ${isDefault ? resourcesText.defaultInline() : ''}`}
               </option>
             ))}
+            {currentFormat !== undefined &&
+            !availableFormatters
+              .map(({ name }) => name)
+              .includes(currentFormat) ? (
+              <option key="invalidCOT" value={currentFormat}>
+                {queryText.invalidPicklistValue({ value: currentFormat })}
+              </option>
+            ) : undefined}
           </Select>
         </div>
       )}

--- a/specifyweb/frontend/js_src/lib/components/QueryBuilder/Formatter.tsx
+++ b/specifyweb/frontend/js_src/lib/components/QueryBuilder/Formatter.tsx
@@ -1,18 +1,29 @@
 import React from 'react';
 
-import { usePromise } from '../../hooks/useAsyncState';
+import { useAsyncState, usePromise } from '../../hooks/useAsyncState';
 import { useId } from '../../hooks/useId';
 import { commonText } from '../../localization/common';
 import { queryText } from '../../localization/query';
 import { resourcesText } from '../../localization/resources';
+import type { RA } from '../../utils/types';
+import { filterArray } from '../../utils/types';
 import { Button } from '../Atoms/Button';
 import { Select } from '../Atoms/Form';
 import { icons } from '../Atoms/Icons';
-import type { Tables } from '../DataModel/types';
+import type { SpecifyResource } from '../DataModel/legacyTypes';
+import { resourceFromUrl } from '../DataModel/resource';
+import { fetchContext as fetchDomain, schema } from '../DataModel/schema';
+import type { CollectionObjectType, Tables } from '../DataModel/types';
 import { fetchFormatters } from '../Formatters/formatters';
 import { customSelectElementBackground } from '../WbPlanView/CustomSelectElement';
 
-export function QueryFieldFormatter({
+type SimpleFormatter = {
+  readonly name: string;
+  readonly title: string;
+  readonly isDefault: boolean;
+};
+
+export function QueryFieldRecordFormatter({
   type,
   tableName,
   formatter,
@@ -24,7 +35,7 @@ export function QueryFieldFormatter({
   readonly onChange: ((formatter: string | undefined) => void) | undefined;
 }): JSX.Element | null {
   const [formatters] = usePromise(fetchFormatters, false);
-  const availableFormatters = React.useMemo(
+  const availableFormatters = React.useMemo<RA<SimpleFormatter> | undefined>(
     () =>
       // Some code duplication, but required by TypeScript
       (type === 'formatter'
@@ -50,24 +61,99 @@ export function QueryFieldFormatter({
     [type, formatters, tableName]
   );
 
+  return (
+    <FormatSelect
+      availableFormatters={availableFormatters}
+      currentFormat={formatter}
+      onChange={handleChange}
+    />
+  );
+}
+
+export function CatalogNumberFormatSelection({
+  formatter,
+  onChange: handleChange,
+}: {
+  readonly formatter: string | undefined;
+  readonly onChange: ((formatter: string | undefined) => void) | undefined;
+}): JSX.Element | null {
+  const [availableFormatters] = useAsyncState(
+    React.useCallback(
+      async () =>
+        fetchDomain
+          .then(async (schema) =>
+            Promise.all(
+              Object.keys(schema.collectionObjectTypeCatalogNumberFormats).map(
+                async (cotUri) =>
+                  resourceFromUrl(cotUri, {
+                    noBusinessRules: true,
+                  })?.fetch() as Promise<
+                    SpecifyResource<CollectionObjectType> | undefined
+                  >
+              )
+            )
+          )
+          .then((cots) =>
+            filterArray(cots).map((cot) => {
+              const format =
+                cot.get('catalogNumberFormatName') ??
+                schema.catalogNumFormatName;
+              return {
+                name: format,
+                title: cot.get('name'),
+                isDefault: false,
+              };
+            })
+          ),
+      []
+    ),
+    false
+  );
+
+  return (
+    <FormatSelect
+      availableFormatters={availableFormatters}
+      currentFormat={formatter}
+      showSingular={
+        !Object.values(schema.collectionObjectTypeCatalogNumberFormats).some(
+          (format) => format === null || format === schema.catalogNumFormatName
+        )
+      }
+      onChange={handleChange}
+    />
+  );
+}
+
+function FormatSelect({
+  availableFormatters,
+  currentFormat,
+  showSingular = false,
+  onChange: handleChange,
+}: {
+  readonly availableFormatters: RA<SimpleFormatter> | undefined;
+  readonly currentFormat: string | undefined;
+  readonly showSingular?: boolean;
+  readonly onChange: ((formatter: string | undefined) => void) | undefined;
+}): JSX.Element | null {
   const [formatterSelectIsOpen, setFormatterSelect] = React.useState(false);
 
   const id = useId('formatters-selection');
 
   return availableFormatters === undefined ? (
-    typeof formatter === 'string' ? (
+    typeof currentFormat === 'string' ? (
       <>{commonText.loading()}</>
     ) : null
-  ) : availableFormatters.length > 1 ? (
+  ) : showSingular || availableFormatters.length > 1 ? (
     <>
       <Button.Small
         aria-controls={id('list')}
         aria-label={queryText.chooseFormatter()}
         className={`${
-          availableFormatters.find((selected) => selected.name === formatter)
-            ?.isDefault ||
-          formatter === undefined ||
-          formatter === ''
+          availableFormatters.find(
+            (selected) => selected.name === currentFormat
+          )?.isDefault ||
+          currentFormat === undefined ||
+          currentFormat === ''
             ? 'bg-white dark:bg-neutral-600'
             : 'bg-yellow-250 dark:bg-yellow-900 '
         }`}
@@ -83,7 +169,7 @@ export function QueryFieldFormatter({
             className={customSelectElementBackground}
             disabled={handleChange === undefined}
             id={id('list')}
-            value={formatter}
+            value={currentFormat}
             onValueChange={handleChange}
           >
             <option />

--- a/specifyweb/frontend/js_src/lib/components/QueryBuilder/FromMap.tsx
+++ b/specifyweb/frontend/js_src/lib/components/QueryBuilder/FromMap.tsx
@@ -233,7 +233,6 @@ function getNewQueryLines(
     sortType: undefined,
     isDisplay: definedField.isDisplay,
     ...(fields[latitudeLineIndex] as Partial<QueryField>),
-    dataObjFormatter: undefined,
     filters: [
       {
         type: 'between',
@@ -253,7 +252,6 @@ function getNewQueryLines(
     sortType: undefined,
     isDisplay: definedField.isDisplay,
     ...(fields[longitudeLineIndex] as Partial<QueryField>),
-    dataObjFormatter: undefined,
     filters:
       operator === 'between'
         ? [

--- a/specifyweb/frontend/js_src/lib/components/QueryBuilder/Line.tsx
+++ b/specifyweb/frontend/js_src/lib/components/QueryBuilder/Line.tsx
@@ -425,14 +425,17 @@ export function QueryLine({
                     )
                   : undefined;
 
-                const parser =
-                  (filter.fieldFormat === undefined ||
-                  terminatingField === undefined
+                const fieldFormatter =
+                  filter.fieldFormat === undefined
                     ? undefined
-                    : formatterToParser(
-                        terminatingField,
-                        getUiFormatters()[filter.fieldFormat]
-                      )) ?? fieldMeta.parser;
+                    : getUiFormatters()[filter.fieldFormat];
+
+                const parser =
+                  (terminatingField === undefined ||
+                  fieldFormatter === undefined
+                    ? undefined
+                    : formatterToParser(terminatingField, fieldFormatter)) ??
+                  fieldMeta.parser;
 
                 return (
                   <div

--- a/specifyweb/frontend/js_src/lib/components/QueryBuilder/Line.tsx
+++ b/specifyweb/frontend/js_src/lib/components/QueryBuilder/Line.tsx
@@ -2,7 +2,10 @@ import React from 'react';
 
 import { commonText } from '../../localization/common';
 import type { Parser } from '../../utils/parser/definitions';
-import { resolveParser } from '../../utils/parser/definitions';
+import {
+  formatterToParser,
+  resolveParser,
+} from '../../utils/parser/definitions';
 import type { RA } from '../../utils/types';
 import { filterArray } from '../../utils/types';
 import { replaceItem } from '../../utils/utils';
@@ -13,6 +16,7 @@ import { icons } from '../Atoms/Icons';
 import { schema } from '../DataModel/schema';
 import { genericTables, getTable } from '../DataModel/tables';
 import type { Tables } from '../DataModel/types';
+import { getUiFormatters } from '../FieldFormatters';
 import { join } from '../Molecules';
 import { TableIcon } from '../Molecules/TableIcon';
 import { customSelectElementBackground } from '../WbPlanView/CustomSelectElement';
@@ -45,7 +49,10 @@ import {
 import { FieldFilterTool } from './FieldFilterTool';
 import type { DatePart } from './fieldSpec';
 import { QueryFieldSpec } from './fieldSpec';
-import { QueryFieldFormatter } from './Formatter';
+import {
+  CatalogNumberFormatSelection,
+  QueryFieldRecordFormatter,
+} from './Formatter';
 import type { QueryField } from './helpers';
 import { QueryLineTools } from './QueryLineTools';
 
@@ -141,7 +148,7 @@ export function QueryLine({
         : getTable(tableName ?? '')?.getField(fieldName);
 
       let fieldType: QueryFieldType | undefined = undefined;
-      let parser = undefined;
+      let parser: Parser | undefined = undefined;
       const hasParser =
         typeof dataModelField === 'object' &&
         !dataModelField.isRelationship &&
@@ -377,23 +384,32 @@ export function QueryLine({
             )}
             {(fieldMeta.fieldType === 'formatter' ||
               fieldMeta.fieldType === 'aggregator') &&
-            typeof fieldMeta.tableName === 'string' ? (
-              <QueryFieldFormatter
-                formatter={field.dataObjFormatter}
+            typeof fieldMeta.tableName === 'string' &&
+            hasAny ? (
+              // REFACTOR: move this to the field.filters map
+              <QueryFieldRecordFormatter
+                formatter={
+                  field.filters.find(({ type }) => type === 'any')?.fieldFormat
+                }
                 tableName={fieldMeta.tableName}
                 type={fieldMeta.fieldType}
                 onChange={
                   handleChange === undefined
                     ? undefined
-                    : (dataObjectFormatter): void =>
-                        handleChange({
-                          ...field,
-                          dataObjFormatter: dataObjectFormatter,
-                        })
+                    : (dataObjectFormatter): void => {
+                        const filterIndex = field.filters.findIndex(
+                          ({ type }) => type === 'any'
+                        );
+                        handleFilterChange(filterIndex, {
+                          ...field.filters[filterIndex],
+                          fieldFormat: dataObjectFormatter,
+                        });
+                      }
                 }
               />
             ) : undefined}
           </div>
+
           {filtersVisible ? (
             <div
               className={
@@ -402,110 +418,147 @@ export function QueryLine({
                   : `flex items-center gap-2 ${isBasic ? '' : ' flex-wrap'}`
               }
             >
-              {field.filters.map((filter, index) => (
-                <div
-                  className={
-                    field.filters.length > 1
-                      ? 'flex flex-wrap gap-2'
-                      : 'contents'
-                  }
-                  key={index}
-                >
-                  <div className="flex contents items-center gap-2">
-                    <FieldFilterTool
-                      fieldFilters={field.filters}
-                      fieldName={field.mappingPath[0]}
-                      handleChange={handleChange}
-                      handleFilterChange={handleFilterChange}
-                      hasAny={hasAny}
-                      index={index}
-                      isBasic={isBasic}
-                      isFieldComplete={isFieldComplete}
-                    />
-                    <div className="contents w-full">
-                      <Select
-                        aria-label={
-                          queryFieldFilters[field.filters[index].type]
-                            .description ?? commonText.filter()
-                        }
-                        className={`
+              {field.filters.map((filter, index) => {
+                const terminatingField = isFieldComplete
+                  ? genericTables[baseTableName].getField(
+                      mappingPathToString(field.mappingPath)
+                    )
+                  : undefined;
+
+                const parser =
+                  (filter.fieldFormat === undefined ||
+                  terminatingField === undefined
+                    ? undefined
+                    : formatterToParser(
+                        terminatingField,
+                        getUiFormatters()[filter.fieldFormat]
+                      )) ?? fieldMeta.parser;
+
+                return (
+                  <div
+                    className={
+                      field.filters.length > 1
+                        ? 'flex flex-wrap gap-2'
+                        : 'contents'
+                    }
+                    key={index}
+                  >
+                    <div className="flex contents items-center gap-2">
+                      <FieldFilterTool
+                        fieldFilters={field.filters}
+                        fieldName={field.mappingPath[0]}
+                        handleChange={handleChange}
+                        handleFilterChange={handleFilterChange}
+                        hasAny={hasAny}
+                        index={index}
+                        isBasic={isBasic}
+                        isFieldComplete={isFieldComplete}
+                      />
+                      <div className="contents w-full">
+                        <Select
+                          aria-label={
+                            queryFieldFilters[filter.type].description ??
+                            commonText.filter()
+                          }
+                          className={`
                         !w-[unset] ${customSelectElementBackground}
                       `}
-                        disabled={handleChange === undefined}
-                        title={
-                          queryFieldFilters[field.filters[index].type]
-                            .description ?? commonText.filter()
-                        }
-                        value={filter.type}
-                        onChange={({ target }): void => {
-                          const newFilter = (target as HTMLSelectElement)
-                            .value as QueryFieldFilter;
-                          const startValue =
-                            queryFieldFilters[newFilter].component === undefined
-                              ? ''
-                              : filter.type === 'any' &&
-                                  filtersWithDefaultValue.has(newFilter) &&
-                                  filter.startValue === '' &&
-                                  typeof fieldMeta.parser?.value === 'string'
-                                ? fieldMeta.parser.value
-                                : filter.startValue;
+                          disabled={handleChange === undefined}
+                          title={
+                            queryFieldFilters[filter.type].description ??
+                            commonText.filter()
+                          }
+                          value={filter.type}
+                          onChange={({ target }): void => {
+                            const newFilter = (target as HTMLSelectElement)
+                              .value as QueryFieldFilter;
+                            const startValue =
+                              queryFieldFilters[newFilter].component ===
+                              undefined
+                                ? ''
+                                : filter.type === 'any' &&
+                                    filtersWithDefaultValue.has(newFilter) &&
+                                    filter.startValue === '' &&
+                                    typeof parser?.value === 'string'
+                                  ? parser.value
+                                  : filter.startValue;
 
-                          /*
-                           * When going from "in" to another filter type, throw away
-                           * all but first one or two values
-                           */
-                          const valueLength = newFilter === 'between' ? 2 : 1;
-                          const trimmedValue =
-                            filter.type === 'in'
-                              ? startValue
-                              : startValue
-                                  .split(',')
-                                  .slice(0, valueLength)
-                                  .join(', ');
+                            /*
+                             * When going from "in" to another filter type, throw away
+                             * all but first one or two values
+                             */
+                            const valueLength = newFilter === 'between' ? 2 : 1;
+                            const trimmedValue =
+                              filter.type === 'in'
+                                ? startValue
+                                : startValue
+                                    .split(',')
+                                    .slice(0, valueLength)
+                                    .join(', ');
 
-                          handleFilterChange?.(index, {
-                            ...field.filters[index],
-                            type: newFilter,
-                            startValue: trimmedValue,
-                          });
-                        }}
-                      >
-                        {availableFilters.map(([filterName, { label }]) => (
-                          <option key={filterName} value={filterName}>
-                            {label}
-                          </option>
-                        ))}
-                      </Select>
+                            handleFilterChange?.(index, {
+                              ...field.filters[index],
+                              type: newFilter,
+                              startValue: trimmedValue,
+                            });
+                          }}
+                        >
+                          {availableFilters.map(([filterName, { label }]) => (
+                            <option key={filterName} value={filterName}>
+                              {label}
+                            </option>
+                          ))}
+                        </Select>
+                      </div>
+                    </div>
+                    <div className="contents">
+                      {typeof parser === 'object' && (
+                        <QueryLineFilter
+                          enforceLengthLimit={enforceLengthLimit}
+                          fieldName={mappingPathToString(field.mappingPath)}
+                          filter={filter}
+                          parser={parser}
+                          terminatingField={terminatingField}
+                          onChange={
+                            typeof handleChange === 'function'
+                              ? (startValue): void =>
+                                  handleFilterChange(index, {
+                                    ...field.filters[index],
+                                    startValue,
+                                  })
+                              : undefined
+                          }
+                        />
+                      )}
+                      {/**
+                       * The CO catalogNumber format can be determined by the
+                       * Collection Object Type (COT) catalogNumberFormatName
+                       *
+                       * This format selection allows selecting which COT
+                       * field formatter is being used for this query filter
+                       */}
+                      {fieldMeta.tableName === 'CollectionObject' &&
+                      terminatingField?.name === 'catalogNumber' &&
+                      queryFieldFilters[filter.type].hasParser ? (
+                        <CatalogNumberFormatSelection
+                          formatter={filter.fieldFormat}
+                          onChange={
+                            handleChange === undefined
+                              ? undefined
+                              : (formatName): void => {
+                                  handleFilterChange(index, {
+                                    ...field.filters[index],
+                                    fieldFormat:
+                                      (formatName ?? '') || undefined,
+                                  });
+                                }
+                          }
+                        />
+                      ) : undefined}
                     </div>
                   </div>
-                  <div className="contents">
-                    {typeof fieldMeta.parser === 'object' && (
-                      <QueryLineFilter
-                        enforceLengthLimit={enforceLengthLimit}
-                        fieldName={mappingPathToString(field.mappingPath)}
-                        filter={field.filters[index]}
-                        parser={fieldMeta.parser}
-                        terminatingField={
-                          isFieldComplete
-                            ? genericTables[baseTableName].getField(
-                                mappingPathToString(field.mappingPath)
-                              )
-                            : undefined
-                        }
-                        onChange={
-                          typeof handleChange === 'function'
-                            ? (startValue): void =>
-                                handleFilterChange(index, {
-                                  ...field.filters[index],
-                                  startValue,
-                                })
-                            : undefined
-                        }
-                      />
-                    )}
-                  </div>
-                </div>
-              ))}
+                );
+              })}
             </div>
           ) : (
             <span className={`${isBasic ? 'col-span-1' : 'contents'}`} />

--- a/specifyweb/frontend/js_src/lib/components/QueryBuilder/QueryLineTools.tsx
+++ b/specifyweb/frontend/js_src/lib/components/QueryBuilder/QueryLineTools.tsx
@@ -81,7 +81,7 @@ export function QueryLineTools({
               : queryText.sort()
         }
         className={`
-         ${isFieldComplete ? undefined : 'invisible'} ${isBasic ? 'h-full' : ''}
+         ${isFieldComplete ? '' : 'invisible'} ${isBasic ? 'h-full' : ''}
         `}
         title={
           field.sortType === 'ascending'

--- a/specifyweb/frontend/js_src/lib/components/QueryBuilder/Wrapped.tsx
+++ b/specifyweb/frontend/js_src/lib/components/QueryBuilder/Wrapped.tsx
@@ -190,7 +190,6 @@ function Wrapped({
           id: Math.max(-1, ...state.fields.map(({ id }) => id)) + 1,
           mappingPath,
           sortType: undefined,
-          dataObjFormatter: undefined,
           filters: [
             {
               type: 'any',

--- a/specifyweb/frontend/js_src/lib/components/QueryBuilder/reducer.ts
+++ b/specifyweb/frontend/js_src/lib/components/QueryBuilder/reducer.ts
@@ -156,11 +156,6 @@ export const reducer = generateReducer<MainState, Actions>({
       fields: replaceItem(state.fields, line, {
         ...state.fields[line],
         mappingPath: newMappingPath,
-        dataObjFormatter:
-          mappingPathIsComplete(newMappingPath) &&
-          action.currentTableName === action.newTableName
-            ? undefined
-            : state.fields[line].dataObjFormatter,
       }),
       autoMapperSuggestions: undefined,
     };

--- a/specifyweb/frontend/js_src/lib/components/SpecifyNetwork/Map.tsx
+++ b/specifyweb/frontend/js_src/lib/components/SpecifyNetwork/Map.tsx
@@ -115,7 +115,6 @@ function getFields(query: SerializedResource<SpQuery>): RA<QueryField> {
           id: fields.length,
           mappingPath: ['collectingEvent', 'locality'],
           sortType: undefined,
-          dataObjFormatter: undefined,
           isDisplay: true,
           filters: [
             {

--- a/specifyweb/frontend/js_src/lib/components/SpecifyNetwork/__tests__/Map.test.tsx
+++ b/specifyweb/frontend/js_src/lib/components/SpecifyNetwork/__tests__/Map.test.tsx
@@ -68,7 +68,6 @@ test('getFields and extractQueryTaxonId', async () => {
   expect(addedFields).toMatchInlineSnapshot(`
     [
       {
-        "dataObjFormatter": undefined,
         "filters": [
           {
             "isNot": false,

--- a/specifyweb/frontend/js_src/lib/utils/parser/definitions.ts
+++ b/specifyweb/frontend/js_src/lib/utils/parser/definitions.ts
@@ -401,7 +401,10 @@ export function formatterToParser(
         value === undefined || value === null ? title : undefined,
     ],
     placeholder: formatter.pattern() ?? undefined,
-    type: field.type === undefined ? undefined : parserFromType(field.type as ExtendedJavaType).type,
+    type:
+      field.type === undefined
+        ? undefined
+        : parserFromType(field.type as ExtendedJavaType).type,
     parser: (value: unknown): string =>
       formatter.canonicalize(value as RA<string>),
     value: canAutoNumber ? formatter.valueOrWild() : undefined,

--- a/specifyweb/frontend/js_src/lib/utils/parser/definitions.ts
+++ b/specifyweb/frontend/js_src/lib/utils/parser/definitions.ts
@@ -401,6 +401,7 @@ export function formatterToParser(
         value === undefined || value === null ? title : undefined,
     ],
     placeholder: formatter.pattern() ?? undefined,
+    type: field.type === undefined ? undefined : parserFromType(field.type as ExtendedJavaType).type,
     parser: (value: unknown): string =>
       formatter.canonicalize(value as RA<string>),
     value: canAutoNumber ? formatter.valueOrWild() : undefined,

--- a/specifyweb/stored_queries/format.py
+++ b/specifyweb/stored_queries/format.py
@@ -125,8 +125,9 @@ class ObjectFormatter(object):
             result = lookup('name', aggregator_name)
         return result if result is not None else lookup_default('class', specify_model.classname)
 
-    def catalog_number_is_numeric(self):
-        return self.collection.catalognumformatname == 'CatalogNumberNumeric'
+    def catalog_number_is_numeric(self, raw_format_name: Optional[str] = None):
+        format_name = raw_format_name if raw_format_name else self.collection.catalognumformatname
+        return format_name == 'CatalogNumberNumeric'
 
     def pseudo_sprintf(self, format, expr):
         """Handle format attribute of fields in data object formatter definitions.
@@ -310,7 +311,7 @@ class ObjectFormatter(object):
                 pass
 
             else:
-                field = self._fieldformat(field_spec.get_field(), field)
+                field = self._fieldformat(field_spec.get_field(), field, query_field.format_name)
         return blank_nulls(field) if self.replace_nulls else field
 
     def _dateformat(self, specify_field, field):
@@ -328,7 +329,8 @@ class ObjectFormatter(object):
         return func.date_format(field, format_expr)
 
     def _fieldformat(self, specify_field: Field,
-                     field: Union[InstrumentedAttribute, Extract]):
+                     field: Union[InstrumentedAttribute, Extract], 
+                     format_name: Optional[str] = None):
         if specify_field.type == "java.lang.Boolean":
             return field != 0
 
@@ -336,7 +338,7 @@ class ObjectFormatter(object):
             return field
 
         if specify_field is CollectionObject_model.get_field('catalogNumber') \
-                and self.catalog_number_is_numeric():
+                and self.catalog_number_is_numeric(format_name):
             return cast(field,
                         types.Numeric(65))  # 65 is the mysql max precision
 

--- a/specifyweb/stored_queries/queryfieldspec.py
+++ b/specifyweb/stored_queries/queryfieldspec.py
@@ -69,40 +69,6 @@ def make_stringid(fs, table_list):
         field_name += 'Numeric' + fs.date_part
     return table_list, fs.table.name.lower(), field_name
 
-# class QueryFieldSpec(NamedTuple):
-#     root_table: 'Table'
-#     root_sql_table: 'SQLTable' # type: ignore
-#     join_path: Tuple['Field', ...]
-#     table: 'Table'
-#     date_part: Optional[str]
-#     tree_rank: Optional[str]
-#     tree_field: Optional[str]
-
-#     @classmethod
-#     def create(cls, root_table, root_sql_table, join_path, table, date_part=None, tree_rank=None, tree_field=None):
-#         # Create a new QueryFieldSpec instance
-#         instance = cls(
-#             root_table=root_table,
-#             root_sql_table=root_sql_table,
-#             join_path=join_path,
-#             table=table,
-#             date_part=date_part,
-#             tree_rank=tree_rank,
-#             tree_field=tree_field
-#         )
-#         # Validate the instance
-#         instance.validate()
-#         return instance
-
-#     def validate(self):
-#         valid_date_parts = ('Full Date', 'Day', 'Month', 'Year', None)
-#         assert self.is_temporal() or self.date_part is None
-#         if self.date_part not in valid_date_parts:
-#             raise AssertionError(
-#                 f"Invalid date part '{self.date_part}'. Expected one of {valid_date_parts}",
-#                 {"datePart": self.date_part,
-#                  "validDateParts": str(valid_date_parts),
-#                  "localizationKey": "invalidDatePart"})
 class QueryFieldSpec(namedtuple("QueryFieldSpec", "root_table root_sql_table join_path table date_part tree_rank tree_field")):
     @classmethod
     def from_path(cls, path_in, add_id=False):


### PR DESCRIPTION
Fixes #5474
Related to #5232

Allows the selection of Collection Object Type (COT) Catalog Number formats in the Query Builder!: 

<img width="1434" alt="Screenshot 2024-12-17 at 11 34 05 PM" src="https://github.com/user-attachments/assets/5b187c81-0272-448b-aa5a-0ac86fe0bdea" />

Known edge case: https://github.com/specify/specify7/issues/5487 and https://github.com/specify/specify7/issues/5488

### Checklist

- [x] Self-review the PR after opening it to make sure the changes look good and
      self-explanatory (or properly documented)
- [ ] Add automated tests
- [x] Add relevant issue to release milestone

### Testing instructions
- Create a CollectionObjectType with a Catalog Number Format Name which differs from that of the Collection's default Catalog Number format
  - You can run a query on the Collection table with the `Catalog Num Format Name` field to determine the  default format
-  Create a new Collection Object query, add Catalog Number to the query, and switch the type from `Any` to any of: 
   - Equal 
   - Greater than
   - Less than
   - Greater or Equal to
   - Less or Equal to
   - Between
   - In
   - (all other types-like Contains or Starts With- have validation disabled by default)
- [ ] Ensure that by default, the Collection's default Catalog Number format is enforced 
- Switch the Catalog Number format to the previously created Collection Object Type using the new gear icon and picklist 
- [ ] Ensure the input of the field is now validating based on the format defined on the chosen Collection Object Type
- Add one or more OR filters to the Catalog Number field (this can be done through the `+` button) with a type from the list above 
- [ ] Ensure each filter on the Catalog Number field with validation can independently have its own format
- [ ] Save the Query and refresh the page: the Query should load successfully
- [ ] Ensure the query returns correct results when using filters with multiple Catalog Number formats
  - You may need to create/modify Collection Object records with the desired Collection Object Type 
  - For reference see https://github.com/specify/specify7/pull/5431#issue-2716025555 
 
- If there is only one CollectionObjectType or all CollectionObjectTypes either don't specify a Catalog Number format or use the Collection's default, then the gear icon to select a formatter should not appear on Catalog Number
- `Collection Object -> Catalog Number` along with formatted/aggregated fields are the **_only_** filters which should have the gear icon to select a format
- [ ] Briefly generally test other functionality of the Query Builder, such as: running old queries, selecting a different record formatter (https://github.com/specify/specify7/pull/4615), Query From Tree Node, etc.
