### PR TITLE
Add Tectonic Unit paleoContexts relationship to the datamodel

### DIFF
--- a/specifyweb/frontend/js_src/lib/components/DataModel/types.ts
+++ b/specifyweb/frontend/js_src/lib/components/DataModel/types.ts
@@ -6809,5 +6809,8 @@ export type TectonicUnit = {
     readonly parent: TectonicUnit;
   };
   readonly toManyDependent: RR<never, never>;
-  readonly toManyIndependent: { readonly acceptedChildren: RA<TectonicUnit> };
+  readonly toManyIndependent: {
+    readonly acceptedChildren: RA<TectonicUnit>;
+    readonly paleoContexts: RA<PaleoContext>;
+  };
 };

--- a/specifyweb/frontend/js_src/lib/components/QueryComboBox/index.tsx
+++ b/specifyweb/frontend/js_src/lib/components/QueryComboBox/index.tsx
@@ -489,7 +489,7 @@ export function QueryComboBox({
                 }
               />
             )}
-            {hasSearchButton && (
+            {hasSearchButton && !field.isDependent() && (
               <DataEntry.Search
                 aria-pressed={state.type === 'SearchState'}
                 onClick={

--- a/specifyweb/specify/datamodel.py
+++ b/specifyweb/specify/datamodel.py
@@ -8701,6 +8701,7 @@ datamodel = Datamodel(tables=[
             Relationship(name='parent', type='many-to-one', required=True, relatedModelName='TectonicUnit', column='ParentID'),
             Relationship(name='definition', type='many-to-one', required=True, relatedModelName='TectonicUnitTreeDef', column='TectonicUnitTreeDefID', otherSideName='treeEntries'),
             Relationship(name='definitionItem', type='many-to-one', required=True, relatedModelName='TectonicUnitTreeDefItem', column='TectonicUnitTreeDefItemID', otherSideName='treeEntries'),
+            Relationship(name='paleoContexts', type='one-to-many',required=False, relatedModelName='PaleoContext', otherSideName='tectonicUnit'),
         ],
         fieldAliases=[
             {'vname':'acceptedParent', 'aname':'acceptedTectonicUnit'}


### PR DESCRIPTION
Fixes #6042

This PR does not address the true underlying cause: that it's easy to miss such a relationship in the datamodel to begin with!
A more ideal solution to make sure this problem doesn't happen again is to write a backend test to verify the integrity of the datamodel. 
Alternatively, we can remove the separate datamodel file entirely, and only use the Django models and fields, adding any necessary attributes to the fields as need (and implementing a way to enforce integrity for those attributes).  

While investigating the Issue, I also uncovered another bug which may be relavent for testing: #6058

### Checklist

- [x] Self-review the PR after opening it to make sure the changes look good and
      self-explanatory (or properly documented)
- [ ] Add automated tests
- [x] Add relevant issue to release milestone
- [ ] Add relevant documentation (Tester - Dev) 

### Testing instructions
- In a database which has a paleo/geo discipline (such as `ciscocollections` from https://github.com/specify/specify7/issues/6042#issue-2773689353), switch to a Collection in a Geo/Paleo discipline
- If not present already, add TectonicUnit to the PaleoContext form (either as Subview or Query Combo Box) 
- Navigate to the Data Entry form for a table which has a relationship to PaleoContext ([paleo_context_schema](https://files.specifysoftware.org/schema/version/2.10/#paleocontext) and TectonicUnit) 
- [ ] Add a new or edit an existing PaleoContext which has a related TectonicUnit
  - No error should occur
- [ ] On the Tectonic Unit form, display the `paleoContexts` relationship as a Subview and ensure that PaleoContexts can be added, removed, and edited
