### PR TITLE
Define 0022_ensure_default_cots to be revertible

### DIFF
--- a/specifyweb/specify/migrations/0022_ensure_default_cots.py
+++ b/specifyweb/specify/migrations/0022_ensure_default_cots.py
@@ -7,7 +7,17 @@ class Migration(migrations.Migration):
         create_default_collection_types(apps)
 
     def revert_default_collection_types(apps, schema_editor):
-        pass
+        # Set all collection records to have a null collectionobjecttype
+        Collectionobject = apps.get_model('specify', 'Collectionobject')
+        Collectionobject.objects.all().update(collectionobjecttype=None)
+
+        # Set all the collectionobject records of the collection
+        # NOTE: Do we want to do this?
+        Collectionobject.objects.update(collectionobjecttype=None)
+
+        # Delete all CollectionObjectType records
+        Collectionobjecttype = apps.get_model('specify', 'Collectionobjecttype')
+        Collectionobjecttype.objects.all().delete()
 
     dependencies = [
         ('specify', '0021_update_hidden_geo_tables'),

--- a/specifyweb/specify/migrations/0022_ensure_default_cots.py
+++ b/specifyweb/specify/migrations/0022_ensure_default_cots.py
@@ -11,9 +11,9 @@ class Migration(migrations.Migration):
         Collectionobject = apps.get_model('specify', 'Collectionobject')
         Collectionobject.objects.all().update(collectionobjecttype=None)
 
-        # Set all the collectionobject records of the collection
-        # NOTE: Do we want to do this?
-        Collectionobject.objects.update(collectionobjecttype=None)
+        # Set all the collection records to have a null collectionobjecttype
+        Collection = apps.get_model('specify', 'Collection')
+        Collection.objects.all().update(collectionobjecttype=None)
 
         # Delete all CollectionObjectType records
         Collectionobjecttype = apps.get_model('specify', 'Collectionobjecttype')

--- a/specifyweb/specify/migrations/0022_ensure_default_cots.py
+++ b/specifyweb/specify/migrations/0022_ensure_default_cots.py
@@ -7,11 +7,11 @@ class Migration(migrations.Migration):
         create_default_collection_types(apps)
 
     def revert_default_collection_types(apps, schema_editor):
-        # Set all collection records to have a null collectionobjecttype
+        # Set all CollectionObject records to have a null CollectionObjectType
         Collectionobject = apps.get_model('specify', 'Collectionobject')
         Collectionobject.objects.all().update(collectionobjecttype=None)
 
-        # Set all the collection records to have a null collectionobjecttype
+        # Set all the Collection records to have a null CollectionObjectType
         Collection = apps.get_model('specify', 'Collection')
         Collection.objects.all().update(collectionobjecttype=None)
 

--- a/specifyweb/specify/migrations/0022_ensure_default_cots.py
+++ b/specifyweb/specify/migrations/0022_ensure_default_cots.py
@@ -6,11 +6,14 @@ class Migration(migrations.Migration):
     def handle_default_collection_types(apps, schema_editor):
         create_default_collection_types(apps)
 
+    def revert_default_collection_types(apps, schema_editor):
+        pass
+
     dependencies = [
         ('specify', '0021_update_hidden_geo_tables'),
     ]
 
     operations = [
-        migrations.RunPython(handle_default_collection_types, atomic=True),
+        migrations.RunPython(handle_default_collection_types, revert_default_collection_types, atomic=True),
     ]
 


### PR DESCRIPTION
Fixes #6092

Add a reverse migration function to 0022_ensure_default_cots.

The revert migration does the following:
1. Set all collection records to have a null collectionobjecttype.
2. Set all the collection records to have a null collectionobjecttype.
3. Delete all CollectionObjectType records.

### Checklist

- [x] Self-review the PR after opening it to make sure the changes look good and
      self-explanatory (or properly documented)
- [x] Add automated tests
- [x] Add relevant issue to release milestone
- [x] Add a reverse migration if a migration is present in the PR

### Testing instructions

- In the specify 7 container, run `python manage.py migrate; #migrate`, see that all migrations run correctly
- In the specify 7 container, run `python manage.py migrate specify 0021; #revert`
- [x] See that the 0022 migration has been reverted `python manage.py showmigrations`
- In the specify 7 container, run `python manage.py migrate; #migrate again`
- [x] See that all the default COTs exist by checking that each collection record has an associated COT in its CollectionObjectType foreign key field.
