### PR TITLE
Remove virtual field age from QB for non geo disciplines

### DIFF
--- a/specifyweb/context/views.py
+++ b/specifyweb/context/views.py
@@ -650,6 +650,7 @@ def system_info(request):
         collection=collection and collection.collectionname,
         collection_guid=collection and collection.guid,
         isa_number=collection and collection.isanumber,
+        discipline_type=discipline and discipline.type
         )
     return HttpResponse(json.dumps(info), content_type='application/json')
 

--- a/specifyweb/frontend/js_src/lib/components/InitialContext/systemInfo.ts
+++ b/specifyweb/frontend/js_src/lib/components/InitialContext/systemInfo.ts
@@ -22,6 +22,7 @@ type SystemInfo = {
   readonly institution_guid: LocalizedString;
   readonly isa_number: LocalizedString;
   readonly stats_url: string | null;
+  readonly discipline_type: string
 };
 
 let systemInfo: SystemInfo;
@@ -44,6 +45,7 @@ export const fetchContext = load<SystemInfo>(
           collection: systemInfo.collection,
           collectionGUID: systemInfo.collection_guid,
           isaNumber: systemInfo.isa_number,
+          disciplineType: systemInfo.discipline_type
         },
         /*
          * I don't know if the receiving server handles GET parameters in a

--- a/specifyweb/frontend/js_src/lib/components/WbPlanView/__tests__/navigator.test.ts
+++ b/specifyweb/frontend/js_src/lib/components/WbPlanView/__tests__/navigator.test.ts
@@ -488,15 +488,6 @@ theories(getMappingLineData, [
             optionLabel: 'Accession #',
             tableName: 'Accession',
           },
-          age: {
-            isDefault: false,
-            isEnabled: true,
-            isHidden: false,
-            isRelationship: false,
-            isRequired: false,
-            optionLabel: 'Age',
-            tableName: undefined,
-          },
           altCatalogNumber: {
             isDefault: false,
             isEnabled: true,

--- a/specifyweb/frontend/js_src/lib/components/WbPlanView/navigator.ts
+++ b/specifyweb/frontend/js_src/lib/components/WbPlanView/navigator.ts
@@ -15,6 +15,7 @@ import type { Relationship } from '../DataModel/specifyField';
 import type { SpecifyTable } from '../DataModel/specifyTable';
 import { getFrontEndOnlyFields, strictGetTable } from '../DataModel/tables';
 import type { Tables } from '../DataModel/types';
+import { getSystemInfo } from '../InitialContext/systemInfo';
 import { getTreeDefinitions, isTreeTable } from '../InitialContext/treeRanks';
 import { hasTablePermission, hasTreeAccess } from '../Permissions/helpers';
 import type { CustomSelectSubtype } from './CustomSelectElement';
@@ -552,6 +553,17 @@ export function getMappingLineData({
                 : field.isHidden,
               field.name
             );
+
+            const discipline = getSystemInfo().discipline
+
+            if (
+              field.name === 'age' &&
+              !['geology', 'invertpaleo', 'vertpaleo', 'paleobotany'].includes(
+                discipline
+              )
+            ) {
+              return false;
+            }
 
             isIncluded &&=
               isNoRestrictionsMode ||

--- a/specifyweb/frontend/js_src/lib/components/WbPlanView/navigator.ts
+++ b/specifyweb/frontend/js_src/lib/components/WbPlanView/navigator.ts
@@ -542,6 +542,17 @@ export function getMappingLineData({
           .filter((field) => {
             let isIncluded = true;
 
+            const discipline = getSystemInfo().discipline.toLowerCase()
+
+            if (
+              field.name === 'age' &&
+              !['geology', 'invertpaleo', 'vertpaleo', 'paleobotany'].includes(
+                discipline
+              )
+            ) {
+              return false;
+            }
+
             isIncluded &&=
               generateFieldData === 'all' ||
               field.name === internalState.parsedDefaultValue[0];
@@ -553,17 +564,6 @@ export function getMappingLineData({
                 : field.isHidden,
               field.name
             );
-
-            const discipline = getSystemInfo().discipline
-
-            if (
-              field.name === 'age' &&
-              !['geology', 'invertpaleo', 'vertpaleo', 'paleobotany'].includes(
-                discipline
-              )
-            ) {
-              return false;
-            }
 
             isIncluded &&=
               isNoRestrictionsMode ||

--- a/specifyweb/frontend/js_src/lib/components/WbPlanView/navigator.ts
+++ b/specifyweb/frontend/js_src/lib/components/WbPlanView/navigator.ts
@@ -543,9 +543,10 @@ export function getMappingLineData({
             let isIncluded = true;
 
             const disciplineType = getSystemInfo().discipline_type.toLowerCase()
+            const geoPaleoDisciplines= ['geology', 'invertpaleo', 'vertpaleo', 'paleobotany']
             if (
               field.name === 'age' &&
-              !['geology', 'invertpaleo', 'vertpaleo', 'paleobotany'].includes(
+              !geoPaleoDisciplines.includes(
                 disciplineType
               )
             ) {

--- a/specifyweb/frontend/js_src/lib/components/WbPlanView/navigator.ts
+++ b/specifyweb/frontend/js_src/lib/components/WbPlanView/navigator.ts
@@ -543,7 +543,7 @@ export function getMappingLineData({
             let isIncluded = true;
 
             const disciplineType = getSystemInfo().discipline_type?.toLowerCase()
-            const geoPaleoDisciplines= ['geology', 'invertpaleo', 'vertpaleo', 'paleobotany']
+            const geoPaleoDisciplines= ['geology', 'invertpaleo', 'vertpaleo']
             if (
               field.name === 'age' &&
               !geoPaleoDisciplines.includes(

--- a/specifyweb/frontend/js_src/lib/components/WbPlanView/navigator.ts
+++ b/specifyweb/frontend/js_src/lib/components/WbPlanView/navigator.ts
@@ -542,12 +542,11 @@ export function getMappingLineData({
           .filter((field) => {
             let isIncluded = true;
 
-            const discipline = getSystemInfo().discipline.toLowerCase()
-
+            const disciplineType = getSystemInfo().discipline_type.toLowerCase()
             if (
               field.name === 'age' &&
               !['geology', 'invertpaleo', 'vertpaleo', 'paleobotany'].includes(
-                discipline
+                disciplineType
               )
             ) {
               return false;

--- a/specifyweb/frontend/js_src/lib/components/WbPlanView/navigator.ts
+++ b/specifyweb/frontend/js_src/lib/components/WbPlanView/navigator.ts
@@ -542,7 +542,7 @@ export function getMappingLineData({
           .filter((field) => {
             let isIncluded = true;
 
-            const disciplineType = getSystemInfo().discipline_type.toLowerCase()
+            const disciplineType = getSystemInfo().discipline_type?.toLowerCase()
             const geoPaleoDisciplines= ['geology', 'invertpaleo', 'vertpaleo', 'paleobotany']
             if (
               field.name === 'age' &&


### PR DESCRIPTION
Fixes #6064 

<!--
> [!WARNING]  
> This PR affects database migrations. See [migration testing instructions](https://specify.github.io/testing/pull_requests.html#prs-tagged-with-label-migration).
-->

### Checklist

- [ ] Self-review the PR after opening it to make sure the changes look good and
      self-explanatory (or properly documented)
- [ ] Add relevant issue to release milestone

### Testing instructions

- Go to a collection that is not part of ['geology', 'invertpaleo', 'vertpaleo', 'paleobotany'] disciplines
- Open QB > CO 
- [ ] Verify age is not present 
- Go to a collection that is a part of ['geology', 'invertpaleo', 'vertpaleo', 'paleobotany'] disciplines
- Open QB > CO 
- [ ] Verify age is present 
