### PR TITLE
Formatter fixes

### DIFF
--- a/specifyweb/specify/func.py
+++ b/specifyweb/specify/func.py
@@ -35,27 +35,12 @@ class Func:
         return _generator(step)
 
     @staticmethod
-    def tap_call(
-        callback: Callable[[], O], generator: Generator[int, None, None]
-    ) -> Tuple[bool, O]:
-        init_1 = next(generator)
-        init_2 = next(generator)
-        step = init_2 - init_1
-        to_return = callback()
-        post = next(generator)
-        called = (post - init_2) != step
-        assert (
-            post - init_2
-        ) % step == 0, "(sanity check failed): made irregular generator"
-        return called, to_return
-
-    @staticmethod
     def remove_keys(source: Dict[I, O], callback: Callable[[O], bool]) -> Dict[I, O]:
         return {key: value for key, value in source.items() if callback(key, value)}
 
     @staticmethod
-    def is_not_empty(key, val):
-        return val
+    def is_not_empty(key, val) -> bool:
+        return bool(val)
 
     @staticmethod
     def first(source: List[Tuple[I, O]]) -> List[I]:
@@ -64,3 +49,14 @@ class Func:
     @staticmethod
     def second(source: List[Tuple[I, O]]) -> List[O]:
         return [second for (_, second) in source]
+
+class CustomRepr:
+    def __init__(self, func, new_repr):
+        self.new_repr = new_repr
+        self.func = func
+
+    def __call__(self, *args, **kwargs):
+        return None if self.func is None else self.func(*args, **kwargs)
+
+    def __repr__(self):
+        return self.new_repr

--- a/specifyweb/specify/parse.py
+++ b/specifyweb/specify/parse.py
@@ -9,7 +9,7 @@ from specifyweb.specify import models
 from specifyweb.specify.agent_types import agent_types
 from specifyweb.stored_queries.format import get_date_format, MYSQL_TO_YEAR, MYSQL_TO_MONTH
 from specifyweb.specify.datamodel import datamodel, Table, Field, Relationship
