### PR TITLE
Update deprecated navigator.appVersion function

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -49,7 +49,7 @@ RUN apt-get update \
         curl \
         git \
         libsasl2-dev \
-        libsasl2-modules-gssapi-mit \
+        libsasl2-modules \
         libldap2-dev \
         libssl-dev \
         libgmp-dev \

--- a/specifyweb/frontend/js_src/lib/components/Preferences/UserDefinitions.tsx
+++ b/specifyweb/frontend/js_src/lib/components/Preferences/UserDefinitions.tsx
@@ -64,7 +64,7 @@ const isDarkMode = ({
   isRedirecting,
 }: PreferencesVisibilityContext): boolean => isDarkMode || isRedirecting;
 
-const altKeyName = globalThis.navigator?.appVersion?.includes('Mac')
+const altKeyName = globalThis.navigator?.userAgent?.includes('Mac')
   ? 'Option'
   : 'Alt';
 

--- a/specifyweb/frontend/js_src/lib/components/Preferences/UserDefinitions.tsx
+++ b/specifyweb/frontend/js_src/lib/components/Preferences/UserDefinitions.tsx
@@ -64,7 +64,7 @@ const isDarkMode = ({
   isRedirecting,
 }: PreferencesVisibilityContext): boolean => isDarkMode || isRedirecting;
 
-// navigator may not be defined in some environments, like non-browser environments
+// Navigator may not be defined in some environments, like non-browser environments
 const altKeyName = typeof navigator !== 'undefined' && navigator?.userAgent?.includes('Mac')
   ? 'Option'
   : 'Alt';

--- a/specifyweb/frontend/js_src/lib/components/Preferences/UserDefinitions.tsx
+++ b/specifyweb/frontend/js_src/lib/components/Preferences/UserDefinitions.tsx
@@ -64,7 +64,7 @@ const isDarkMode = ({
   isRedirecting,
 }: PreferencesVisibilityContext): boolean => isDarkMode || isRedirecting;
 
-const altKeyName = globalThis.navigator?.appVersion.includes('Mac')
+const altKeyName = globalThis.navigator?.appVersion?.includes('Mac')
   ? 'Option'
   : 'Alt';
 

--- a/specifyweb/frontend/js_src/lib/components/Preferences/UserDefinitions.tsx
+++ b/specifyweb/frontend/js_src/lib/components/Preferences/UserDefinitions.tsx
@@ -64,7 +64,8 @@ const isDarkMode = ({
   isRedirecting,
 }: PreferencesVisibilityContext): boolean => isDarkMode || isRedirecting;
 
-const altKeyName = globalThis.navigator?.userAgent?.includes('Mac')
+// navigator may not be defined in some environments, like non-browser environments
+const altKeyName = typeof navigator !== 'undefined' && navigator?.userAgent?.includes('Mac')
   ? 'Option'
   : 'Alt';
 


### PR DESCRIPTION
Fixes #6129

It seems this line is causing the weblate localization workflow to fail:
https://github.com/specify/specify7/blob/95786328c26f610d7066de9a5c97ffc774fe3af0/specifyweb/frontend/js_src/lib/components/Preferences/UserDefinitions.tsx#L67-L69

Example error: https://github.com/specify/specify7/actions/runs/12128718100/job/33815688425

The `navigator.appVersion` function has been deprecated and can be replaced with `navigator.userAgent` in order to get platform information, like the user's OS.  This change will also handle both browser and non-browser environments.

Once this is merged into production, the weblate localization workflow will run again and we can see if any other issues occur.

### Checklist

- [x] Self-review the PR after opening it to make sure the changes look good and
      self-explanatory (or properly documented)

### Testing instructions

No testing now, need to merge into production and test the weblate localization workflows.
