### PR TITLE
Add/Edit handling of 'one-to-one' relationship cases in resourceApi

### DIFF
--- a/specifyweb/frontend/js_src/lib/components/DataModel/resourceApi.ts
+++ b/specifyweb/frontend/js_src/lib/components/DataModel/resourceApi.ts
@@ -558,23 +558,20 @@ export const ResourceBase = Backbone.Model.extend({
       /*
        * Needed for taxonTreeDef on discipline because field.isVirtual equals false
        */
-      // case 'one-to-one': {
-      //   return value;
-      // }
       case 'one-to-one': {
         if (!value) {
           if (field.isDependent()) this.storeDependent(field, null);
           else this.storeIndependent(field, null);
           return value;
         }
-
-        const toOne = maybeMakeResource(value, relatedTable);
-        if (field.isDependent()) this.storeDependent(field, toOne);
-        else this.storeIndependent(field, toOne);
+  
+        const oneToOne = maybeMakeResource(value, relatedTable);
+        if (field.isDependent()) this.storeDependent(field, oneToOne);
+        else this.storeIndependent(field, oneToOne);
         this.trigger(`change:${fieldName}`, this);
         this.trigger('change', this);
-        return toOne.url();
-      } 
+        return oneToOne.url();
+      }
     }
     if (!field.isVirtual)
       softFail('Unhandled setting of relationship field', {

--- a/specifyweb/frontend/js_src/lib/components/DataModel/resourceApi.ts
+++ b/specifyweb/frontend/js_src/lib/components/DataModel/resourceApi.ts
@@ -215,6 +215,13 @@ export const ResourceBase = Backbone.Model.extend({
               );
               break;
             }
+            case 'one-to-one': {
+              newResource.set(
+                fieldName,
+                await related?.clone(cloneAll, isBulkCarry)
+              );
+              break;
+            }
             default: {
               throw new Error('unhandled relationship type');
             }


### PR DESCRIPTION
Fixes #5461

Mimic the functionality of 'many-to-one' relationship handling in the 'resourceApi.ts' file for the 'one-to-one' relationships.  This works since 'one-to-one' relationships are essentially the same as 'many-to-one' relationshps, just with a uniqueness constraint on the foreign key.

### Checklist

- [ ] Self-review the PR after opening it to make sure the changes look good and
      self-explanatory (or properly documented)
- [ ] Add relevant issue to release milestone

### Testing instructions

- [ ] Select a CO form and add a parentCog to it in the Cojo subform.
- [ ] Save the CO
- [ ] Press the Clone button (no errors occur)
- [ ] Save the new cloned CO
