### PR TITLE
Block save on invalid determinations

### DIFF
--- a/specifyweb/frontend/js_src/lib/components/DataModel/__tests__/businessRules.test.ts
+++ b/specifyweb/frontend/js_src/lib/components/DataModel/__tests__/businessRules.test.ts
@@ -131,6 +131,41 @@ describe('Collection Object business rules', () => {
   };
   overrideAjax(otherCollectionObjectTypeUrl, otherCollectionObjectType);
 
+  test('CollectionObject -> determinations: Save blocked when a determination does not belong to COT tree', async () => {
+    const collectionObject = getBaseCollectionObject();
+    collectionObject.set(
+      'collectionObjectType',
+      getResourceApiUrl('CollectionObjectType', 1)
+    );
+
+    const determination =
+      collectionObject.getDependentResource('determinations')?.models[0];
+
+    const { result } = renderHook(() =>
+      useSaveBlockers(determination, tables.Determination.getField('Taxon'))
+    );
+
+    await act(async () => {
+      await collectionObject?.businessRuleManager?.checkField(
+        'collectionObjectType'
+      );
+    });
+    expect(result.current[0]).toStrictEqual([
+      resourcesText.invalidDeterminationTaxon(),
+    ]);
+
+    collectionObject.set(
+      'collectionObjectType',
+      getResourceApiUrl('CollectionObjectType', 2)
+    );
+    await act(async () => {
+      await collectionObject?.businessRuleManager?.checkField(
+        'collectionObjectType'
+      );
+    });
+    expect(result.current[0]).toStrictEqual([]);
+  });
+
   test('CollectionObject -> determinations: New determinations are current by default', async () => {
     const collectionObject = getBaseCollectionObject();
     const determinations =

--- a/specifyweb/frontend/js_src/lib/components/DataModel/businessRuleDefs.ts
+++ b/specifyweb/frontend/js_src/lib/components/DataModel/businessRuleDefs.ts
@@ -174,7 +174,7 @@ export const businessRuleDefs: MappedBusinessRuleDefs = {
           return;
 
         const taxons = await Promise.all(
-          determinations.models.map((det) => det.rgetPromise('taxon'))
+          determinations.models.map(async (det) => det.rgetPromise('taxon'))
         );
         const coType = await resource.rgetPromise('collectionObjectType');
         const coTypeTreeDef = coType.get('taxonTreeDef');

--- a/specifyweb/frontend/js_src/lib/components/DataModel/businessRuleUtils.ts
+++ b/specifyweb/frontend/js_src/lib/components/DataModel/businessRuleUtils.ts
@@ -7,6 +7,7 @@ export const CURRENT_DETERMINATION_KEY = 'determination-isCurrent';
 export const COG_TOITSELF = 'cog-toItself';
 export const PARENTCOG_KEY = 'cog-parentCog';
 export const COG_PRIMARY_KEY = 'cog-isPrimary';
+export const DETERMINATION_TAXON_KEY = 'determination-Taxon';
 
 /**
  *

--- a/specifyweb/frontend/js_src/lib/localization/resources.ts
+++ b/specifyweb/frontend/js_src/lib/localization/resources.ts
@@ -846,4 +846,8 @@ export const resourcesText = createDictionary({
     'en-us':
       'A Consolidated Collection Object Group must have a primary Collection Object child',
   },
+  invalidDeterminationTaxon: {
+    'en-us':
+      'Determination does not belong to the taxon tree associated with the Collection Object Type',
+  },
 } as const);


### PR DESCRIPTION
Fixes #6097

There isn't a way right now to trigger an interactive dialog through business rules (which is where we track field changes) and so I've added a save blocker to Determination -> Taxon if the COT changes and determinations become invalid. Since we have a working Taxon QCBX filter and all migrations work fine (🤞) the save blocker should be a lot less strict and we shouldn't be seeing issues like #5299 and #5322 again. 

The implementation this time around is also different - we're checking validity of determinations only when COT changes instead of checking it when adding a Taxon, so ideally it should catch all possible cases of having an invalid determination

<!--
> [!WARNING]  
> This PR affects database migrations. See [migration testing instructions](https://specify.github.io/testing/pull_requests.html#prs-tagged-with-label-migration).
-->

### Checklist

- [x] Self-review the PR after opening it to make sure the changes look good and
      self-explanatory (or properly documented)
- [x] Add automated tests
- [x] Add relevant issue to release milestone
- [ ] Add relevant documentation (Tester - Dev)
- [ ] Add a reverse migration if a migration is present in the PR

### Testing instructions

<!-- What are the steps to verify the fixes/changes in this PR? -->
<!-- Can part of that be replaced by automated tests? -->
- Create a CO
- Add a valid determination
- Change COType
- [ ] Verify there's a save blocker on invalid determination(s)
- Test different ways of resolving the save blocker
  - Enter a valid Taxon for the new COType
    - [ ] Verify save blocker is removed
  - Change back to original COType
    - [ ] Verify save blocker is removed 