### PR TITLE
Add default query mapping path to filter by COT tree def in QB search

### DIFF
--- a/specifyweb/frontend/js_src/lib/components/QueryComboBox/index.tsx
+++ b/specifyweb/frontend/js_src/lib/components/QueryComboBox/index.tsx
@@ -550,6 +550,10 @@ export function QueryComboBox({
                                         : fieldName === 'taxonTreeDefId'
                                           ? {
                                               field: 'definition',
+                                              queryBuilderFieldPath: [
+                                                'definition',
+                                                'id',
+                                              ],
                                               isRelationship: true,
                                               operation: 'in',
                                               isNot: false,

--- a/specifyweb/frontend/js_src/lib/components/SearchDialog/index.tsx
+++ b/specifyweb/frontend/js_src/lib/components/SearchDialog/index.tsx
@@ -35,7 +35,7 @@ import type { QueryFieldFilter } from '../QueryBuilder/FieldFilter';
 import { queryFieldFilters } from '../QueryBuilder/FieldFilter';
 import { QueryFieldSpec } from '../QueryBuilder/fieldSpec';
 import { QueryBuilder } from '../QueryBuilder/Wrapped';
-import { MappingPath } from '../WbPlanView/Mapper';
+import type { MappingPath } from '../WbPlanView/Mapper';
 import { queryCbxExtendedSearch } from './helpers';
 import { SelectRecordSets } from './SelectRecordSet';
 
@@ -158,7 +158,7 @@ function testFilter<SCHEMA extends AnySchema>(
         ? // Cast numbers to strings
           values.some((value) => {
             const fieldValue = resource.get(field);
-            // eslint-disable-next-line eqeqeq
+
             return isRelationship
               ? value == strictIdFromUrl(fieldValue!).toString()
               : value == fieldValue;

--- a/specifyweb/frontend/js_src/lib/components/SearchDialog/index.tsx
+++ b/specifyweb/frontend/js_src/lib/components/SearchDialog/index.tsx
@@ -158,7 +158,7 @@ function testFilter<SCHEMA extends AnySchema>(
         ? // Cast numbers to strings
           values.some((value) => {
             const fieldValue = resource.get(field);
-
+            // eslint-disable-next-line eqeqeq
             return isRelationship
               ? value == strictIdFromUrl(fieldValue!).toString()
               : value == fieldValue;

--- a/specifyweb/frontend/js_src/lib/components/SearchDialog/index.tsx
+++ b/specifyweb/frontend/js_src/lib/components/SearchDialog/index.tsx
@@ -35,6 +35,7 @@ import type { QueryFieldFilter } from '../QueryBuilder/FieldFilter';
 import { queryFieldFilters } from '../QueryBuilder/FieldFilter';
 import { QueryFieldSpec } from '../QueryBuilder/fieldSpec';
 import { QueryBuilder } from '../QueryBuilder/Wrapped';
+import { MappingPath } from '../WbPlanView/Mapper';
 import { queryCbxExtendedSearch } from './helpers';
 import { SelectRecordSets } from './SelectRecordSet';
 
@@ -42,6 +43,7 @@ const resourceLimit = 100;
 
 export type QueryComboBoxFilter<SCHEMA extends AnySchema> = {
   readonly field: string & (keyof CommonFields | keyof SCHEMA['fields']);
+  readonly queryBuilderFieldPath?: MappingPath;
   readonly isRelationship: boolean;
   readonly isNot: boolean;
   readonly operation: QueryFieldFilter & ('between' | 'in' | 'less');
@@ -395,8 +397,8 @@ const toQueryFields = <SCHEMA extends AnySchema>(
   table: SpecifyTable<SCHEMA>,
   filters: RA<QueryComboBoxFilter<SCHEMA>>
 ): RA<SpecifyResource<SpQueryField>> =>
-  filters.map(({ field, operation, isNot, value }) =>
-    QueryFieldSpec.fromPath(table.name, [field])
+  filters.map(({ field, queryBuilderFieldPath, operation, isNot, value }) =>
+    QueryFieldSpec.fromPath(table.name, queryBuilderFieldPath ?? [field])
       .toSpQueryField()
       .set('operStart', queryFieldFilters[operation].id)
       .set('isNot', isNot)


### PR DESCRIPTION
Fixes #6098

<!--
> [!WARNING]  
> This PR affects database migrations. See [migration testing instructions](https://specify.github.io/testing/pull_requests.html#prs-tagged-with-label-migration).
-->

### Checklist

- [x] Self-review the PR after opening it to make sure the changes look good and
      self-explanatory (or properly documented)
- [ ] Add automated tests
- [x] Add relevant issue to release milestone
- [ ] Add relevant documentation (Tester - Dev)
- [ ] Add a reverse migration if a migration is present in the PR

### Testing instructions

<!-- What are the steps to verify the fixes/changes in this PR? -->
<!-- Can part of that be replaced by automated tests? -->
- Create a new CO and set a COT
- Click the Search button next to the Determination QCBX
- [ ] Verify there is already a mapping line for filtering by COT tree def
