### PR TITLE
Allow displaying children on Chrono node subview

### DIFF
--- a/specifyweb/frontend/js_src/lib/components/DataModel/collection.ts
+++ b/specifyweb/frontend/js_src/lib/components/DataModel/collection.ts
@@ -193,6 +193,7 @@ export const fetchRows = async <
     readonly fields: FIELDS;
     readonly distinct?: boolean;
     readonly limit?: number;
+    readonly filterChronostrat?: boolean;
   },
   /**
    * Advanced filters, not type-safe.

--- a/specifyweb/frontend/js_src/lib/components/PickLists/__tests__/fetch.test.ts
+++ b/specifyweb/frontend/js_src/lib/components/PickLists/__tests__/fetch.test.ts
@@ -182,7 +182,7 @@ describe('fetchPickListItems', () => {
   });
 
   overrideAjax(
-    '/api/specify_rows/locality/?limit=0&domainfilter=true&distinct=true&fields=localityname',
+    '/api/specify_rows/locality/?limit=0&domainfilter=true&filterchronostrat=false&distinct=true&fields=localityname',
     [['abc']]
   );
   test('entire column', async () => {

--- a/specifyweb/frontend/js_src/lib/components/PickLists/fetch.ts
+++ b/specifyweb/frontend/js_src/lib/components/PickLists/fetch.ts
@@ -14,7 +14,7 @@ import {
   deserializeResource,
   serializeResource,
 } from '../DataModel/serializers';
-import { strictGetTable } from '../DataModel/tables';
+import { strictGetTable, tables } from '../DataModel/tables';
 import type { PickList, PickListItem, Tables } from '../DataModel/types';
 import { softFail } from '../Errors/Crash';
 import { format } from '../Formatters/formatters';
@@ -159,6 +159,7 @@ async function fetchFromField(
     fields: { [fieldName]: ['string', 'number', 'boolean', 'null'] },
     distinct: true,
     domainFilter: true,
+    filterChronostrat: tableName === tables.GeologicTimePeriod.name.toLowerCase() && fieldName === "name", // Prop for age filter in QueryBuilder
   }).then((rows) =>
     rows
       .map((row) => row[fieldName] ?? '')

--- a/specifyweb/specify/api.py
+++ b/specifyweb/specify/api.py
@@ -216,11 +216,14 @@ class GetCollectionForm(forms.Form):
 
     orderby = forms.CharField(required=False)
 
+    filterchronostrat = forms.BooleanField(required=False)
+
     defaults = dict(
         domainfilter=None,
         limit=0,
         offset=0,
         orderby=None,
+        filterchronostrat=False,
     )
 
     def clean_limit(self):
@@ -1010,14 +1013,13 @@ def apply_filters(logged_in_collection, params, model, control_params=GetCollect
 
         filters.update({param: val})
 
-#code repsonsible for issue 6086, this snipet is called to display the children of GeologicTimePeriod node. Need to refine to be applied only in the context of extended age query 
-    # if model.__name__ == 'Geologictimeperiod':
-    #     # Filter out invalid chronostrats
-    #     filters.update({
-    #         'startperiod__isnull': False,
-    #         'endperiod__isnull': False,
-    #         'startperiod__gte': F('endperiod')
-    #     })
+    if control_params['filterchronostrat'] == True:
+        # Filter out invalid chronostrats
+        filters.update({
+            'startperiod__isnull': False,
+            'endperiod__isnull': False,
+            'startperiod__gte': F('endperiod')
+        })
 
     try:
         objs = model.objects.filter(**filters)
@@ -1082,6 +1084,7 @@ class RowsForm(GetCollectionForm):
         orderby=None,
         distinct=False,
         fields=None,
+        filterchronostrat=False,
     )
 
 def rows(request, model_name: str) -> HttpResponse:

--- a/specifyweb/specify/api.py
+++ b/specifyweb/specify/api.py
@@ -1010,13 +1010,14 @@ def apply_filters(logged_in_collection, params, model, control_params=GetCollect
 
         filters.update({param: val})
 
-    if model.__name__ == 'Geologictimeperiod':
-        # Filter out invalid chronostrats
-        filters.update({
-            'startperiod__isnull': False,
-            'endperiod__isnull': False,
-            'startperiod__gte': F('endperiod')
-        })
+#code repsonsible for issue 6086, this snipet is called to display the children of GeologicTimePeriod node. Need to refine to be applied only in the context of extended age query 
+    # if model.__name__ == 'Geologictimeperiod':
+    #     # Filter out invalid chronostrats
+    #     filters.update({
+    #         'startperiod__isnull': False,
+    #         'endperiod__isnull': False,
+    #         'startperiod__gte': F('endperiod')
+    #     })
 
     try:
         objs = model.objects.filter(**filters)


### PR DESCRIPTION
Fixes #6086

Added a `filterChronostrat` param to `specify_rows` so that Chronostrats are only filtered when using the age picklist. 

A potentially cleaner way to do this could be to pass an `advancedFilter` to `fetchRows` so that the filters we need (https://github.com/specify/specify7/blob/4fb34be163977025d53bc9fcabae1353f1f5be73/specifyweb/specify/api.py#L1018-L1022) can be passed directly from the frontend but I don't think it supports F expressions and so we would need a prop anyway. I figure this solution should suffice until there's a requirement for more flexible advancedFilters.
https://github.com/specify/specify7/blob/36f7a7eddb9216cf634034105a36ad7672fe6571/specifyweb/frontend/js_src/lib/components/PickLists/fetch.ts#L157-L167

### Checklist

- [x] Self-review the PR after opening it to make sure the changes look good and
      self-explanatory (or properly documented)
- [x] Add relevant issue to release milestone

### Testing instructions

- Go to the chronostratigraphy tree
- Select a node and add a child
- Fill out required fields and save
- Select the parent node and click Edit
- [ ] Verify that the child node does appear under the Child Nodes subview
- [ ] Re-test https://github.com/specify/specify7/pull/5411
