### PR TITLE
Update isHidden for geo tables in non geo disciplines

### DIFF
--- a/specifyweb/specify/migration_utils/sp7_schemaconfig.py
+++ b/specifyweb/specify/migration_utils/sp7_schemaconfig.py
@@ -76,3 +76,7 @@ MIGRATION_0013_FIELDS = {
 MIGRATION_0020_FIELDS = {
     'PaleoContext': ['tectonicUnit'],
 }
+
+MIGRATION_0021_FIELDS = {
+    'CollectionObject': ['relativeAges', 'absoluteAges', 'cojo'],
+}

--- a/specifyweb/specify/migrations/0021_update_hidden_geo_tables.py
+++ b/specifyweb/specify/migrations/0021_update_hidden_geo_tables.py
@@ -1,0 +1,63 @@
+"""
+This migration updates the geo tables hidden proprety in schema config.
+"""
+
+from django.db import migrations
+from specifyweb.specify.migration_utils.sp7_schemaconfig import MIGRATION_0021_FIELDS as SCHEMA_CONFIG_MOD_TABLE_FIELDS
+
+def fix_hidden_geo_prop(apps, schema_editor):
+    Splocalecontainer = apps.get_model('specify', 'Splocalecontainer')
+    Splocalecontaineritem = apps.get_model('specify', 'Splocalecontaineritem')
+    Discipline = apps.get_model('specify', 'Discipline')
+
+    filtered_disciplines = Discipline.objects.exclude(name__in=['verpaleo', 'invertpaleo', 'geology'])
+
+    for discipline in filtered_disciplines:
+        for table, fields in SCHEMA_CONFIG_MOD_TABLE_FIELDS.items():
+            containers = Splocalecontainer.objects.filter(
+                name=table.lower(),
+                discipline_id=discipline.id,
+            )
+            for container in containers:
+                for field_name in fields:
+                    items = Splocalecontaineritem.objects.filter(
+                        container=container,
+                        name=field_name.lower()
+                    )
+
+                    for item in items:
+                        item.ishidden = True
+                        item.save()
+
+def reverse_fix_hidden_geo_prop(apps, schema_editor):
+    Splocalecontainer = apps.get_model('specify', 'Splocalecontainer')
+    Splocalecontaineritem = apps.get_model('specify', 'Splocalecontaineritem')
+    Discipline = apps.get_model('specify', 'Discipline')
+
+    filtered_disciplines = Discipline.objects.exclude(name__in=['verpaleo', 'invertpaleo', 'geology'])
+
+    for discipline in filtered_disciplines:
+        for table, fields in SCHEMA_CONFIG_MOD_TABLE_FIELDS.items():
+            containers = Splocalecontainer.objects.filter(
+                name=table.lower(),
+                discipline_id=discipline.id,
+            )
+            for container in containers:
+                for field_name in fields:
+                    items = Splocalecontaineritem.objects.filter(
+                        container=container,
+                        name=field_name.lower()
+                    )
+
+                    for item in items:
+                        item.ishidden = False
+                        item.save()
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ('specify', '0020_add_tectonicunit_to_pc_in_schema_config'),
+    ]
+
+    operations = [
+        migrations.RunPython(fix_hidden_geo_prop, reverse_fix_hidden_geo_prop, atomic=True)
+    ]

--- a/specifyweb/specify/migrations/0021_update_hidden_geo_tables.py
+++ b/specifyweb/specify/migrations/0021_update_hidden_geo_tables.py
@@ -4,13 +4,16 @@ This migration updates the geo tables hidden proprety in schema config.
 
 from django.db import migrations
 from specifyweb.specify.migration_utils.sp7_schemaconfig import MIGRATION_0021_FIELDS as SCHEMA_CONFIG_MOD_TABLE_FIELDS
+from specifyweb.specify.model_extras import GEOLOGY_DISCIPLINES, PALEO_DISCIPLINES
 
 def fix_hidden_geo_prop(apps, schema_editor):
     Splocalecontainer = apps.get_model('specify', 'Splocalecontainer')
     Splocalecontaineritem = apps.get_model('specify', 'Splocalecontaineritem')
     Discipline = apps.get_model('specify', 'Discipline')
 
-    filtered_disciplines = Discipline.objects.exclude(name__in=['verpaleo', 'invertpaleo', 'geology'])
+    excluded_disciplines = PALEO_DISCIPLINES | GEOLOGY_DISCIPLINES
+
+    filtered_disciplines = Discipline.objects.exclude(type__in=excluded_disciplines)
 
     for discipline in filtered_disciplines:
         for table, fields in SCHEMA_CONFIG_MOD_TABLE_FIELDS.items():
@@ -34,7 +37,9 @@ def reverse_fix_hidden_geo_prop(apps, schema_editor):
     Splocalecontaineritem = apps.get_model('specify', 'Splocalecontaineritem')
     Discipline = apps.get_model('specify', 'Discipline')
 
-    filtered_disciplines = Discipline.objects.exclude(name__in=['verpaleo', 'invertpaleo', 'geology'])
+    excluded_disciplines = PALEO_DISCIPLINES | GEOLOGY_DISCIPLINES
+
+    filtered_disciplines = Discipline.objects.exclude(type__in=excluded_disciplines)
 
     for discipline in filtered_disciplines:
         for table, fields in SCHEMA_CONFIG_MOD_TABLE_FIELDS.items():


### PR DESCRIPTION
Fixes #6065

> [!WARNING]  
> This PR affects database migrations. See [migration testing instructions](https://specify.github.io/testing/pull_requests.html#prs-tagged-with-label-migration).

### Checklist

- [ ] Self-review the PR after opening it to make sure the changes look good and
      self-explanatory (or properly documented)
- [ ] Add relevant issue to release milestone

### Testing instructions

- Log into a collection that is not a part of one of those discipline: ['verpaleo', 'invertpaleo', 'geology']
- Go to QB > CO 
- [ ] Verify that those three fields are hidden: 'relativeAges', 'absoluteAges', 'cojo'
- Log into a collection that is a part of one of those discipline: ['verpaleo', 'invertpaleo', 'geology']
- Go to QB > CO 
- [ ] Verify that those three fields are NOT hidden: 'relativeAges', 'absoluteAges', 'cojo'