-from specifyweb.specify.uiformatters import get_uiformatter, UIFormatter, FormatMismatch
+from specifyweb.specify.uiformatters import get_uiformatter, UIFormatter, FormatMismatch, ScopedFormatter
 
 ParseFailureKey = Literal[
 'valueTooLong',
@@ -43,17 +43,15 @@ class ParseSucess(NamedTuple):
 ParseResult = Union[ParseSucess, ParseFailure]
 
 
-def parse_field(collection, table_name: str, field_name: str, raw_value: str, with_formatter = None) -> ParseResult:
+def parse_field(table_name: str, field_name: str, raw_value: str, formatter: Optional[ScopedFormatter] = None) -> ParseResult:
     table = datamodel.get_table_strict(table_name)
     field = table.get_field_strict(field_name)
-
-    formatter = get_uiformatter(collection, table_name, field_name) if with_formatter is None else with_formatter
 
     if field.is_relationship:
         return parse_integer(field.name, raw_value)
 
     if formatter is not None:
-        return parse_formatted(collection, formatter, table, field, raw_value)
+        return parse_formatted(formatter, table, field, raw_value)
 
     if is_latlong(table, field):
         return parse_latlong(field, raw_value)
@@ -170,17 +168,11 @@ def parse_date(table: Table, field_name: str, dateformat: str, value: str) -> Pa
     return ParseFailure('badDateFormat', {'value': value, 'format': dateformat})
 
 
-def parse_formatted(collection, uiformatter: UIFormatter, table: Table, field: Union[Field, Relationship], value: str) -> ParseResult:
+def parse_formatted(uiformatter: ScopedFormatter, table: Table, field: Union[Field, Relationship], value: str) -> ParseResult:
     try:
-        parsed = uiformatter.parse(value)
+        canonicalized = uiformatter(table, value)
     except FormatMismatch as e:
         return ParseFailure('formatMismatch', {'value': e.value, 'formatter': e.formatter})
-
-    if uiformatter.needs_autonumber(parsed):
-        canonicalized = uiformatter.autonumber_now(
-            collection, getattr(models, table.django_name), parsed)
-    else:
-        canonicalized = uiformatter.canonicalize(parsed)
 
     if hasattr(field, 'length') and len(canonicalized) > field.length:
         return ParseFailure('valueTooLong', {'maxLength': field.length})

--- a/specifyweb/specify/uiformatters.py
+++ b/specifyweb/specify/uiformatters.py
@@ -78,18 +78,6 @@ class FormatMismatch(ValueError):
         self.formatter = formatter
     pass
 
-class CustomRepr:
-    def __init__(self, func, new_repr):
-        self.new_repr = new_repr
-        self.func = func
-
-    def __call__(self, *args, **kwargs):
-        return None if self.func is None else self.func(*args, **kwargs)
-
-    def __repr__(self):
-        return self.new_repr
-
-
 class UIFormatter(NamedTuple):
     model_name: str
     field_name: str

--- a/specifyweb/stored_queries/execution.py
+++ b/specifyweb/stored_queries/execution.py
@@ -897,5 +897,5 @@ def build_query(
     internal_predicate = query.get_internal_filters()
     query = query.filter(internal_predicate)
 
-    logger.warning("query: %s", query.query)
+    logger.debug("query: %s", query.query)
     return query.query, order_by_exprs

--- a/specifyweb/workbench/upload/auditor.py
+++ b/specifyweb/workbench/upload/auditor.py
@@ -12,12 +12,12 @@ from specifyweb.specify.field_change_info import FieldChangeInfo
 
 logger = logging.getLogger(__name__)
 
-
+# TODO: Improve documentation of this
 class BatchEditPrefs(TypedDict):
     deferForMatch: bool
     deferForNullCheck: bool
 
-
+# TODO: Improve documentation of these props
 class AuditorProps(NamedTuple):
     allow_delete_dependents: bool
     batch_edit_prefs: BatchEditPrefs

--- a/specifyweb/workbench/upload/auditor.py
+++ b/specifyweb/workbench/upload/auditor.py
@@ -12,13 +12,19 @@ from specifyweb.specify.field_change_info import FieldChangeInfo
 
 logger = logging.getLogger(__name__)
 
-# TODO: Improve documentation of this
+
 class BatchEditPrefs(TypedDict):
+    # If set to True, it means the value from the database of a record
+    # is not used to match the record
     deferForMatch: bool
+    # If set to True, it means value from the database of a record 
+    # is not used to determine if the record is "null". If a record is Null
+    # it can possibly be deleted (depending on if it is a dependent or not)
     deferForNullCheck: bool
 
-# TODO: Improve documentation of these props
 class AuditorProps(NamedTuple):
+    # If set to True, dependents are allowed to be deleted.
+    # Otherwise, if they _can_ be deleted, they are instead force-saved.
     allow_delete_dependents: bool
     batch_edit_prefs: BatchEditPrefs
 

--- a/specifyweb/workbench/upload/column_options.py
+++ b/specifyweb/workbench/upload/column_options.py
@@ -1,19 +1,12 @@
 from typing import List, Dict, Any, NamedTuple, Union, Optional, Callable
 from typing_extensions import Literal
 
-from specifyweb.specify.uiformatters import UIFormatter
+from specifyweb.specify.uiformatters import UIFormatter, ScopedFormatter
 
 MatchBehavior = Literal["ignoreWhenBlank", "ignoreAlways", "ignoreNever"]
 
 # A single row in the workbench. Maps column names to values in the row
 Row = Dict[str, str]
-
-""" The field formatter (uiformatter) for the column is determined by one or 
-more values for other columns in the WorkBench row. 
-
-See https://github.com/specify/specify7/issues/5473 
-"""
-DeferredUIFormatter = Callable[[Row], Optional[UIFormatter]]
 
 class ColumnOptions(NamedTuple):
     column: str
@@ -32,7 +25,7 @@ class ExtendedColumnOptions(NamedTuple):
     matchBehavior: MatchBehavior
     nullAllowed: bool
     default: Optional[str]
-    uiformatter: Union[None, UIFormatter, DeferredUIFormatter]
+    uiformatter: Optional[ScopedFormatter]
     schemaitem: Any
     picklist: Any
     dateformat: Optional[str]

--- a/specifyweb/workbench/upload/scope_context.py
+++ b/specifyweb/workbench/upload/scope_context.py
@@ -1,0 +1,38 @@
+from typing import Dict, Any, Optional, Tuple, TypedDict
+
+from specifyweb.specify.uiformatters import UIFormatter
+
+# This stores some info we can reuse for caching. If this is empty, logic doesn't change, just it is slower.
+# IMPORTANT: In the current implementation, if there are no CRs or COTypes, it _automatically_ caches scoped upload plan
+# just once, and is it reused for all. This makes it efficient for most of the workbench / batch-edit cases, which don't rely on those.
+class ScopingCache(TypedDict):
+    # This stores UIFormatters for a collection's cotypes. We support collection relationships so we cannot assume
+    # that there's just one collection. This takes care of if because collection is used into the value dict.
+    cotypes: Dict[Any, Dict[str, Optional[UIFormatter]]]
+    # This stores UIFormatters for granular fields. This is used to handle the bad scenario where are in heavy-collection relationships
+    # or cotypes but want to reuse as much as other field based info
+    fields: Dict[Tuple[Any, str, str], Optional[UIFormatter]]
+    date_format: Optional[str]
+
+class ScopeContext(object):
+    cache: ScopingCache
+    _is_variable: bool = False
+
+    def __init__(self):
+        self.cache = {}
+        self.cache['cotypes'] = {}
+        self.cache['date_format'] = None
+        self.cache['fields'] = {}
+        
+    def set_is_variable(self):
+        # We "discover" whether the scoping is variable across the rows.
+        # If it is not variable, we can just perform it once and reuse.
+        # Otherwise, we'd need to apply again and again. Even in that case,
+        # we still look at cache for more granular things cached. Look at "ScopingCache" typed dict
+        # for more info. We don't bother calling this function when we know we aren't variable so we 
+        # don't need any parameter to this function.
+        self._is_variable = True
+
+    @property
+    def is_variable(self):
+        return self._is_variable

--- a/specifyweb/workbench/upload/scoping.py
+++ b/specifyweb/workbench/upload/scoping.py
@@ -266,13 +266,14 @@ def apply_scoping_to_uploadtable(
     ut: UploadTable, collection, context: Optional[ScopeContext] = None, row=None
 ) -> ScopedUploadTable:
     # IMPORTANT:
-    # Before this comment, collection is UNTRUSTED (you'd not necessarily have the correct side of a collection relationship)
+    # before this comment, collection is untrusted and unreliable
+    # (you'd not necessarily have the correct side of a collection relationship)
     
     table = datamodel.get_table_strict(ut.name)
     if ut.overrideScope is not None and isinstance(ut.overrideScope["collection"], int):
         collection = models.Collection.objects.get(id=ut.overrideScope["collection"])
     
-    # After this comment, collection CAN be trusted (even if you are in collection relationships)
+    # After this comment, collection can be trusted and is safe to use (even if you are in collection relationships)
     to_one_fields = get_to_one_fields(collection)
     adjuster = reduce(
         lambda accum, curr: _make_one_to_one(curr, accum),

--- a/specifyweb/workbench/upload/scoping.py
+++ b/specifyweb/workbench/upload/scoping.py
@@ -112,7 +112,6 @@ def extend_columnoptions(
         ) -> ExtendedColumnOptions:
 
     context = context or ScopeContext()
-    row = row or {}
     toOne = toOne or {}
     schema_items = models.Splocalecontaineritem.objects.filter(
         container__discipline=collection.discipline,
@@ -206,7 +205,7 @@ def get_or_defer_formatter(
         collection, 
         tablename: str, 
         fieldname: str, 
-        row: Row,
+        row: Optional[Row],
         _toOne: Dict[str, Uploadable],
         context: Optional[ScopeContext] = None,
         ) -> Optional[UIFormatter]:
@@ -242,8 +241,9 @@ def get_or_defer_formatter(
                 # I guess we could 
                 context.cache["cotypes"][collection] = co_type_cache
 
-            # At this point, we now look at the row.
-            formatter = co_type_cache.get(row[wb_col.column]) if row[wb_col.column] is not None else None
+            if row:
+                # At this point, we now look at the row.
+                formatter = co_type_cache.get(row[wb_col.column]) if row[wb_col.column] is not None else None
         
     
     if formatter is None:

--- a/specifyweb/workbench/upload/scoping.py
+++ b/specifyweb/workbench/upload/scoping.py
@@ -1,16 +1,18 @@
 from functools import reduce
-from typing import Dict, Any, Optional, Tuple, Callable, Union, cast, List
+from typing import Dict, Any, Optional, Tuple, Callable, TypedDict, Union, cast, List
 
 from specifyweb.specify.datamodel import datamodel, Table, is_tree_table
+from specifyweb.specify.func import CustomRepr
 from specifyweb.specify.load_datamodel import DoesNotExistError
 from specifyweb.specify import models
 from specifyweb.specify.uiformatters import get_uiformatter, get_catalognumber_format, UIFormatter
 from specifyweb.stored_queries.format import get_date_format
 from specifyweb.workbench.upload.predicates import SPECIAL_TREE_FIELDS_TO_SKIP
+from specifyweb.workbench.upload.scope_context import ScopeContext
 
-from .uploadable import ScopeGenerator, Uploadable, ScopedUploadable
+from .uploadable import Uploadable, ScopedUploadable, Row
 from .upload_table import UploadTable, ScopedUploadTable, ScopedOneToOneTable
-from .column_options import ColumnOptions, ExtendedColumnOptions, DeferredUIFormatter
+from .column_options import ColumnOptions, ExtendedColumnOptions
 from .treerecord import TreeRank, TreeRankRecord, TreeRecord, ScopedTreeRecord
 
 """ There are cases in which the scoping of records should be dependent on another record/column in a WorkBench dataset.
@@ -47,7 +49,6 @@ DEFERRED_SCOPING: Dict[Tuple[str, str], Tuple[str, str, str]] = {
         "leftsidecollection",
     ),
 }
-
 
 def scoping_relationships(collection, table: Table) -> Dict[str, int]:
     extra_static: Dict[str, int] = {}
@@ -98,8 +99,21 @@ def _make_one_to_one(fieldname: str, rest: AdjustToOnes) -> AdjustToOnes:
     return adjust_to_ones
 
 
-def extend_columnoptions(colopts: ColumnOptions, collection, tablename: str, fieldname: str, _toOne: Optional[Dict[str, Uploadable]] = None) -> ExtendedColumnOptions:
-    toOne = {} if _toOne is None else _toOne
+def extend_columnoptions(
+        colopts: ColumnOptions, 
+        # IMPORTANT: This collection CAN be trusted. That is, even if you are in a collection relationship,
+        # it'll always point to the correct collection (so whatever you want to use it for, you can trust it.)
+        collection, 
+        tablename: str, 
+        fieldname: str, 
+        row: Optional[Row] = None,
+        toOne: Optional[Dict[str, Uploadable]] = None,
+        context: Optional[ScopeContext] = None
+        ) -> ExtendedColumnOptions:
+
+    context = context or ScopeContext()
+    row = row or {}
+    toOne = toOne or {}
     schema_items = models.Splocalecontaineritem.objects.filter(
         container__discipline=collection.discipline,
         container__schematype=0,
@@ -120,20 +134,32 @@ def extend_columnoptions(colopts: ColumnOptions, collection, tablename: str, fie
             picklists[0] if len(collection_picklists) == 0 else collection_picklists[0]
         )
 
-    ui_formatter = get_uiformatter(collection, tablename, fieldname)
+
+    ui_formatter = get_or_defer_formatter(collection, tablename, fieldname, row, toOne, context)
     scoped_formatter = (
         None if ui_formatter is None else ui_formatter.apply_scope(collection)
     )
-    friendly_repr = f"{tablename}-{fieldname}-{collection}"
+
+    # REFACTOR: Make context always required and simply
+    date_format = context.cache['date_format']
+    date_format = get_date_format() if date_format is None else date_format
+    context.cache['date_format'] = date_format
+
+    # Technically this should contain info about cotypes but oh well
+    friendly_repr = f"{collection.collectionname}-{tablename}-{fieldname}"
+
     return ExtendedColumnOptions(
         column=colopts.column,
         matchBehavior=colopts.matchBehavior,
         nullAllowed=colopts.nullAllowed,
         default=colopts.default,
         schemaitem=schemaitem,
-        uiformatter=get_or_defer_formatter(collection, tablename, fieldname, toOne),
+        # Formatters are "scoped" here, that is, all they need is a value coming directly from the row.
+        uiformatter=(None if scoped_formatter is None else CustomRepr(scoped_formatter, friendly_repr)),
         picklist=picklist,
-        dateformat=get_date_format(),
+        # caching this, since it literally makes a database hit for every row.
+        # TODO: I don't think this should belong here in the first place, should probably be in context or something
+        dateformat=date_format
     )
 
 
@@ -143,7 +169,7 @@ def get_deferred_scoping(
     uploadable: UploadTable,
     row: Dict[str, Any],
     base_ut,
-    generator: ScopeGenerator,
+    context: Optional[ScopeContext]
 ):
     deferred_key = (table_name, key)
     deferred_scoping = DEFERRED_SCOPING.get(deferred_key, None)
@@ -160,6 +186,7 @@ def get_deferred_scoping(
         filter_value = row[related_column_name]
         filter_search = {filter_field: filter_value}
         related_table = datamodel.get_table_strict(related_key)
+        # TODO: Consider caching this??
         related = getattr(models, related_table.django_name).objects.get(
             **filter_search
         )
@@ -169,12 +196,20 @@ def get_deferred_scoping(
         collection_id = None
 
     # don't cache anymore, since values can be dependent on rows.
-    if generator is not None:
-        next(generator)  # a bit hacky
+    if context is not None:
+        context.set_is_variable()
+
     return uploadable._replace(overrideScope={"collection": collection_id})
 
 
-def get_or_defer_formatter(collection, tablename: str, fieldname: str, _toOne: Dict[str, Uploadable]) -> Union[None, UIFormatter, DeferredUIFormatter]:
+def get_or_defer_formatter(
+        collection, 
+        tablename: str, 
+        fieldname: str, 
+        row: Row,
+        _toOne: Dict[str, Uploadable],
+        context: Optional[ScopeContext] = None,
+        ) -> Optional[UIFormatter]:
     """ The CollectionObject -> catalogNumber format can be determined by the 
     CollectionObjectType -> catalogNumberFormatName for the CollectionObject
 
@@ -184,28 +219,61 @@ def get_or_defer_formatter(collection, tablename: str, fieldname: str, _toOne: D
     See https://github.com/specify/specify7/issues/5473 
     """
     toOne = {key.lower():value for key, value in _toOne.items()}
-    if tablename.lower() == 'collectionobject' and fieldname.lower() == 'catalognumber' and 'collectionobjecttype' in toOne.keys():
+
+    formatter: Optional[UIFormatter] = None
+    if tablename.lower() == 'collectionobject' and fieldname.lower() == 'catalognumber' and 'collectionobjecttype' in toOne:
         uploadTable = toOne['collectionobjecttype']
 
-        wb_col = cast(UploadTable, uploadTable).wbcols.get('name', None) if hasattr(uploadTable, 'wbcols') else None
-        optional_col_name = None if wb_col is None else wb_col.column
-        if optional_col_name is not None: 
-            col_name = cast(str, optional_col_name)
-            formats: Dict[str, Optional[UIFormatter]] = {cot.name: get_catalognumber_format(collection, cot.catalognumberformatname, None) for cot in collection.cotypes.all()}
-            return lambda row: formats.get(row[col_name], get_uiformatter(collection, tablename, fieldname))
+        wb_col: Optional[ColumnOptions] = cast(UploadTable, uploadTable).wbcols.get('name', None)
+        co_type_cache : Dict[str, Optional[UIFormatter]] = {}
+        # At this point, we are variable since we saw a co.
+        if context:
+            context.set_is_variable()
+            co_type_cache = context.cache["cotypes"].get(collection, {})
+        
+        if wb_col is not None:
+            # try deferring this expensive operation as much as possible. That is, until we see a value, don't bother fetching catalognumber formats.
+            if not co_type_cache:
+                co_type_cache = {
+                    cot.name: get_catalognumber_format(collection, cot.catalognumberformatname, None) 
+                    for cot in collection.cotypes.all()
+                }
+            if context and collection not in context.cache["cotypes"]:
+                # I guess we could 
+                context.cache["cotypes"][collection] = co_type_cache
 
-    return get_uiformatter(collection, tablename, fieldname)
+            # At this point, we now look at the row.
+            formatter = co_type_cache.get(row[wb_col.column]) if row[wb_col.column] is not None else None
+        
+    
+    if formatter is None:
+        # All the default cases.
+        key = (collection, tablename, fieldname)
+        if context:
+            formatter = context.cache["fields"].get(key, None)
+        
+        # cache hit failed
+        if formatter is None:
+            formatter = get_uiformatter(collection, tablename, fieldname)
+        
+        if context:
+            context.cache["fields"][key] = formatter
+
+    return formatter
 
 
 def apply_scoping_to_uploadtable(
-    ut: UploadTable, collection, generator: ScopeGenerator = None, row=None
+    ut: UploadTable, collection, context: Optional[ScopeContext] = None, row=None
 ) -> ScopedUploadTable:
+    # IMPORTANT:
+    # Before this comment, collection is UNTRUSTED (you'd not necessarily have the correct side of a collection relationship)
+    
     table = datamodel.get_table_strict(ut.name)
     if ut.overrideScope is not None and isinstance(ut.overrideScope["collection"], int):
         collection = models.Collection.objects.get(id=ut.overrideScope["collection"])
-
+    
+    # After this comment, collection CAN be trusted (even if you are in collection relationships)
     to_one_fields = get_to_one_fields(collection)
-
     adjuster = reduce(
         lambda accum, curr: _make_one_to_one(curr, accum),
         to_one_fields.get(table.name.lower(), []),
@@ -213,8 +281,8 @@ def apply_scoping_to_uploadtable(
     )
 
     apply_scoping = lambda key, value: get_deferred_scoping(
-        key, table.django_name, value, row, ut, generator
-    ).apply_scoping(collection, generator, row)
+        key, table.django_name, value, row, ut, context
+    ).apply_scoping(collection, context, row)
 
     to_ones = {
         key: adjuster(apply_scoping(key, value), key)
@@ -237,7 +305,7 @@ def apply_scoping_to_uploadtable(
     scoped_table = ScopedUploadTable(
         name=ut.name,
         wbcols={
-            f: extend_columnoptions(colopts, collection, table.name, f, ut.toOne)
+            f: extend_columnoptions(colopts, collection, table.name, f, row, ut.toOne, context)
             for f, colopts in ut.wbcols.items()
         },
         static=ut.static,

--- a/specifyweb/workbench/upload/tests/test_collection_types.py
+++ b/specifyweb/workbench/upload/tests/test_collection_types.py
@@ -1,0 +1,134 @@
+from jsonschema import validate # type: ignore
+
+from specifyweb.workbench.upload.tests.base import UploadTestsBase
+from ..upload_plan_schema import schema, parse_plan
+from specifyweb.specify.models import Collectionobjecttype, Collectionobject
+from ..scope_context import ScopeContext
+from ..upload import do_upload
+from ..upload_result import UploadResult, Matched, NullRecord
+
+class CollectionObjectTypeTests(UploadTestsBase):
+
+    def setUp(self):
+        super().setUp()
+        Collectionobjecttype.objects.all().delete()
+        self.cot_1 = Collectionobjecttype.objects.create(
+            name="cot_1",
+            catalognumberformatname  = "CatalogNumberNumeric",
+            collection = self.collection,
+            taxontreedef = self.taxontreedef,
+        )
+        self.cot_2 = Collectionobjecttype.objects.create(
+            name="cot_2",
+            catalognumberformatname  = "CatalogNumberAlphaNumByYear",
+            collection = self.collection,
+            taxontreedef = self.taxontreedef,
+        )
+        self.cot_3 = Collectionobjecttype.objects.create(
+            name="cot_3",
+            # For this case, making sure it goes to default.
+            catalognumberformatname  = None,
+            collection = self.collection,
+            taxontreedef = self.taxontreedef,
+        )
+
+    def get_basic_plan(self):
+        return dict(
+            baseTableName = 'Collectionobject',
+            uploadable = {
+                'uploadTable': dict(
+                    wbcols = {
+                        'catalognumber': 'cn'
+                    },
+                    static = {},
+                    toOne = {
+                        "collectionobjecttype": {
+                            "uploadTable": dict(
+                                wbcols = {
+                                    "name": "COTName"
+                                },
+                                static = {},
+                                toOne = {},
+                                toMany = {}
+                            )
+                        }
+                    },
+                    toMany = {}
+                )
+            }
+        )
+        
+
+    def test_basic_parsing(self) -> None:
+        json = self.get_basic_plan()
+        validate(json, schema)
+    
+    def test_no_caching(self) -> None:
+        context = ScopeContext()
+        plan = parse_plan(self.get_basic_plan()).apply_scoping(
+            self.collection, 
+            context
+        )
+        self.assertTrue(context.is_variable, "caching is not possible")
+
+    def test_cotype_catnum(self) -> None:
+        plan = parse_plan(self.get_basic_plan())
+        rows = [
+            dict(
+                cn = "1234",
+                COTName = "cot_1"
+            ),
+            dict(
+                cn = "5678",
+                COTName="cot_1"
+            ),
+            dict(
+                cn = "2025-654321",
+                COTName="cot_2"
+            ),
+            dict(
+                cn = "2025-002898",
+                COTName="cot_2"
+            ),
+            dict(
+                cn = "895679",
+                # goto default
+                COTName="cot_3"
+            ),
+            dict(
+                cn = "895678",
+                # goto default
+                COTName="cot_3"
+            ),
+            dict(
+                cn = "898",
+                # this will also be default!!
+                COTName = ""
+            )
+        ]
+        
+        results = do_upload(self.collection, rows, plan, self.agent.id)
+        # Make sure cat nums are seet
+        self.assertEqual(self._get_co_catnum(results[0]), "000001234")
+        self.assertEqual(self._get_co_catnum(results[1]), "000005678")
+        self.assertEqual(self._get_co_catnum(results[2]), "2025-654321")
+        self.assertEqual(self._get_co_catnum(results[3]), "2025-002898")
+        self.assertEqual(self._get_co_catnum(results[4]), "000895679")
+        self.assertEqual(self._get_co_catnum(results[5]), "000895678")
+        self.assertEqual(self._get_co_catnum(results[6]), "000000898")
+
+        # Make sure COTypes are always matched (except last one)
+        for i in range(6):
+            self.enforce_cot_matched(results[i])
+
+        self.assertIsInstance(results[-1].toOne['collectionobjecttype'].record_result, NullRecord)
+
+    def enforce_cot_matched(self, record_result: UploadResult):
+        self.assertIsInstance(record_result.toOne['collectionobjecttype'].record_result, Matched)
+
+    def _get_co_catnum(self, record_result: UploadResult):
+        return Collectionobject.objects.get(
+            # whatever, if this fails, we know we failed our test anyways
+            id=int(str(record_result.get_id())),
+            collection=self.collection
+            ).catalognumber

--- a/specifyweb/workbench/upload/tests/testuploading.py
+++ b/specifyweb/workbench/upload/tests/testuploading.py
@@ -1370,7 +1370,7 @@ class UploadTests(UploadTestsBase):
         ).apply_scoping(self.collection)
         row = next(reader)
         bt = tree_record.bind(
-            self.collection, row, None, Auditor(self.collection, DEFAULT_AUDITOR_PROPS, auditlog)
+            row, None, Auditor(self.collection, DEFAULT_AUDITOR_PROPS, auditlog)
         )
         assert isinstance(bt, BoundTreeRecord)
         to_upload, matched = bt._match(bt._to_match())
@@ -1440,7 +1440,7 @@ class UploadTests(UploadTestsBase):
         # )
 
         bt = tree_record.bind(
-            self.collection, row, None, Auditor(self.collection, DEFAULT_AUDITOR_PROPS, None)
+            row, None, Auditor(self.collection, DEFAULT_AUDITOR_PROPS, None)
         )
         assert isinstance(bt, BoundTreeRecord)
         to_upload, matched = bt._match(bt._to_match())
@@ -1461,7 +1461,7 @@ class UploadTests(UploadTestsBase):
         )
 
         bt = tree_record.bind(
-            self.collection, row, None, Auditor(self.collection, DEFAULT_AUDITOR_PROPS, None)
+            row, None, Auditor(self.collection, DEFAULT_AUDITOR_PROPS, None)
         )
         assert isinstance(bt, BoundTreeRecord)
         upload_result = bt.process_row()
@@ -1473,7 +1473,7 @@ class UploadTests(UploadTestsBase):
         self.assertEqual(uploaded.parent.id, state.id)
 
         bt = tree_record.bind(
-            self.collection, row, None, Auditor(self.collection, DEFAULT_AUDITOR_PROPS, None)
+            row, None, Auditor(self.collection, DEFAULT_AUDITOR_PROPS, None)
         )
         assert isinstance(bt, BoundTreeRecord)
         to_upload, matched = bt._match(bt._to_match())
@@ -1486,7 +1486,7 @@ class UploadTests(UploadTestsBase):
         )
 
         bt = tree_record.bind(
-            self.collection, row, None, Auditor(self.collection, DEFAULT_AUDITOR_PROPS, None)
+            row, None, Auditor(self.collection, DEFAULT_AUDITOR_PROPS, None)
         )
         assert isinstance(bt, BoundTreeRecord)
         upload_result = bt.process_row()

--- a/specifyweb/workbench/upload/uploadable.py
+++ b/specifyweb/workbench/upload/uploadable.py
@@ -68,13 +68,12 @@ class DisambiguationInfo(Protocol):
 class ScopedUploadable(Protocol):
     def disambiguate(self, disambiguation: Disambiguation) -> "ScopedUploadable": ...
 
+    # We don't pass in collection in bind() anymore since it can cause
+    # unintended behaviour in the case of collection relationship.
+    # Previously, formatters used to depend on collection, but they are now
+    # instead determined in apply_scoping (where the usage of collection is safer)
     def bind(
         self,
-        # STOP. Think more before allowing collection in bind.
-        # This is because collection can be arbitrary based on collection relationships.
-        # You may be in a collection relationship (not necessarily even CR as the basetable)
-        # You probably want to move all the relevant logic to apply_scoping (where the usage of collection is safe)
-        # collection,
         row: Row,
         uploadingAgentId: int,
         auditor: Auditor,


### PR DESCRIPTION
1. Refactors CollectionType-based CatNo Numbering a little bit
2. Removes the need to passing bind() and adds code documentation why it's not ideal to do so.
3. Adds unit tests for CollectionType-based numbering 

I'm pretty sure unit tests would fail since I'm not in org. However, they do run fine locally.

<!--
> [!WARNING]  
> This PR affects database migrations. See [migration testing instructions](https://specify.github.io/testing/pull_requests.html#prs-tagged-with-label-migration).
-->

### Checklist

- [x] Self-review the PR after opening it to make sure the changes look good and
      self-explanatory (or properly documented)
- [x] Add automated tests
- [ ] Add relevant issue to release milestone
- [ ] Add relevant documentation (Tester - Dev)
- [ ] Add a reverse migration if a migration is present in the PR

### Testing instructions

<!-- What are the steps to verify the fixes/changes in this PR? -->
<!-- Can part of that be replaced by automated tests? -->
