### PR TITLE
Add Author to the disambiguation dialog

### DIFF
--- a/specifyweb/frontend/js_src/lib/components/WorkBench/Disambiguation.tsx
+++ b/specifyweb/frontend/js_src/lib/components/WorkBench/Disambiguation.tsx
@@ -99,6 +99,7 @@ function Row({
               .then((parent) =>
                 wbText.ambiguousTaxaChild({
                   node: resource.get('fullname'),
+                  author: resource.get('author'),
                   parent: parent.get('fullName'),
                 })
               )

--- a/specifyweb/frontend/js_src/lib/localization/workbench.ts
+++ b/specifyweb/frontend/js_src/lib/localization/workbench.ts
@@ -1577,11 +1577,11 @@ export const wbText = createDictionary({
     'de-ch': 'WB-Upload von „{dataSet:string}“',
   },
   ambiguousTaxaChild: {
-    'en-us': '{node:string} (in {parent:string})',
-    'ru-ru': '{node:string} (в {parent:string})',
-    'es-es': '{node:string} (en {parent:string})',
-    'de-ch': 'Datensatz erfolgreich gelöscht.',
-    'fr-fr': '{node:string} (dans {parent:string})',
-    'uk-ua': '{node:string} (у {parent:string})',
+    'en-us': '{node:string} {author:string} (in {parent:string})',
+    'ru-ru': '{node:string} {author:string} (в {parent:string})',
+    'es-es': '{node:string} {author:string} (en {parent:string})',
+    'de-ch': '{node:string} {author:string} (in {parent:string})',
+    'fr-fr': '{node:string} {author:string} (dans {parent:string})',
+    'uk-ua': '{node:string} {author:string} (у {parent:string})',
   },
 } as const);


### PR DESCRIPTION
Fixes #5212

<!--
> [!WARNING]  
> This PR affects database migrations. See [migration testing instructions](https://specify.github.io/testing/pull_requests.html#prs-tagged-with-label-migration).
-->

### Checklist

- [X] Self-review the PR after opening it to make sure the changes look good and
      self-explanatory (or properly documented)

### Testing instructions

* Create a duplicate node in the Taxon tree
* Add a unique author to each node
* Create a WorkBench Data Set
* Add the parent and child information for the duplicate node to trigger disambiguation
* Disambiguate the nodes and see that the author information is now present to help the user make a decision

<img width="915" alt="image" src="https://github.com/user-attachments/assets/b3d52942-8d08-43c5-b353-af3da40adbfb" />

