### PR TITLE
Fix Dockerfile dependencies for arm64 docker build error on GitHub Actions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -48,12 +48,17 @@ RUN apt-get update \
         ca-certificates \
         curl \
         git \
-        libldap2-dev \
-        libmariadbclient-dev \
         libsasl2-dev \
+        libsasl2-modules-gssapi-mit \
+        libldap2-dev \
+        libssl-dev \
+        libgmp-dev \
+        libffi-dev \
         python3.8-venv \
         python3.8-distutils \
-        python3.8-dev
+        python3.8-dev \
+ && apt-get clean \
+ && rm -rf /var/lib/apt/lists/*
 
 USER specify
 COPY --chown=specify:specify requirements.txt /home/specify/

--- a/Dockerfile
+++ b/Dockerfile
@@ -57,6 +57,7 @@ RUN apt-get update \
         python3.8-venv \
         python3.8-distutils \
         python3.8-dev \
+        default-libmysqlclient-dev \
  && apt-get clean \
  && rm -rf /var/lib/apt/lists/*
 
@@ -66,7 +67,6 @@ COPY --chown=specify:specify requirements.txt /home/specify/
 WORKDIR /opt/specify7
 RUN python3.8 -m venv ve \
  && ve/bin/pip install --no-cache-dir --upgrade pip setuptools wheel \
- && ve/bin/pip install --no-cache-dir --only-binary=:all: pycryptodome==3.14.1 \
  && ve/bin/pip install -v --no-cache-dir -r /home/specify/requirements.txt
 RUN ve/bin/pip install --no-cache-dir gunicorn
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -60,7 +60,7 @@ COPY --chown=specify:specify requirements.txt /home/specify/
 
 WORKDIR /opt/specify7
 RUN python3.8 -m venv ve \
- && ve/bin/pip install --no-cache-dir -r /home/specify/requirements.txt
+ && ve/bin/pip install -v --no-cache-dir -r /home/specify/requirements.txt
 RUN ve/bin/pip install --no-cache-dir gunicorn
 
 COPY --from=build-frontend /home/node/dist specifyweb/frontend/static/js

--- a/Dockerfile
+++ b/Dockerfile
@@ -65,6 +65,8 @@ COPY --chown=specify:specify requirements.txt /home/specify/
 
 WORKDIR /opt/specify7
 RUN python3.8 -m venv ve \
+ && ve/bin/pip install --no-cache-dir --upgrade pip setuptools wheel \
+ && ve/bin/pip install --no-cache-dir --only-binary=:all: pycryptodome==3.14.1 \
  && ve/bin/pip install -v --no-cache-dir -r /home/specify/requirements.txt
 RUN ve/bin/pip install --no-cache-dir gunicorn
 

--- a/specifyweb/interactions/cog_preps.py
+++ b/specifyweb/interactions/cog_preps.py
@@ -1,4 +1,3 @@
-import re
 import logging
 from typing import Any, List, Optional, Set
 from django.db.models import Subquery

--- a/specifyweb/interactions/cog_preps.py
+++ b/specifyweb/interactions/cog_preps.py
@@ -1,3 +1,4 @@
+import re
 import logging
 from typing import Any, List, Optional, Set
 from django.db.models import Subquery


### PR DESCRIPTION
Fix Dockerfile dependencies for arm64 docker build error on GitHub Actions.

This resolves issues with building the Docker image for arm64 architecture by updating the Dockerfile to include additional dependencies and improving compatibility for Python packages that require compilation during installation.

Added libsasl2-modules-gssapi-mit, libssl-dev, libgmp-dev, libffi-dev, and default-libmysqlclient-dev to the apt-get install step.

This will also fix the problematic branches on the test-panel.  Will need to update those branches to production once this branch is merged into production.


