### PR TITLE
Fix loanreturnpreparations key error

### DIFF
--- a/specifyweb/interactions/cog_preps.py
+++ b/specifyweb/interactions/cog_preps.py
@@ -380,7 +380,11 @@ def modify_update_of_loan_return_sibling_preps(original_interaction_obj, updated
             prep_uri, "preparation") if prep_uri is not None else [None, None]
         map_prep_id_to_loan_prep_idx[prep_id] = loan_prep_idx
         loan_prep_idx += 1
-        loan_return_prep_data_lst = loan_prep_data["loanreturnpreparations"]
+        loan_return_prep_data_lst = (
+            loan_prep_data["loanreturnpreparations"]
+            if "loanreturnpreparations" in loan_prep_data.keys()
+            else []
+        )
 
         # Continue if the loan preparation has no new loan return preparation data,
         # or if there are more than one loan return preparation data (consolidated COG prep have no partial returns)
@@ -527,7 +531,14 @@ def modify_update_of_loan_return_sibling_preps(original_interaction_obj, updated
     for loan_prep_idx in range(len(updated_interaction_data["loanpreparations"])):
         if type(updated_interaction_data["loanpreparations"]) is str:
             continue
-        loan_return_data = updated_interaction_data["loanpreparations"][loan_prep_idx]["loanreturnpreparations"]
+        loan_return_data = (
+            updated_interaction_data["loanpreparations"][loan_prep_idx][
+                "loanreturnpreparations"
+            ]
+            if "loanreturnpreparations"
+            in updated_interaction_data["loanpreparations"][loan_prep_idx].keys()
+            else []
+        )
         total_quantity_returned = sum(
             [loan_return["quantityreturned"] for loan_return in loan_return_data])
         total_quantity_resolved = sum(


### PR DESCRIPTION
Fixes #6103

Handle loan prep addition to a loan record without any loan returns.  Fixed by handling the case where there is no loanreturnpreparations key.

### Checklist

- [ ] Self-review the PR after opening it to make sure the changes look good and
      self-explanatory (or properly documented)
- [ ] Add automated tests
- [ ] Add relevant issue to release milestone
- [ ] Add relevant documentation (Tester - Dev)
- [ ] Add a reverse migration if a migration is present in the PR

### Testing instructions

<!-- What are the steps to verify the fixes/changes in this PR? -->
<!-- Can part of that be replaced by automated tests? -->
