### PR TITLE
Omit unknown tables and fields when reading uniqueness rules 

### DIFF
--- a/specifyweb/businessrules/uniqueness_rules.py
+++ b/specifyweb/businessrules/uniqueness_rules.py
@@ -135,8 +135,10 @@ def field_path_with_value(instance, model_name: str, field_path: str, default):
         if '__' in field_path or hasattr(object_or_field, 'id'):
             return None
 
-        table = datamodel.get_table_strict(model_name)
-        field = table.get_field_strict(field_path)
+        table = datamodel.get_table(model_name)
+        if table is None: return None
+        
+        field = table.get_field(field_path)
         field_required = field.required if field is not None else False
         if not field_required:
             return None
@@ -161,7 +163,8 @@ def apply_default_uniqueness_rules(discipline, registry=None):
 
     for table, rules in DEFAULT_UNIQUENESS_RULES.items():
         _discipline = discipline
-        model_name = datamodel.get_table_strict(table).django_name
+        model_name = getattr(datamodel.get_table(table), "django_name", None)
+        if model_name is None: continue
         for rule in rules:
             fields, scopes = rule["rule"]
             isDatabaseConstraint = rule["isDatabaseConstraint"]

--- a/specifyweb/frontend/js_src/lib/components/DataModel/uniquenessRules.ts
+++ b/specifyweb/frontend/js_src/lib/components/DataModel/uniquenessRules.ts
@@ -70,7 +70,9 @@ export const fetchContext = f
             table.name,
             rules
               ?.filter(({ rule }) =>
-                rule.fields.some((field) => table.getField(field) !== undefined)
+                rule.fields.every(
+                  (field) => table.getField(field) !== undefined
+                )
               )
               .map(({ rule }) => ({
                 rule,


### PR DESCRIPTION
Fixes #5451 

This fix is not backwards compatible, which means that all versions which don't include the fix (`v7.9.10`, `v7.9.6.2`, `v7.9.5`, ...) will still raise the error when there are tables or fields in uniqueness rules which don't exist in the datamodel. 

If needed, we can cherry-pick the commits on this branch to previous versions and retag to make this change available on previous versions. Users using the previous versions would also need to re-pull the changes to make them available on their instance. 

@specify/ux-testing 
Because of this, to facilitate testing this using the test panel, I have created a separate branch - `issue-5451-test` - which will run a migration on a database when switched to. 
The migration: 
- Creates a table called `Issue5451Test`
- Adds a relationship to CollectionObject called `issue5451`
- Creates four uniqueness rules: 
  -  `Issue5451Test -> name` must be unique in `CollectionObject -> collection`
  - `Issue5451Test -> name` must be unique in `CollectionObject`
  - `CollectionObject -> issue5451` must be unique in `Collection`
  - `CollectionObject -> text1 and issue5451` must be unique in `Collection


### Checklist

- [x] Self-review the PR after opening it to make sure the changes look good and
      self-explanatory (or properly documented)
- [ ] Add automated tests
- [x] Add relevant issue to release milestone

### Testing instructions
- [ ] 
