### PR TITLE
Pass is_strict in op_age_period to search_co_ids_in_time_period

### DIFF
--- a/specifyweb/stored_queries/query_ops.py
+++ b/specifyweb/stored_queries/query_ops.py
@@ -138,4 +138,4 @@ class QueryOps(namedtuple("QueryOps", "uiformatter")):
 
     def op_age_period(self, field, value, query, is_strict=False):
         time_period_name = value
-        return field.in_(search_co_ids_in_time_period(time_period_name, require_full_overlap=False))
+        return field.in_(search_co_ids_in_time_period(time_period_name, require_full_overlap=is_strict))


### PR DESCRIPTION
Fixes #6017

Fix the bug involving the extend age period queries where the strict mode was not working correctly.  Simple fix by passing is_strict in op_age_period function to the search_co_ids_in_time_period function.  This was accidentally omitted during testing in the original PR.

### Checklist

- [x] Self-review the PR after opening it to make sure the changes look good and
      self-explanatory (or properly documented)
- [x] Add relevant issue to release milestone

### Testing instructions

- Use the calvertmarinemuseum_2024_11_14 on the test panel
- Go to the saved query named "Cretaceous Query", also should be at https://calvertmarinemuseum20241114-production.test.specifysystems.org/specify/query/19/
- See that the extend age query field is set to "non-strict mode", and the period name is "Cretaceous"
- Press the "Count" button to run the count query and mark down the resulting number.
- Set the age query field to "strict mode"
- Again, Press the "Count" button to run the count query and mark down the resulting number.
- [x] See that the count from this last query is either zero or any number less than the count from the previous query.
