### PR TITLE
Always update to-one relationships when using QueryCBX and PickLists of Entire Table

### DIFF
--- a/specifyweb/frontend/js_src/lib/components/DataModel/__tests__/businessRules.test.ts
+++ b/specifyweb/frontend/js_src/lib/components/DataModel/__tests__/businessRules.test.ts
@@ -11,12 +11,7 @@ import { getResourceApiUrl } from '../resource';
 import { useSaveBlockers } from '../saveBlockers';
 import { schema } from '../schema';
 import { tables } from '../tables';
-import type {
-  CollectionObjectType,
-  Determination,
-  Taxon,
-  TaxonTreeDefItem,
-} from '../types';
+import type { CollectionObjectType, Taxon, TaxonTreeDefItem } from '../types';
 
 mockTime();
 requireContext();
@@ -92,7 +87,7 @@ describe('Collection Object business rules', () => {
           taxon: getResourceApiUrl('Taxon', otherTaxonId),
           preferredTaxon: getResourceApiUrl('Taxon', otherTaxonId),
           isCurrent: true,
-        } as SerializedResource<Determination>,
+        },
       ],
       resource_uri: collectionObjectUrl,
       description: 'Base collection object',

--- a/specifyweb/frontend/js_src/lib/components/DataModel/__tests__/resourceApi.test.ts
+++ b/specifyweb/frontend/js_src/lib/components/DataModel/__tests__/resourceApi.test.ts
@@ -1,12 +1,16 @@
 import { overrideAjax } from '../../../tests/ajax';
 import { requireContext } from '../../../tests/helpers';
-import type { RA } from '../../../utils/types';
+import type { RA, WritableArray } from '../../../utils/types';
 import { removeKey, replaceItem } from '../../../utils/utils';
+import { formatUrl } from '../../Router/queryString';
 import { addMissingFields } from '../addMissingFields';
-import type { SerializedRecord } from '../helperTypes';
+import { DependentCollection } from '../collectionApi';
+import type { SerializedRecord, SerializedResource } from '../helperTypes';
 import { getResourceApiUrl } from '../resource';
+import { deserializeResource, serializeResource } from '../serializers';
+import type { Collection } from '../specifyTable';
 import { tables } from '../tables';
-import type { Determination } from '../types';
+import type { CollectionObjectAttribute, Determination } from '../types';
 
 requireContext();
 
