### PR TITLE
Use a context for filtering Taxon names in QCBX

### DIFF
--- a/specifyweb/frontend/js_src/lib/components/FormMeta/MergeRecord.tsx
+++ b/specifyweb/frontend/js_src/lib/components/FormMeta/MergeRecord.tsx
@@ -60,6 +60,7 @@ export function MergeRecord({
           extraFilters={[
             {
               field: 'id',
+              isRelationship: false,
               operation: 'in',
               isNot: true,
               value: resource.id.toString(),

--- a/specifyweb/frontend/js_src/lib/components/FormPlugins/CollectionRelOneToMany.tsx
+++ b/specifyweb/frontend/js_src/lib/components/FormPlugins/CollectionRelOneToMany.tsx
@@ -191,6 +191,7 @@ export function CollectionOneToManyPlugin({
           extraFilters={[
             {
               field: 'id',
+              isRelationship: false,
               operation: 'in',
               isNot: true,
               value: existingItemFilter?.join(',') ?? '',

--- a/specifyweb/frontend/js_src/lib/components/QueryComboBox/helpers.ts
+++ b/specifyweb/frontend/js_src/lib/components/QueryComboBox/helpers.ts
@@ -143,9 +143,11 @@ export function getQueryComboBoxConditions({
     }
   }
 
-  if (
-    treeDefinition !== undefined
-  ) {
+  /**
+   * Filter values by tree definition if provided through context.
+   * Used for filtering Taxon values by COT tree definition.
+   */
+  if (treeDefinition !== undefined) {
     fields.push(
       QueryFieldSpec.fromPath(tables.Taxon.name, ['definition', 'id'])
         .toSpQueryField()

--- a/specifyweb/frontend/js_src/lib/components/QueryComboBox/helpers.ts
+++ b/specifyweb/frontend/js_src/lib/components/QueryComboBox/helpers.ts
@@ -144,8 +144,6 @@ export function getQueryComboBoxConditions({
   }
 
   if (
-    resource.specifyTable === tables.Determination &&
-    fieldName === 'fullName' &&
     treeDefinition !== undefined
   ) {
     fields.push(

--- a/specifyweb/frontend/js_src/lib/components/QueryComboBox/index.tsx
+++ b/specifyweb/frontend/js_src/lib/components/QueryComboBox/index.tsx
@@ -524,34 +524,41 @@ export function QueryComboBox({
                                 .map(serializeResource)
                                 .map(({ fieldName, startValue }) =>
                                   fieldName === 'rankId'
+                                ? {
+                                    field: 'rankId',
+                                    isRelationship: false,
+                                    isNot: false,
+                                    operation: 'less',
+                                    value: startValue,
+                                  }
+                                : fieldName === 'nodeNumber'
+                                  ? {
+                                      field: 'nodeNumber',
+                                      isRelationship: false,
+                                      operation: 'between',
+                                      isNot: true,
+                                      value: startValue,
+                                    }
+                                  : fieldName === 'collectionRelTypeId'
                                     ? {
-                                        field: 'rankId',
+                                        field: 'id',
+                                        isRelationship: false,
+                                        operation: 'in',
                                         isNot: false,
-                                        operation: 'less',
                                         value: startValue,
                                       }
-                                    : fieldName === 'nodeNumber'
+                                    : fieldName === 'taxonTreeDefId'
                                       ? {
-                                          field: 'nodeNumber',
-                                          operation: 'between',
-                                          isNot: true,
-                                          value: startValue,
+                                          field: 'definition',
+                                          isRelationship: true,
+                                          operation: 'in',
+                                          isNot: false,
+                                          value: startValue
                                         }
-                                      : fieldName === 'collectionRelTypeId'
-                                        ? {
-                                            field: 'id',
-                                            operation: 'in',
-                                            isNot: false,
-                                            value: startValue,
-                                          }
-                                        : f.error(
-                                            `extended filter not created`,
-                                            {
-                                              fieldName,
-                                              startValue,
-                                            }
-                                          )
-                                )
+                                    : f.error(`extended filter not created`, {
+                                        fieldName,
+                                        startValue,
+                                      }))
                             ),
                           })
                       : undefined

--- a/specifyweb/frontend/js_src/lib/components/QueryComboBox/index.tsx
+++ b/specifyweb/frontend/js_src/lib/components/QueryComboBox/index.tsx
@@ -52,6 +52,7 @@ import type { TypeSearch } from './spec';
 import { useCollectionRelationships } from './useCollectionRelationships';
 import { useTreeData } from './useTreeData';
 import { useTypeSearch } from './useTypeSearch';
+import { TreeDefinitionContext } from './useTreeData';
 
 /*
  * REFACTOR: split this component
@@ -263,7 +264,7 @@ export function QueryComboBox({
     (typeof typeSearch === 'object' ? typeSearch?.table : undefined) ??
     field.relatedTable;
 
-  const [treeDefinition] = useAsyncState(
+  const [fetchedTreeDefinition] = useAsyncState(
     React.useCallback(
       async () =>
         resource?.specifyTable === tables.Determination &&
@@ -282,6 +283,10 @@ export function QueryComboBox({
     ),
     false
   );
+
+  // Tree Definition passed by a parent QCBX in the component tree
+  const parentTreeDefinition = React.useContext(TreeDefinitionContext);
+  const treeDefinition = fetchedTreeDefinition ?? parentTreeDefinition;
 
   // FEATURE: use main table field if type search is not defined
   const fetchSource = React.useCallback(
@@ -359,7 +364,8 @@ export function QueryComboBox({
       relatedCollectionId,
       resource,
       treeData,
-      treeDefinition,
+      fetchedTreeDefinition,
+      parentTreeDefinition
     ]
   );
 
@@ -382,6 +388,7 @@ export function QueryComboBox({
   );
   return (
     <div className="flex w-full min-w-[theme(spacing.40)] items-center sm:min-w-[unset]">
+      <TreeDefinitionContext.Provider value={treeDefinition}>
       <AutoComplete<string>
         aria-label={undefined}
         disabled={
@@ -626,6 +633,7 @@ export function QueryComboBox({
           }
         />
       ) : undefined}
+      </TreeDefinitionContext.Provider>
     </div>
   );
 }

--- a/specifyweb/frontend/js_src/lib/components/QueryComboBox/index.tsx
+++ b/specifyweb/frontend/js_src/lib/components/QueryComboBox/index.tsx
@@ -51,8 +51,8 @@ import {
 import type { TypeSearch } from './spec';
 import { useCollectionRelationships } from './useCollectionRelationships';
 import { useTreeData } from './useTreeData';
-import { useTypeSearch } from './useTypeSearch';
 import { TreeDefinitionContext } from './useTreeData';
+import { useTypeSearch } from './useTypeSearch';
 
 /*
  * REFACTOR: split this component
@@ -365,7 +365,7 @@ export function QueryComboBox({
       resource,
       treeData,
       fetchedTreeDefinition,
-      parentTreeDefinition
+      parentTreeDefinition,
     ]
   );
 
@@ -389,83 +389,49 @@ export function QueryComboBox({
   return (
     <div className="flex w-full min-w-[theme(spacing.40)] items-center sm:min-w-[unset]">
       <TreeDefinitionContext.Provider value={treeDefinition}>
-      <AutoComplete<string>
-        aria-label={undefined}
-        disabled={
-          !isLoaded ||
-          isReadOnly ||
-          formType === 'formTable' ||
-          typeSearch === undefined ||
-          /**
-           * Don't disable the input if it is currently focused
-           * Fixes https://github.com/specify/specify7/issues/2142
-           */
-          (formatted === undefined &&
-            document.activeElement !== inputRef.current)
-        }
-        filterItems={false}
-        forwardRef={validationRef}
-        inputProps={{
-          id,
-          required: isRequired,
-          title: typeof typeSearch === 'object' ? typeSearch.title : undefined,
-          ...getValidationAttributes(parser),
-          type: 'text',
-          [titlePosition]: 'top',
-        }}
-        pendingValueRef={pendingValueRef}
-        source={fetchSource}
-        value={
-          formatted?.label ??
-          formattedRef.current?.formatted ??
-          commonText.loading()
-        }
-        onChange={({ data, label }): void => {
-          formattedRef.current = {
-            value: data,
-            formatted: localized(label.toString()),
-          };
-          updateValue(data);
-        }}
-        onCleared={(): void => updateValue('')}
-        onNewValue={
-          formType !== 'formTable' && canAdd
-            ? (): void =>
-                state.type === 'AddResourceState'
-                  ? setState({ type: 'MainState' })
-                  : setState({
-                      type: 'AddResourceState',
-                      resource: pendingValueToResource(
-                        field,
-                        typeSearch,
-                        pendingValueRef.current
-                      ),
-                    })
-            : undefined
-        }
-      />
-      <span className="contents print:hidden">
-        {formType === 'formTable' ? undefined : isReadOnly ? (
-          formatted?.resource === undefined ||
-          hasTablePermission(formatted.resource.specifyTable.name, 'read') ? (
-            viewButton
-          ) : undefined
-        ) : (
-          <>
-            {hasEditButton && (
-              <DataEntry.Edit
-                aria-pressed={state.type === 'ViewResourceState'}
-                disabled={
-                  formatted?.resource === undefined ||
-                  collectionRelationships === undefined
-                }
-                onClick={(): void => handleOpenRelated(false)}
-              />
-            )}
-            {canAdd && hasNewButton ? (
-              <DataEntry.Add
-                aria-pressed={state.type === 'AddResourceState'}
-                onClick={(): void =>
+        <AutoComplete<string>
+          aria-label={undefined}
+          disabled={
+            !isLoaded ||
+            isReadOnly ||
+            formType === 'formTable' ||
+            typeSearch === undefined ||
+            /**
+             * Don't disable the input if it is currently focused
+             * Fixes https://github.com/specify/specify7/issues/2142
+             */
+            (formatted === undefined &&
+              document.activeElement !== inputRef.current)
+          }
+          filterItems={false}
+          forwardRef={validationRef}
+          inputProps={{
+            id,
+            required: isRequired,
+            title:
+              typeof typeSearch === 'object' ? typeSearch.title : undefined,
+            ...getValidationAttributes(parser),
+            type: 'text',
+            [titlePosition]: 'top',
+          }}
+          pendingValueRef={pendingValueRef}
+          source={fetchSource}
+          value={
+            formatted?.label ??
+            formattedRef.current?.formatted ??
+            commonText.loading()
+          }
+          onChange={({ data, label }): void => {
+            formattedRef.current = {
+              value: data,
+              formatted: localized(label.toString()),
+            };
+            updateValue(data);
+          }}
+          onCleared={(): void => updateValue('')}
+          onNewValue={
+            formType !== 'formTable' && canAdd
+              ? (): void =>
                   state.type === 'AddResourceState'
                     ? setState({ type: 'MainState' })
                     : setState({
@@ -476,163 +442,201 @@ export function QueryComboBox({
                           pendingValueRef.current
                         ),
                       })
-                }
-              />
-            ) : undefined}
-            {hasCloneButton && (
-              <DataEntry.Clone
-                disabled={formatted?.resource === undefined}
-                onClick={(): void =>
-                  state.type === 'AddResourceState'
-                    ? setState({ type: 'MainState' })
-                    : loading(
-                        formatted!.resource!.clone(true).then((resource) =>
-                          setState({
-                            type: 'AddResourceState',
-                            resource,
-                          })
-                        )
-                      )
-                }
-              />
-            )}
-            {hasSearchButton && !field.isDependent() && (
-              <DataEntry.Search
-                aria-pressed={state.type === 'SearchState'}
-                onClick={
-                  isLoaded && typeof resource === 'object'
-                    ? (): void =>
-                        setState({
-                          type: 'SearchState',
-                          extraConditions: filterArray(
-                            getQueryComboBoxConditions({
-                              resource,
-                              fieldName: field.name,
-                              collectionRelationships:
-                                typeof collectionRelationships === 'object'
-                                  ? collectionRelationships
-                                  : undefined,
-                              treeData:
-                                typeof treeData === 'object'
-                                  ? treeData
-                                  : undefined,
-                              relatedTable,
-                              subViewRelationship,
-                              treeDefinition,
-                            })
-                              .map(serializeResource)
-                              .map(({ fieldName, startValue }) =>
-                                fieldName === 'rankId'
-                                  ? {
-                                      field: 'rankId',
-                                      isNot: false,
-                                      operation: 'less',
-                                      value: startValue,
-                                    }
-                                  : fieldName === 'nodeNumber'
-                                    ? {
-                                        field: 'nodeNumber',
-                                        operation: 'between',
-                                        isNot: true,
-                                        value: startValue,
-                                      }
-                                    : fieldName === 'collectionRelTypeId'
-                                      ? {
-                                          field: 'id',
-                                          operation: 'in',
-                                          isNot: false,
-                                          value: startValue,
-                                        }
-                                      : f.error(`extended filter not created`, {
-                                          fieldName,
-                                          startValue,
-                                        })
-                              )
-                          ),
-                        })
-                    : undefined
-                }
-              />
-            )}
-            {hasViewButton && hasTablePermission(relatedTable.name, 'read')
-              ? viewButton
-              : undefined}
-          </>
-        )}
-      </span>
-      {state.type === 'AccessDeniedState' && (
-        <Dialog
-          buttons={commonText.close()}
-          header={userText.collectionAccessDenied()}
-          onClose={(): void => setState({ type: 'MainState' })}
-        >
-          {userText.collectionAccessDeniedDescription({
-            collectionName: state.collectionName,
-          })}
-        </Dialog>
-      )}
-      {typeof formatted?.resource === 'object' &&
-      state.type === 'ViewResourceState' ? (
-        <ReadOnlyContext.Provider value={state.isReadOnly}>
-          <ResourceView
-            dialog="nonModal"
-            isDependent={field.isDependent()}
-            isSubForm={false}
-            resource={formatted.resource}
-            onAdd={undefined}
-            onClose={(): void => {
-              setState({ type: 'MainState' });
-            }}
-            onDeleted={(): void => {
-              resource?.set(field.name, null as never);
-              setState({ type: 'MainState' });
-            }}
-            onSaved={undefined}
-            onSaving={
-              field.isDependent()
-                ? f.never
-                : (): void => setState({ type: 'MainState' })
-            }
-          />
-        </ReadOnlyContext.Provider>
-      ) : state.type === 'AddResourceState' ? (
-        <ResourceView
-          dialog="nonModal"
-          isDependent={false}
-          isSubForm={false}
-          resource={state.resource}
-          onAdd={undefined}
-          onClose={(): void => setState({ type: 'MainState' })}
-          onDeleted={undefined}
-          onSaved={(): void => {
-            resource?.set(field.name, state.resource as never);
-            setState({ type: 'MainState' });
-          }}
-          onSaving={
-            field.isDependent()
-              ? (): false => {
-                  resource?.set(field.name, state.resource as never);
-                  setState({ type: 'MainState' });
-                  return false;
-                }
               : undefined
           }
         />
-      ) : undefined}
-      {state.type === 'SearchState' ? (
-        <SearchDialog
-          extraFilters={state.extraConditions}
-          forceCollection={forceCollection ?? relatedCollectionId}
-          multiple={false}
-          searchView={searchView}
-          table={relatedTable}
-          onClose={(): void => setState({ type: 'MainState' })}
-          onSelected={([selectedResource]): void =>
-            // @ts-expect-error Need to refactor this to use generics
-            void resource.set(field.name, selectedResource)
-          }
-        />
-      ) : undefined}
+        <span className="contents print:hidden">
+          {formType === 'formTable' ? undefined : isReadOnly ? (
+            formatted?.resource === undefined ||
+            hasTablePermission(formatted.resource.specifyTable.name, 'read') ? (
+              viewButton
+            ) : undefined
+          ) : (
+            <>
+              {hasEditButton && (
+                <DataEntry.Edit
+                  aria-pressed={state.type === 'ViewResourceState'}
+                  disabled={
+                    formatted?.resource === undefined ||
+                    collectionRelationships === undefined
+                  }
+                  onClick={(): void => handleOpenRelated(false)}
+                />
+              )}
+              {canAdd && hasNewButton ? (
+                <DataEntry.Add
+                  aria-pressed={state.type === 'AddResourceState'}
+                  onClick={(): void =>
+                    state.type === 'AddResourceState'
+                      ? setState({ type: 'MainState' })
+                      : setState({
+                          type: 'AddResourceState',
+                          resource: pendingValueToResource(
+                            field,
+                            typeSearch,
+                            pendingValueRef.current
+                          ),
+                        })
+                  }
+                />
+              ) : undefined}
+              {hasCloneButton && (
+                <DataEntry.Clone
+                  disabled={formatted?.resource === undefined}
+                  onClick={(): void =>
+                    state.type === 'AddResourceState'
+                      ? setState({ type: 'MainState' })
+                      : loading(
+                          formatted!.resource!.clone(true).then((resource) =>
+                            setState({
+                              type: 'AddResourceState',
+                              resource,
+                            })
+                          )
+                        )
+                  }
+                />
+              )}
+              {hasSearchButton && !field.isDependent() && (
+                <DataEntry.Search
+                  aria-pressed={state.type === 'SearchState'}
+                  onClick={
+                    isLoaded && typeof resource === 'object'
+                      ? (): void =>
+                          setState({
+                            type: 'SearchState',
+                            extraConditions: filterArray(
+                              getQueryComboBoxConditions({
+                                resource,
+                                fieldName: field.name,
+                                collectionRelationships:
+                                  typeof collectionRelationships === 'object'
+                                    ? collectionRelationships
+                                    : undefined,
+                                treeData:
+                                  typeof treeData === 'object'
+                                    ? treeData
+                                    : undefined,
+                                relatedTable,
+                                subViewRelationship,
+                                treeDefinition,
+                              })
+                                .map(serializeResource)
+                                .map(({ fieldName, startValue }) =>
+                                  fieldName === 'rankId'
+                                    ? {
+                                        field: 'rankId',
+                                        isNot: false,
+                                        operation: 'less',
+                                        value: startValue,
+                                      }
+                                    : fieldName === 'nodeNumber'
+                                      ? {
+                                          field: 'nodeNumber',
+                                          operation: 'between',
+                                          isNot: true,
+                                          value: startValue,
+                                        }
+                                      : fieldName === 'collectionRelTypeId'
+                                        ? {
+                                            field: 'id',
+                                            operation: 'in',
+                                            isNot: false,
+                                            value: startValue,
+                                          }
+                                        : f.error(
+                                            `extended filter not created`,
+                                            {
+                                              fieldName,
+                                              startValue,
+                                            }
+                                          )
+                                )
+                            ),
+                          })
+                      : undefined
+                  }
+                />
+              )}
+              {hasViewButton && hasTablePermission(relatedTable.name, 'read')
+                ? viewButton
+                : undefined}
+            </>
+          )}
+        </span>
+        {state.type === 'AccessDeniedState' && (
+          <Dialog
+            buttons={commonText.close()}
+            header={userText.collectionAccessDenied()}
+            onClose={(): void => setState({ type: 'MainState' })}
+          >
+            {userText.collectionAccessDeniedDescription({
+              collectionName: state.collectionName,
+            })}
+          </Dialog>
+        )}
+        {typeof formatted?.resource === 'object' &&
+        state.type === 'ViewResourceState' ? (
+          <ReadOnlyContext.Provider value={state.isReadOnly}>
+            <ResourceView
+              dialog="nonModal"
+              isDependent={field.isDependent()}
+              isSubForm={false}
+              resource={formatted.resource}
+              onAdd={undefined}
+              onClose={(): void => {
+                setState({ type: 'MainState' });
+              }}
+              onDeleted={(): void => {
+                resource?.set(field.name, null as never);
+                setState({ type: 'MainState' });
+              }}
+              onSaved={undefined}
+              onSaving={
+                field.isDependent()
+                  ? f.never
+                  : (): void => setState({ type: 'MainState' })
+              }
+            />
+          </ReadOnlyContext.Provider>
+        ) : state.type === 'AddResourceState' ? (
+          <ResourceView
+            dialog="nonModal"
+            isDependent={false}
+            isSubForm={false}
+            resource={state.resource}
+            onAdd={undefined}
+            onClose={(): void => setState({ type: 'MainState' })}
+            onDeleted={undefined}
+            onSaved={(): void => {
+              resource?.set(field.name, state.resource as never);
+              setState({ type: 'MainState' });
+            }}
+            onSaving={
+              field.isDependent()
+                ? (): false => {
+                    resource?.set(field.name, state.resource as never);
+                    setState({ type: 'MainState' });
+                    return false;
+                  }
+                : undefined
+            }
+          />
+        ) : undefined}
+        {state.type === 'SearchState' ? (
+          <SearchDialog
+            extraFilters={state.extraConditions}
+            forceCollection={forceCollection ?? relatedCollectionId}
+            multiple={false}
+            searchView={searchView}
+            table={relatedTable}
+            onClose={(): void => setState({ type: 'MainState' })}
+            onSelected={([selectedResource]): void =>
+              // @ts-expect-error Need to refactor this to use generics
+              void resource.set(field.name, selectedResource)
+            }
+          />
+        ) : undefined}
       </TreeDefinitionContext.Provider>
     </div>
   );

--- a/specifyweb/frontend/js_src/lib/components/QueryComboBox/useTreeData.tsx
+++ b/specifyweb/frontend/js_src/lib/components/QueryComboBox/useTreeData.tsx
@@ -79,3 +79,11 @@ export function useTreeData(
   );
   return treeData;
 }
+
+/**
+ * Context for passing down the tree definition of a CollectionObjectType.
+ * Used for filtering Taxon values by tree.
+ */
+export const TreeDefinitionContext =
+  React.createContext<string | undefined>(undefined);
+TreeDefinitionContext.displayName = 'TreeDefinitionContext';

--- a/specifyweb/frontend/js_src/lib/components/QueryComboBox/useTreeData.tsx
+++ b/specifyweb/frontend/js_src/lib/components/QueryComboBox/useTreeData.tsx
@@ -84,6 +84,7 @@ export function useTreeData(
  * Context for passing down the tree definition of a CollectionObjectType.
  * Used for filtering Taxon values by tree.
  */
-export const TreeDefinitionContext =
-  React.createContext<string | undefined>(undefined);
+export const TreeDefinitionContext = React.createContext<string | undefined>(
+  undefined
+);
 TreeDefinitionContext.displayName = 'TreeDefinitionContext';

--- a/specifyweb/frontend/js_src/lib/components/SearchDialog/index.tsx
+++ b/specifyweb/frontend/js_src/lib/components/SearchDialog/index.tsx
@@ -19,7 +19,7 @@ import { Submit } from '../Atoms/Submit';
 import { SearchDialogContext } from '../Core/Contexts';
 import type { AnySchema, CommonFields } from '../DataModel/helperTypes';
 import type { SpecifyResource } from '../DataModel/legacyTypes';
-import { getResourceViewUrl } from '../DataModel/resource';
+import { getResourceViewUrl, strictIdFromUrl } from '../DataModel/resource';
 import type { SpecifyTable } from '../DataModel/specifyTable';
 import type { SpQueryField, Tables } from '../DataModel/types';
 import { error } from '../Errors/assert';
@@ -42,6 +42,7 @@ const resourceLimit = 100;
 
 export type QueryComboBoxFilter<SCHEMA extends AnySchema> = {
   readonly field: string & (keyof CommonFields | keyof SCHEMA['fields']);
+  readonly isRelationship: boolean;
   readonly isNot: boolean;
   readonly operation: QueryFieldFilter & ('between' | 'in' | 'less');
   readonly value: string;
@@ -138,7 +139,7 @@ const filterResults = <SCHEMA extends AnySchema>(
 
 function testFilter<SCHEMA extends AnySchema>(
   resource: SpecifyResource<SCHEMA>,
-  { operation, field, value, isNot }: QueryComboBoxFilter<SCHEMA>
+  { operation, field, value, isNot, isRelationship }: QueryComboBoxFilter<SCHEMA>
 ): boolean {
   const values = value.split(',').map(f.trim);
   const result =
@@ -147,8 +148,11 @@ function testFilter<SCHEMA extends AnySchema>(
         (resource.get(field) ?? 0) <= values[1]
       : operation === 'in'
         ? // Cast numbers to strings
-          // eslint-disable-next-line eqeqeq
-          values.some((value) => value == resource.get(field))
+          values.some((value) => {
+            const fieldValue = resource.get(field);
+            // eslint-disable-next-line eqeqeq
+            return isRelationship ? value == strictIdFromUrl(fieldValue!).toString() : value == fieldValue
+          })
         : operation === 'less'
           ? values.every((value) => (resource.get(field) ?? 0) < value)
           : error('Invalid Query Combo Box search filter', {

--- a/specifyweb/frontend/js_src/lib/components/Security/CollectionRole.tsx
+++ b/specifyweb/frontend/js_src/lib/components/Security/CollectionRole.tsx
@@ -213,6 +213,7 @@ function RoleUsers({
               extraFilters={[
                 {
                   field: 'id',
+                  isRelationship: false,
                   isNot: true,
                   operation: 'in',
                   value: userRoles

--- a/specifyweb/frontend/js_src/lib/components/WbPlanView/navigator.ts
+++ b/specifyweb/frontend/js_src/lib/components/WbPlanView/navigator.ts
@@ -542,13 +542,12 @@ export function getMappingLineData({
           .filter((field) => {
             let isIncluded = true;
 
-            const disciplineType = getSystemInfo().discipline_type?.toLowerCase()
-            const geoPaleoDisciplines= ['geology', 'invertpaleo', 'vertpaleo']
+            const disciplineType =
+              getSystemInfo().discipline_type?.toLowerCase();
+            const geoPaleoDisciplines = ['geology', 'invertpaleo', 'vertpaleo'];
             if (
               field.name === 'age' &&
-              !geoPaleoDisciplines.includes(
-                disciplineType
-              )
+              !geoPaleoDisciplines.includes(disciplineType)
             ) {
               return false;
             }


### PR DESCRIPTION
Fixes #5432 

<!--
> [!WARNING]  
> This PR affects database migrations. See [migration testing instructions](https://specify.github.io/testing/pull_requests.html#prs-tagged-with-label-migration).
-->

Added a context to pass down the tree definition fetched in a `Determination -> Taxon` QCBX down to its children so any Taxon can be filtered by the same treedef. Filtering should now work through autocomplete as well as when using the qcbx search icon 

### Checklist

- [x] Self-review the PR after opening it to make sure the changes look good and
      self-explanatory (or properly documented)
- [ ] Add automated tests
- [ ] Add relevant issue to release milestone
- [ ] Add relevant documentation (Tester - Dev) 

### Testing instructions

- Go to Data Entry > CO
- Set a COType
- Create a new Determination -> Taxon by clicking the + icon
- [ ] Verify parent values are filtered by COType when searching through autocomplete as well as through the search icon
- [ ] Verify Determination -> Taxon values still get filtered as expected (no regression)

<!-- What are the steps to verify the fixes/changes in this PR? -->
<!-- Can part of that be replaced by automated tests? -->
