### PR TITLE
Avoid COJO verisioning error on COG form saving

### DIFF
--- a/specifyweb/specify/api.py
+++ b/specifyweb/specify/api.py
@@ -802,8 +802,8 @@ def update_obj(collection, agent, name: str, id, version, data: Dict[str, Any], 
     else:
         obj.modifiedbyagent = agent
 
-    bump_version(obj, version)
     _handle_special_update_priors(obj, data)
+    bump_version(obj, version)
     obj.save(force_update=True)
     auditlog.update(obj, agent, parent_obj, dirty)
     for dep in dependents_to_delete:
@@ -1071,6 +1071,8 @@ def _save_cojo_prior(obj):
     """
     if obj._meta.model_name in {'collectionobject', 'collectionobjectgroup'} and hasattr(obj, 'cojo'):
         obj.cojo.save()
+    elif obj._meta.model_name in {'collectionobjectgroupjoin'}:
+        obj.save()
 
 def _handle_special_save_priors(obj):
     """

--- a/specifyweb/specify/api.py
+++ b/specifyweb/specify/api.py
@@ -836,6 +836,8 @@ def bump_version(obj, version) -> None:
     manager = obj.__class__._base_manager
     updated = manager.filter(pk=obj.pk, version=version).update(version=version+1)
     if not updated:
+        if obj._meta.model_name in {'collectionobjectgroupjoin'}:
+            return # TODO: temporary solution to allow for multiple updates to the same cojo object
         raise StaleObjectException("%s object %d is out of date" % (obj.__class__.__name__, obj.id))
     obj.version = version + 1
 


### PR DESCRIPTION
Fixes #5471
Fixes #5481

Avoid the error "collectionobjectgroupjoin 54 is out of date" by adding if obj._meta.model_name == 'collectionobjectgroupjoin': obj.save() in the update_obj function.  This allows you to edit and save the cog form without error.  Still working on a better solution to fix all of the related issues.  Here is sample PUT request the was throwing the error 'http://localhost/api/specify/collectionobjectgroup/54/'.

Also, still need to in the future add front-end code that allows the save button to be clicked when a sub-field of a child collection object is edited, instead of also need to edit a direct cog field in order to press the save button.

### Checklist

- [x] Self-review the PR after opening it to make sure the changes look good and
      self-explanatory (or properly documented)
- [x] Add relevant issue to release milestone

### Testing instructions

- Go to CO form
- Add a COG
- Save
- Edit the COG (change name, add child, etc.)
- Save COG
- Make change to CO (ex. edit the 'Alt Cat Number')
- Save (Might need to make an edit to a COG field in order to get the save button to work)
- [ ] See that the form and been saved and updated correctly (might need to reload) 

- Go to COG form
- Add a CO child
- Save
- Edit the CO in the subview
- Make change to COG (ex. edit the 'Alt Cat Number') to trigger the save
- Save 
- [ ] See that the CO and been saved and updated correctly (might need to reload) 
