### PR TITLE
Add tectonic unit to paleo context in schema config

### DIFF
--- a/specifyweb/specify/migration_utils/sp7_schemaconfig.py
+++ b/specifyweb/specify/migration_utils/sp7_schemaconfig.py
@@ -72,3 +72,7 @@ MIGRATION_0012_FIELDS = {
 MIGRATION_0013_FIELDS = {
     'CollectionObjectGroup': ['parentCog']
 }
+
+MIGRATION_0020_FIELDS = {
+    'PaleoContext': ['tectonicUnit'],
+}

--- a/specifyweb/specify/migrations/0019_remove_parentCog.py
+++ b/specifyweb/specify/migrations/0019_remove_parentCog.py
@@ -10,8 +10,8 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
-        migrations.RemoveField(
-            model_name='collectionobjectgroup',
-            name='parentcog',
-        ),
+        # migrations.RemoveField(
+        #     model_name='collectionobjectgroup',
+        #     name='parentcog',
+        # ),
     ]

--- a/specifyweb/specify/migrations/0020_add_tectonicunit_to_pc_in_schema_config.py
+++ b/specifyweb/specify/migrations/0020_add_tectonicunit_to_pc_in_schema_config.py
@@ -1,0 +1,38 @@
+"""
+This migration adds Tectonic Unit -> Paleo Context in the Schema Config.
+"""
+from django.db import migrations
+from specifyweb.specify.migration_utils.update_schema_config import revert_table_field_schema_config, update_table_field_schema_config_with_defaults
+from specifyweb.specify.migration_utils.sp7_schemaconfig import MIGRATION_0020_FIELDS as SCHEMA_CONFIG_MOD_TABLE_FIELDS
+
+
+def add_tectonicunit_to_pc_in_schema_config(apps):
+    Discipline = apps.get_model('specify', 'Discipline')
+    for discipline in Discipline.objects.all():
+        for table, fields in SCHEMA_CONFIG_MOD_TABLE_FIELDS.items():
+            for field in fields:
+                update_table_field_schema_config_with_defaults(
+                    table, discipline.id, field, apps)
+
+
+def remove_tectonicunit_from_pc_schema_config(apps):
+    for table, fields in SCHEMA_CONFIG_MOD_TABLE_FIELDS.items():
+        for field in fields:
+            revert_table_field_schema_config(table, field, apps)
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('specify', '0019_remove_parentCog'),
+    ]
+
+    def apply_migration(apps, schema_editor):
+        add_tectonicunit_to_pc_in_schema_config(apps)
+
+    def revert_migration(apps, schema_editor):
+        remove_tectonicunit_from_pc_schema_config(apps)
+
+    operations = [
+        migrations.RunPython(apply_migration, revert_migration, atomic=True),
+    ]


### PR DESCRIPTION
Fixes #6069 


> [!WARNING]  
> This PR affects database migrations. See [migration testing instructions](https://specify.github.io/testing/pull_requests.html#prs-tagged-with-label-migration).


### Checklist

- [ ] Self-review the PR after opening it to make sure the changes look good and
      self-explanatory (or properly documented)
- [ ] Add relevant issue to release milestone
- [ ] Add relevant documentation (Tester - Dev) 

### Testing instructions

- Go to any database
- Go to Schema Config
- Select paleocontext from the schema config tables list
- [ ] Verify that tectonicUnit is in the relationships 
