### PR TITLE
Add borders to subviews

### DIFF
--- a/specifyweb/frontend/js_src/lib/components/Atoms/DataEntry.tsx
+++ b/specifyweb/frontend/js_src/lib/components/Atoms/DataEntry.tsx
@@ -65,7 +65,7 @@ export const DataEntry = {
   >(
     'DataEntry.Grid',
     'div',
-    `items-center p-1 -ml-1 gap-2`,
+    `items-center p-1 gap-2`,
     ({
       viewDefinition,
       display,

--- a/specifyweb/frontend/js_src/lib/components/Atoms/DataEntry.tsx
+++ b/specifyweb/frontend/js_src/lib/components/Atoms/DataEntry.tsx
@@ -138,7 +138,7 @@ export const DataEntry = {
   SubFormHeader: wrap(
     'DataEntry.SubFormHeader',
     'legend',
-    'gap-2 flex font-bold border-b border-gray-500 pt-5 pb-1 items-center',
+    'gap-2 flex font-bold border-b border-gray-500 pt-3 pb-1 items-center',
     ({ children, ...props }) => ({
       // A hack for Safari. See https://github.com/specify/specify7/issues/1535
       children: <div {...props}>{children}</div>,

--- a/specifyweb/frontend/js_src/lib/components/Atoms/__tests__/__snapshots__/DataEntry.test.ts.snap
+++ b/specifyweb/frontend/js_src/lib/components/Atoms/__tests__/__snapshots__/DataEntry.test.ts.snap
@@ -231,7 +231,7 @@ exports[`DataEntry.SubFormHeader renders without errors 1`] = `
 <DocumentFragment>
   <legend>
     <div
-      class="gap-2 flex font-bold border-b border-gray-500 pt-5 pb-1 items-center"
+      class="gap-2 flex font-bold border-b border-gray-500 pt-3 pb-1 items-center"
     >
       Test
     </div>

--- a/specifyweb/frontend/js_src/lib/components/Atoms/__tests__/__snapshots__/DataEntry.test.ts.snap
+++ b/specifyweb/frontend/js_src/lib/components/Atoms/__tests__/__snapshots__/DataEntry.test.ts.snap
@@ -199,7 +199,7 @@ exports[`DataEntry.Footer renders without errors 1`] = `
 exports[`DataEntry.Grid renders without errors 1`] = `
 <DocumentFragment>
   <div
-    class="grid items-center p-1 -ml-1 gap-2"
+    class="grid items-center p-1 gap-2"
     style="grid-template-columns: 1fr 2fr 3fr auto;"
   >
     Test

--- a/specifyweb/frontend/js_src/lib/components/FormCells/FormTable.tsx
+++ b/specifyweb/frontend/js_src/lib/components/FormCells/FormTable.tsx
@@ -237,7 +237,11 @@ export function FormTable<SCHEMA extends AnySchema>({
       <p>{formsText.noData()}</p>
     ) : (
       <div
-        className={isCollapsed ? 'hidden' : 'overflow-x-auto border border-gray-500 border-t-0 rounded-b p-1'}
+        className={
+          isCollapsed
+            ? 'hidden'
+            : 'overflow-x-auto border border-gray-500 border-t-0 rounded-b p-1'
+        }
         onScroll={handleScroll}
       >
         <DataEntry.Grid

--- a/specifyweb/frontend/js_src/lib/components/FormCells/FormTable.tsx
+++ b/specifyweb/frontend/js_src/lib/components/FormCells/FormTable.tsx
@@ -237,7 +237,7 @@ export function FormTable<SCHEMA extends AnySchema>({
       <p>{formsText.noData()}</p>
     ) : (
       <div
-        className={isCollapsed ? 'hidden' : 'overflow-x-auto dark:border-gray-800 border border-t-0 rounded-bl rounded-br'}
+        className={isCollapsed ? 'hidden' : 'overflow-x-auto border border-gray-500 border-t-0 rounded-b p-0.5'}
         onScroll={handleScroll}
       >
         <DataEntry.Grid

--- a/specifyweb/frontend/js_src/lib/components/FormCells/FormTable.tsx
+++ b/specifyweb/frontend/js_src/lib/components/FormCells/FormTable.tsx
@@ -237,7 +237,7 @@ export function FormTable<SCHEMA extends AnySchema>({
       <p>{formsText.noData()}</p>
     ) : (
       <div
-        className={isCollapsed ? 'hidden' : 'overflow-x-auto'}
+        className={isCollapsed ? 'hidden' : 'overflow-x-auto border rounded-bl rounded-br'}
         onScroll={handleScroll}
       >
         <DataEntry.Grid

--- a/specifyweb/frontend/js_src/lib/components/FormCells/FormTable.tsx
+++ b/specifyweb/frontend/js_src/lib/components/FormCells/FormTable.tsx
@@ -237,7 +237,7 @@ export function FormTable<SCHEMA extends AnySchema>({
       <p>{formsText.noData()}</p>
     ) : (
       <div
-        className={isCollapsed ? 'hidden' : 'overflow-x-auto border rounded-bl rounded-br'}
+        className={isCollapsed ? 'hidden' : 'overflow-x-auto dark:border-gray-800 border border-t-0 rounded-bl rounded-br'}
         onScroll={handleScroll}
       >
         <DataEntry.Grid

--- a/specifyweb/frontend/js_src/lib/components/FormCells/FormTable.tsx
+++ b/specifyweb/frontend/js_src/lib/components/FormCells/FormTable.tsx
@@ -240,7 +240,7 @@ export function FormTable<SCHEMA extends AnySchema>({
         className={
           isCollapsed
             ? 'hidden'
-            : 'overflow-x-auto border border-gray-500 border-t-0 rounded-b p-1'
+            : 'overflow-x-auto border border-gray-500 border-t-0 rounded-b pl-1 pr-1 pb-1'
         }
         onScroll={handleScroll}
       >

--- a/specifyweb/frontend/js_src/lib/components/FormCells/FormTable.tsx
+++ b/specifyweb/frontend/js_src/lib/components/FormCells/FormTable.tsx
@@ -237,7 +237,7 @@ export function FormTable<SCHEMA extends AnySchema>({
       <p>{formsText.noData()}</p>
     ) : (
       <div
-        className={isCollapsed ? 'hidden' : 'overflow-x-auto border border-gray-500 border-t-0 rounded-b p-0.5'}
+        className={isCollapsed ? 'hidden' : 'overflow-x-auto border border-gray-500 border-t-0 rounded-b p-1'}
         onScroll={handleScroll}
       >
         <DataEntry.Grid

--- a/specifyweb/frontend/js_src/lib/components/Forms/ResourceView.tsx
+++ b/specifyweb/frontend/js_src/lib/components/Forms/ResourceView.tsx
@@ -322,7 +322,7 @@ export function ResourceView<SCHEMA extends AnySchema>({
               ? 'hidden'
               : hasNoData
                 ? ''
-                : 'border border-gray-500 border-t-0 rounded-b p-2'
+                : 'border border-gray-500 border-t-0 rounded-b p-1'
           }
         >
           {formattedChildren}

--- a/specifyweb/frontend/js_src/lib/components/Forms/ResourceView.tsx
+++ b/specifyweb/frontend/js_src/lib/components/Forms/ResourceView.tsx
@@ -315,7 +315,7 @@ export function ResourceView<SCHEMA extends AnySchema>({
           </DataEntry.SubFormTitle>
           {headerComponents}
         </DataEntry.SubFormHeader>
-        <div className={isCollapsed ? 'hidden' : (hasNoData ? '' : 'border rounded-bl rounded-br')}>
+        <div className={isCollapsed ? 'hidden' : (hasNoData ? '' : 'dark:border-gray-700 border border-t-0 rounded-bl rounded-br')}>
           {formattedChildren}
         </div>
       </DataEntry.SubForm>

--- a/specifyweb/frontend/js_src/lib/components/Forms/ResourceView.tsx
+++ b/specifyweb/frontend/js_src/lib/components/Forms/ResourceView.tsx
@@ -264,7 +264,8 @@ export function ResourceView<SCHEMA extends AnySchema>({
       </ErrorBoundary>
     ) : undefined;
 
-  const hasNoData = !resource || (Array.isArray(resource) && resource.length === 0);
+  const hasNoData =
+    !resource || (Array.isArray(resource) && resource.length === 0);
 
   const headerContent = (
     <>
@@ -315,7 +316,15 @@ export function ResourceView<SCHEMA extends AnySchema>({
           </DataEntry.SubFormTitle>
           {headerComponents}
         </DataEntry.SubFormHeader>
-        <div className={isCollapsed ? 'hidden' : (hasNoData ? '' : 'dark:border-gray-700 border border-t-0 rounded-bl rounded-br')}>
+        <div
+          className={
+            isCollapsed
+              ? 'hidden'
+              : hasNoData
+                ? ''
+                : 'dark:border-gray-700 border border-t-0 rounded-bl rounded-br'
+          }
+        >
           {formattedChildren}
         </div>
       </DataEntry.SubForm>

--- a/specifyweb/frontend/js_src/lib/components/Forms/ResourceView.tsx
+++ b/specifyweb/frontend/js_src/lib/components/Forms/ResourceView.tsx
@@ -264,6 +264,8 @@ export function ResourceView<SCHEMA extends AnySchema>({
       </ErrorBoundary>
     ) : undefined;
 
+  const hasNoData = !resource || (Array.isArray(resource) && resource.length === 0);
+
   const headerContent = (
     <>
       {specifyNetworkBadge}
@@ -313,7 +315,9 @@ export function ResourceView<SCHEMA extends AnySchema>({
           </DataEntry.SubFormTitle>
           {headerComponents}
         </DataEntry.SubFormHeader>
-        <div className={isCollapsed ? 'hidden' : ''}>{formattedChildren}</div>
+        <div className={isCollapsed ? 'hidden' : (hasNoData ? '' : 'border rounded-bl rounded-br')}>
+          {formattedChildren}
+        </div>
       </DataEntry.SubForm>
     ) : (
       <Container.FullGray>

--- a/specifyweb/frontend/js_src/lib/components/Forms/ResourceView.tsx
+++ b/specifyweb/frontend/js_src/lib/components/Forms/ResourceView.tsx
@@ -322,7 +322,7 @@ export function ResourceView<SCHEMA extends AnySchema>({
               ? 'hidden'
               : hasNoData
                 ? ''
-                : 'dark:border-gray-700 border border-t-0 rounded-bl rounded-br'
+                : 'border border-gray-500 border-t-0 rounded-b p-2'
           }
         >
           {formattedChildren}


### PR DESCRIPTION
Fixes #6030

This has long bothered me and others, but it only took a few minutes to add a fix. Please let me know your thoughts and if you feel this should be a preference, but I am leaning towards it being the default as to remove the common confusion described in the aforementioned issue.

**Before:**
<img width="2032" alt="image" src="https://github.com/user-attachments/assets/e1341467-6b49-4bb3-b981-ce7b593b1d8c" />

**After:**
<img width="2032" alt="image" src="https://github.com/user-attachments/assets/1a7ac243-0119-406a-b46f-7864fa52ef6e" />
### Checklist

- [X] Self-review the PR after opening it to make sure the changes look good and
      self-explanatory (or properly documented)

### Testing instructions

This PR adds borders to children of subviews. These borders should only display when:
1. The subview item has data ("No Data" should not have a border)
2. The subview item is not collapsed
3. The subform displays under a header (independent forms without an immediate subview heading should not have a border)

The border should appear whenever a subview has a child (either in a grid or form).

If you have suggestions about visibility or prominence, please let me know. I aimed to keep it subtle to avoid bothering users who are familiar with the system, while still making it visible enough for those learning or reviewing it to use as a guide.