@@ -392,6 +396,344 @@ test('save', async () => {
   const newDetermination =
     resource.getDependentResource('determinations')!.models[0];
   expect(newDetermination.get('number1')).toBe(2);
+});
+
+describe('set', () => {
+  test('field value', () => {
+    const resource = new tables.CollectionObject.Resource();
+    const testIntegerValue = 10;
+    expect(resource.get('integer1')).toBeUndefined();
+    resource.set('integer1', testIntegerValue);
+    expect(resource.get('integer1')).toBe(testIntegerValue);
+    resource.set('integer1', undefined as never);
+    expect(resource.get('integer1')).toBe(testIntegerValue);
+    resource.set('integer1', null);
+    expect(resource.get('integer1')).toBeNull();
+  });
+  test('array dependent to-many', () => {
+    const resource = new tables.CollectionObject.Resource();
+    const determinations = [
+      new tables.Determination.Resource({ isCurrent: true }),
+      new tables.Determination.Resource(),
+    ];
+    resource.set('determinations', determinations);
+    const determinationCollection =
+      resource.getDependentResource('determinations');
+    expect(resource.get('determinations')).toBeUndefined();
+    expect(determinationCollection).toBeInstanceOf(DependentCollection);
+    expect(determinationCollection?.length).toBe(2);
+    expect(determinationCollection?.related).toBe(resource);
+    expect(resource.dependentResources.determinations).toBe(
+      determinationCollection
+    );
+  });
+  test('collection dependent to-many', () => {
+    const resource = new tables.CollectionObject.Resource();
+    const determinations = [
+      new tables.Determination.Resource({ isCurrent: true }),
+      new tables.Determination.Resource(),
+    ];
+    const initialDeterminationCollection =
+      new tables.Determination.DependentCollection(
+        {
+          related: resource,
+          field: tables.Determination.strictGetRelationship('collectionObject'),
+        },
+        determinations
+      ) as Collection<Determination>;
+    resource.set('determinations', initialDeterminationCollection);
+    const determinationCollection =
+      resource.getDependentResource('determinations');
+    expect(resource.get('determinations')).toBeUndefined();
+    expect(determinationCollection?.length).toBe(2);
+    expect(determinationCollection?.related).toBe(resource);
+    expect(resource.dependentResources.determinations).toBe(
+      determinationCollection
+    );
+    expect(initialDeterminationCollection).not.toBe(determinationCollection);
+  });
+  test('url dependent to-many', () => {
+    const expectedWarnings = [
+      'expected inline data for dependent field',
+      'Setting uri on to-many relationship',
+    ];
+    const warnings: WritableArray<unknown> = [];
+    const consoleWarn = jest.fn((...args) => warnings.push(args[0]));
+    jest.spyOn(console, 'warn').mockImplementation(consoleWarn);
+
+    const resource = new tables.CollectionObject.Resource({
+      id: 1,
+      determinations: [
+        {
+          _tablename: 'Determination',
+          iscurrent: true,
+        },
+        { _tablename: 'Determination' },
+      ],
+    });
+    const determinationCollection =
+      resource.getDependentResource('determinations');
+    expect(determinationCollection).toHaveLength(2);
+    resource.set(
+      'determinations',
+      formatUrl(getResourceApiUrl('Determination', undefined), {
+        collectionobject: resource.id,
+      }) as never
+    );
+    expect(warnings).toStrictEqual(expectedWarnings);
+    expect(resource.get('determinations')).toBe(
+      formatUrl(getResourceApiUrl('Determination', undefined), {
+        collectionobject: resource.id,
+      })
+    );
+    expect(resource.getDependentResource('determinations')).toBe(
+      determinationCollection
+    );
+    expect(resource.dependentResources.determinations).toBe(
+      determinationCollection
+    );
+  });
+  test('undefined dependent to-many', () => {
+    const expectedWarnings = [
+      'Expected array of resources or collection when setting one-to-many',
+    ];
+    const warnings: WritableArray<unknown> = [];
+    const consoleWarn = jest.fn((...args) => warnings.push(args[0]));
+    jest.spyOn(console, 'warn').mockImplementation(consoleWarn);
+    const resource = new tables.CollectionObject.Resource({
+      id: 1,
+      determinations: [
+        {
+          _tablename: 'Determination',
+          iscurrent: true,
+        },
+        { _tablename: 'Determination' },
+      ],
+    });
+    const determinationCollection =
+      resource.getDependentResource('determinations');
+    resource.set('determinations', undefined as never);
+    expect(warnings).toStrictEqual(expectedWarnings);
+    expect(resource.get('determinations')).toBeUndefined();
+    expect(resource.getDependentResource('determinations')).toBe(
+      determinationCollection
+    );
+    expect(resource.dependentResources.determinations).toBe(
+      determinationCollection
+    );
+  });
+  test('null dependent to-many', () => {
+    const expectedWarnings = [
+      'Expected array of resources or collection when setting one-to-many',
+    ];
+    const warnings: WritableArray<unknown> = [];
+    const consoleWarn = jest.fn((...args) => warnings.push(args[0]));
+    jest.spyOn(console, 'warn').mockImplementation(consoleWarn);
+    const resource = new tables.CollectionObject.Resource({
+      id: 1,
+      determinations: [
+        {
+          _tablename: 'Determination',
+          iscurrent: true,
+        },
+        { _tablename: 'Determination' },
+      ],
+    });
+    const determinationCollection =
+      resource.getDependentResource('determinations');
+    resource.set('determinations', null as never);
+    expect(warnings).toStrictEqual(expectedWarnings);
+    expect(resource.get('determinations')).toBeUndefined();
+    expect(resource.getDependentResource('determinations')).toBe(
+      determinationCollection
+    );
+    expect(resource.dependentResources.determinations).toBe(
+      determinationCollection
+    );
+  });
+  test('specifyResource dependent to-one', () => {
+    const resource = new tables.CollectionObject.Resource();
+    const collectionObjectAttributeId = 1;
+    const collectionObjectAttribute =
+      new tables.CollectionObjectAttribute.Resource({
+        id: collectionObjectAttributeId,
+        text1: 'test',
+        integer1: 10,
+      });
+    resource.set('collectionObjectAttribute', collectionObjectAttribute);
+    expect(resource.dependentResources.collectionobjectattribute).toBe(
+      collectionObjectAttribute
+    );
+    expect(resource.getDependentResource('collectionObjectAttribute')).toBe(
+      collectionObjectAttribute
+    );
+    expect(resource.get('collectionObjectAttribute')).toBe(
+      getResourceApiUrl(
+        'CollectionObjectAttribute',
+        collectionObjectAttributeId
+      )
+    );
+  });
+  test('seralizedResource dependent to-one', () => {
+    const resource = new tables.CollectionObject.Resource({
+      id: 1,
+    });
+    const collectionObjectAttributeId = 1;
+    const seralizedCOAttribute: Partial<
+      SerializedResource<CollectionObjectAttribute>
+    > = {
+      _tableName: 'CollectionObjectAttribute',
+      id: collectionObjectAttributeId,
+      text1: 'test',
+      integer1: 10,
+    };
+    resource.set(
+      'collectionObjectAttribute',
+      seralizedCOAttribute as SerializedResource<CollectionObjectAttribute>
+    );
+    const collectionObjectAttribute = resource.getDependentResource(
+      'collectionObjectAttribute'
+    );
+    expect(resource.dependentResources.collectionobjectattribute).toBe(
+      collectionObjectAttribute
+    );
+    expect(serializeResource(collectionObjectAttribute!)).toStrictEqual(
+      serializeResource(deserializeResource(seralizedCOAttribute))
+    );
+    expect(resource.get('collectionObjectAttribute')).toBe(
+      getResourceApiUrl(
+        'CollectionObjectAttribute',
+        collectionObjectAttributeId
+      )
+    );
+  });
+  test('uri dependent to-one', () => {
+    const expectedWarnings = ['expected inline data for dependent field'];
+    const warnings: WritableArray<unknown> = [];
+    const consoleWarn = jest.fn((...args) => warnings.push(args[0]));
+    jest.spyOn(console, 'warn').mockImplementation(consoleWarn);
+    const resource = new tables.CollectionObject.Resource();
+    const collectionObjectAttributeId = 1;
+    resource.set(
+      'collectionObjectAttribute',
+      getResourceApiUrl(
+        'CollectionObjectAttribute',
+        collectionObjectAttributeId
+      ) as never
+    );
+    expect(warnings).toStrictEqual(expectedWarnings);
+    expect(resource.get('collectionObjectAttribute')).toBe(
+      getResourceApiUrl(
+        'CollectionObjectAttribute',
+        collectionObjectAttributeId
+      )
+    );
+    expect(
+      resource.dependentResources.collectionobjectattribute
+    ).toBeUndefined();
+  });
+  test('uri unsets dependent to-one references', () => {
+    const expectedWarnings = [
+      'expected inline data for dependent field',
+      'unexpected condition',
+    ];
+    const warnings: WritableArray<unknown> = [];
+    const consoleWarn = jest.fn((...args) => warnings.push(args[0]));
+    jest.spyOn(console, 'warn').mockImplementation(consoleWarn);
+
+    const collectionObjectAttributeId = 1;
+    const seralizedCOAttribute = {
+      id: collectionObjectAttributeId,
+      text1: 'test',
+    };
+    const resource = new tables.CollectionObject.Resource({
+      id: 1,
+      collectionObjectAttribute: seralizedCOAttribute as never,
+    });
+    const coAttribute = resource.getDependentResource(
+      'collectionObjectAttribute'
+    );
+    expect(coAttribute).toBeDefined();
+    expect(resource.dependentResources.collectionobjectattribute).toBe(
+      coAttribute
+    );
+    expect(resource.get('collectionObjectAttribute')).toBe(
+      getResourceApiUrl(
+        'CollectionObjectAttribute',
+        collectionObjectAttributeId
+      )
+    );
+    resource.set(
+      'collectionObjectAttribute',
+      getResourceApiUrl(
+        'CollectionObjectAttribute',
+        collectionObjectAttributeId + 1
+      ) as never
+    );
+    expect(warnings).toStrictEqual(expectedWarnings);
+    expect(resource.get('collectionObjectAttribute')).toBe(
+      getResourceApiUrl(
+        'CollectionObjectAttribute',
+        collectionObjectAttributeId + 1
+      )
+    );
+    expect(
+      resource.getDependentResource('collectionObjectAttribute')
+    ).toBeUndefined();
+    expect(
+      resource.dependentResources.collectionobjectattribute
+    ).toBeUndefined();
+  });
+  test('null dependent to-one', () => {
+    const collectionObjectAttributeId = 1;
+    const seralizedCOAttribute = {
+      id: collectionObjectAttributeId,
+      text1: 'test',
+    };
+    const resource = new tables.CollectionObject.Resource({
+      id: 1,
+      collectionObjectAttribute: seralizedCOAttribute as never,
+    });
+    resource.set('collectionObjectAttribute', null);
+    expect(resource.get('collectionObjectAttribute')).toBeNull();
+    expect(
+      resource.getDependentResource('collectionObjectAttribute')
+    ).toBeNull();
+    expect(resource.dependentResources.collectionobjectattribute).toBeNull();
+  });
+  test('url with independendent to-one', () => {
+    const baseId = 1;
+    const resource = new tables.CollectionObject.Resource({ id: baseId });
+    const accession = new tables.Accession.Resource({ id: baseId });
+    resource.set('accession', accession);
+    expect(resource.get('accession')).toBe(
+      getResourceApiUrl('Accession', baseId)
+    );
+    expect(resource.independentResources.accession).toBe(accession);
+    resource.set('accession', getResourceApiUrl('Accession', baseId));
+    expect(resource.get('accession')).toBe(
+      getResourceApiUrl('Accession', baseId)
+    );
+    expect(resource.independentResources.accession).toBe(accession);
+    resource.set('accession', getResourceApiUrl('Accession', baseId + 1));
+    expect(resource.get('accession')).toBe(
+      getResourceApiUrl('Accession', baseId + 1)
+    );
+    expect(resource.independentResources.accession).toBe(undefined);
+  });
+  test('null independent to-one', () => {
+    const baseId = 1;
+    const resource = new tables.CollectionObject.Resource({ id: baseId });
+    const accession = new tables.Accession.Resource({ id: baseId });
+    resource.set('accession', accession);
+    expect(resource.get('accession')).toBe(
+      getResourceApiUrl('Accession', baseId)
+    );
+    expect(resource.independentResources.accession).toBeDefined();
+    resource.set('accession', null);
+    expect(resource.get('accession')).toBeNull();
+    expect(resource.independentResources.accession).toBeNull();
+  });
 });
 
 /*

--- a/specifyweb/frontend/js_src/lib/components/DataModel/__tests__/resourceApi.test.ts
+++ b/specifyweb/frontend/js_src/lib/components/DataModel/__tests__/resourceApi.test.ts
@@ -719,7 +719,7 @@ describe('set', () => {
     expect(resource.get('accession')).toBe(
       getResourceApiUrl('Accession', baseId + 1)
     );
-    expect(resource.independentResources.accession).toBe(undefined);
+    expect(resource.independentResources.accession).toBeUndefined();
   });
   test('null independent to-one', () => {
     const baseId = 1;

--- a/specifyweb/frontend/js_src/lib/components/DataModel/collectionApi.ts
+++ b/specifyweb/frontend/js_src/lib/components/DataModel/collectionApi.ts
@@ -4,6 +4,7 @@ import _ from 'underscore';
 
 import { removeKey } from '../../utils/utils';
 import { assert } from '../Errors/assert';
+import { softFail } from '../Errors/Crash';
 import { relationshipIsToMany } from '../WbPlanView/mappingHelpers';
 import { Backbone } from './backbone';
 import { DEFAULT_FETCH_LIMIT } from './collection';
@@ -83,7 +84,13 @@ export const DependentCollection = Base.extend({
   __name__: 'DependentCollectionBase',
   constructor(options, records = []) {
     this.table = this.model;
-    assert(_.isArray(records));
+    if (!Array.isArray(records))
+      softFail(
+        new Error(
+          'Expected array of records when creating DependentCollection'
+        ),
+        { table: this.table.name, records }
+      );
     Base.call(this, records, options);
   },
   initialize(_tables, options) {

--- a/specifyweb/frontend/js_src/lib/components/DataModel/specifyTable.ts
+++ b/specifyweb/frontend/js_src/lib/components/DataModel/specifyTable.ts
@@ -7,7 +7,7 @@ import type { LocalizedString } from 'typesafe-i18n';
 import { commonText } from '../../localization/common';
 import { getCache } from '../../utils/cache';
 import { f } from '../../utils/functools';
-import type { IR, R, RA } from '../../utils/types';
+import type { DeepPartial, IR, R, RA } from '../../utils/types';
 import { defined, filterArray, localized } from '../../utils/types';
 import { camelToHuman, multiSortFunction } from '../../utils/utils';
 import { error } from '../Errors/assert';
@@ -166,7 +166,7 @@ export class SpecifyTable<SCHEMA extends AnySchema = AnySchema> {
    * https://github.com/microsoft/TypeScript/issues/48339
    */
   public readonly Resource: new <RESOURCE extends AnySchema = SCHEMA>(
-    props?: Partial<
+    props?: DeepPartial<
       | SerializedResource<RESOURCE>
       | SerializedRecord<RESOURCE>
       /*


### PR DESCRIPTION
Fixes #6068

> In other words, whenever a resource uri was set into an independent relationship (which in the UI is most commonly via a QueryComboBox or PickList of type Entire Table) for which the 'base' record already had a value, Specify would still remember and use the previous resource reference when constructing the request to the backend.

For more of an explanation of the Issue, see https://github.com/specify/specify7/issues/6068#issuecomment-2589149373. 

The vast majority of this PR is actually tests: I might have missed them elsewhere, but I could not find any tests for `SpecifyResource.set`: surprising because it is a critical component of the frontend ORM. 
I still have not covered all of the cases in these tests (specifically, one-to-one relationships and independent to-many relationships), and thus the coverage for `set` is not complete.

This would be a great time as developers to discuss how we want to handle some edge cases, and how wide/narrow we want  to make some of the critical methods on the frontend ORM. 

### Checklist

- [x] Self-review the PR after opening it to make sure the changes look good and
      self-explanatory (or properly documented)
- [x] Add automated tests
- [x] Add relevant issue to release milestone
- [ ] Add relevant documentation (Tester - Dev) 

### Testing instructions
If needed for testing, here is a list of all independent `to-one` relationships which are bidrectional (exist on both tables in the relationship) in Specify: 

[biderectional_independent_to_ones.json](https://github.com/user-attachments/files/18406607/biderectional_independent_to_ones.json)

- Find or create a resource which has an associated record in an independent to-one relationship
  - e.g.: CollectionObject -> accession,  CollectionObjectGroup ->  cogType,  PaleoContext -> chronosStrat, Address -> agent, etc.
- Make sure the relationship is rendered on the form as a QueryComboBox or PickList of type Entire Table
- Without the field losing focus while being empty, change the value of the field to that of another related resource. Examples: 
  -  QueryCBX: 
     - https://github.com/specify/specify7/issues/6068#issue-2784935072
     - https://github.com/specify/specify7/issues/6068#issuecomment-2588300019
     - https://github.com/specify/specify7/issues/6068#issuecomment-2589149373
  - PickList: 
    - https://github.com/specify/specify7/issues/6045#issue-2773734822
- [ ] Save the resource and ensure the value of the relationship gets properly set to the new related resource
- [ ] With a resource which has an associated record in an independent to-one relationship, unset the value of the relationship on the form (by clearing out the text in a QueryComboBox and clicking away from the field or selecting the empty option for a PickList of type Entire Table), save the base resource and ensure the value becomes un-set 
- [ ] Do some general testing of to-many relationships rendered as a Subview