### PR TITLE
Add Series Option to QB

### DIFF
--- a/specifyweb/frontend/js_src/lib/components/DataModel/__tests__/helpers.test.ts
+++ b/specifyweb/frontend/js_src/lib/components/DataModel/__tests__/helpers.test.ts
@@ -123,6 +123,7 @@ describe('serializeResource', () => {
       remarks: null,
       searchSynonymy: null,
       selectDistinct: null,
+      selectSeries: null,
       smushed: null,
       specifyUser: null,
       sqlStr: null,

--- a/specifyweb/frontend/js_src/lib/components/DataModel/types.ts
+++ b/specifyweb/frontend/js_src/lib/components/DataModel/types.ts
@@ -5291,6 +5291,7 @@ export type SpQuery = {
     readonly remarks: string | null;
     readonly searchSynonymy: boolean | null;
     readonly selectDistinct: boolean | null;
+    readonly selectSeries: boolean | null;
     readonly smushed: boolean | null;
     readonly sqlStr: string | null;
     readonly timestampCreated: string;

--- a/specifyweb/frontend/js_src/lib/components/Forms/__tests__/DeleteButton.test.tsx
+++ b/specifyweb/frontend/js_src/lib/components/Forms/__tests__/DeleteButton.test.tsx
@@ -105,6 +105,7 @@ overrideAjax(
       resource_uri: undefined,
       searchsynonymy: null,
       selectdistinct: false,
+      selectseries: false,
       smushed: null,
       specifyuser: '/api/specify/specifyuser/2/',
       sqlstr: null,

--- a/specifyweb/frontend/js_src/lib/components/QueryBuilder/Toolbar.tsx
+++ b/specifyweb/frontend/js_src/lib/components/QueryBuilder/Toolbar.tsx
@@ -13,6 +13,8 @@ export function QueryToolbar({
   showHiddenFields,
   tableName,
   isDistinct,
+  isSeries,
+  showSeries,
   onToggleHidden: handleToggleHidden,
   onToggleDistinct: handleToggleDistinct,
   onRunCountOnly: handleRunCountOnly,
@@ -21,6 +23,8 @@ export function QueryToolbar({
   readonly showHiddenFields: boolean;
   readonly tableName: keyof Tables;
   readonly isDistinct: boolean;
+  readonly isSeries: boolean;
+  readonly showSeries: boolean;
   readonly onToggleHidden: (value: boolean) => void;
   readonly onToggleDistinct: () => void;
   readonly onRunCountOnly: () => void;
@@ -38,6 +42,15 @@ export function QueryToolbar({
       <span className="-ml-2 flex-1" />
       {hasPermission('/querybuilder/query', 'execute') && (
         <>
+          {showSeries && (
+            <Label.Inline>
+              <Input.Checkbox
+                checked={isSeries}
+                onChange={handleToggleSeries}
+              />
+              {queryText.series()}
+            </Label.Inline>
+          )}
           {/*
            * Query Distinct for trees is disabled because of
            * https://github.com/specify/specify7/pull/1019#issuecomment-973525594

--- a/specifyweb/frontend/js_src/lib/components/QueryBuilder/Wrapped.tsx
+++ b/specifyweb/frontend/js_src/lib/components/QueryBuilder/Wrapped.tsx
@@ -94,6 +94,7 @@ function Wrapped({
   readonly onChange?: (props: {
     readonly fields: RA<SerializedResource<SpQueryField>>;
     readonly isDistinct: boolean | null;
+    readonly isSeries: boolean | null;
   }) => void;
 }): JSX.Element {
   const [query, setQuery] = useResource(queryResource);
@@ -157,8 +158,9 @@ function Wrapped({
     handleChange?.({
       fields: unParseQueryFields(state.baseTableName, state.fields),
       isDistinct: query.selectDistinct,
+      isSeries: query.selectSeries,
     });
-  }, [state, query.selectDistinct]);
+  }, [state, query.selectDistinct, query.selectSeries]);
 
   /**
    * If tried to save a query, enforce the field length limit for the
@@ -295,6 +297,10 @@ function Wrapped({
   const resultsRef = React.useRef<RA<QueryResultRow | undefined> | undefined>(
     undefined
   );
+
+  const showSeries =
+    table.name === 'CollectionObject' &&
+    state.fields.some((field) => field.mappingPath[0] === 'catalogNumber');
 
   return treeRanksLoaded ? (
     <ReadOnlyContext.Provider value={isReadOnly}>
@@ -556,6 +562,8 @@ function Wrapped({
               />
               <QueryToolbar
                 isDistinct={query.selectDistinct ?? false}
+                isSeries={query.selectSeries ?? false}
+                showSeries={showSeries}
                 showHiddenFields={showHiddenFields}
                 tableName={table.name}
                 onRunCountOnly={(): void => runQuery('count')}
@@ -568,6 +576,12 @@ function Wrapped({
                   setQuery({
                     ...query,
                     selectDistinct: !(query.selectDistinct ?? false),
+                  })
+                }
+                onToggleSeries={(): void =>
+                  setQuery({
+                    ...query,
+                    selectSeries: !(query.selectSeries ?? false),
                   })
                 }
                 onToggleHidden={setShowHiddenFields}

--- a/specifyweb/frontend/js_src/lib/components/QueryBuilder/index.tsx
+++ b/specifyweb/frontend/js_src/lib/components/QueryBuilder/index.tsx
@@ -97,6 +97,7 @@ export function createQuery(
   query.set('contextName', table.name);
   query.set('contextTableId', table.tableId);
   query.set('selectDistinct', false);
+  query.set('selectSeries', false);
   query.set('countOnly', false);
   query.set('formatAuditRecIds', false);
   query.set('specifyUser', userInformation.resource_uri);

--- a/specifyweb/frontend/js_src/lib/components/QueryComboBox/helpers.ts
+++ b/specifyweb/frontend/js_src/lib/components/QueryComboBox/helpers.ts
@@ -35,6 +35,7 @@ export function makeComboBoxQuery({
   query.set('contextName', table.name);
   query.set('contextTableId', table.tableId);
   query.set('selectDistinct', false);
+  query.set('selectSeries', false);
   query.set('countOnly', false);
   query.set('specifyUser', userInformation.resource_uri);
   query.set('isFavorite', false);

--- a/specifyweb/frontend/js_src/lib/localization/query.ts
+++ b/specifyweb/frontend/js_src/lib/localization/query.ts
@@ -303,6 +303,9 @@ export const queryText = createDictionary({
     'uk-ua': 'Виразний',
     'de-ch': 'Unterscheidbar',
   },
+  series: {
+    'en-us': 'Series',
+  },
   createCsv: {
     'en-us': 'Create CSV',
     'ru-ru': 'Создать CSV-файл',

--- a/specifyweb/stored_queries/execution.py
+++ b/specifyweb/stored_queries/execution.py
@@ -130,7 +130,6 @@ def filter_by_collection(model, query, collection):
     return query
 
 
-
 EphemeralField = namedtuple('EphemeralField', "stringId isRelFld operStart startValue isNot isDisplay sortType formatName isStrict")
 
 def field_specs_from_json(json_fields):
@@ -405,6 +404,7 @@ def run_ephemeral_query(collection, user, spquery):
     offset = spquery.get('offset', 0)
     recordsetid = spquery.get('recordsetid', None)
     distinct = spquery['selectdistinct']
+    series = spquery.get('selectseries', None)
     tableid = spquery['contexttableid']
     count_only = spquery['countonly']
     try:
@@ -414,7 +414,7 @@ def run_ephemeral_query(collection, user, spquery):
 
     with models.session_context() as session:
         field_specs = field_specs_from_json(spquery['fields'])
-        return execute(session, collection, user, tableid, distinct, count_only,
+        return execute(session, collection, user, tableid, distinct, series, count_only,
                        field_specs, limit, offset, recordsetid, formatauditobjs=format_audits)
 
 def augment_field_specs(field_specs, formatauditobjs=False):
@@ -545,24 +545,62 @@ def return_loan_preps(collection, user, agent, data):
                 ])
         return to_return
 
-def execute(session, collection, user, tableid, distinct, count_only, field_specs, limit, offset, recordsetid=None, formatauditobjs=False):
+def execute(session, collection, user, tableid, distinct, series, count_only,
+            field_specs, limit, offset, recordsetid=None, formatauditobjs=False):
     "Build and execute a query, returning the results as a data structure for json serialization"
 
     set_group_concat_max_len(session.connection())
-    query, order_by_exprs = build_query(session, collection, user, tableid, field_specs, recordsetid=recordsetid, formatauditobjs=formatauditobjs, distinct=distinct)
+    query, order_by_exprs = build_query(session, collection, user, tableid, field_specs, recordsetid=recordsetid,
+                                        formatauditobjs=formatauditobjs, distinct=distinct, series=series)
+    from specifyweb.specify.utils import log_sqlalchemy_query; log_sqlalchemy_query(query) # Debugging
 
     if count_only:
         return {'count': query.count()}
     else:
         logger.debug("order by: %s", order_by_exprs)
+        if series: # TODO: add - and catalog_number_field exists, and id_field doen't exist
+            query = query.order_by('catalognumber')
+        
         query = query.order_by(*order_by_exprs).offset(offset)
+        
         if limit:
             query = query.limit(limit)
+
+        # def is_consecutive(a, b):
+        #     return int(b) == int(a) + 1
+        
+        # newListQuery = []
+        if series:
+            # return {'results': series_post_query(query)}
+            return {'results': series_post_query_func(query)}
+            # resultsFormList = list(query)
+
+            # for item in resultsFormList:
+            #     #need to dertermine which item is the cat number and which is the id than group
+            #     fields = item[1:]  # Get all fields except the first one
+            #     catalog_numbers = item[0].split(',')
+            #     if len(catalog_numbers) == 1:
+            #         newListQuery.append(item)
+            #         continue
+
+            #     grouped_numbers = [catalog_numbers[0]]
+            #     for i in range(1, len(catalog_numbers)):
+            #         if is_consecutive(catalog_numbers[i - 1], catalog_numbers[i]):
+            #             grouped_numbers[-1] = f"{grouped_numbers[-1]},{catalog_numbers[i]}"
+            #         else:
+            #             newListQuery.append((grouped_numbers.pop(), *fields))
+            #             grouped_numbers.append(catalog_numbers[i])
+
+            #     if grouped_numbers:
+            #         newListQuery.append((grouped_numbers.pop(), *fields))
+
+        # print(newListQuery)
 
         return {'results': list(query)}
 
 def build_query(session, collection, user, tableid, field_specs,
-                recordsetid=None, replace_nulls=False, formatauditobjs=False, distinct=False, implicit_or=True):
+                recordsetid=None, replace_nulls=False, formatauditobjs=False,
+                distinct=False, series=False, implicit_or=True):
     """Build a sqlalchemy query using the QueryField objects given by
     field_specs.
 
@@ -587,18 +625,31 @@ def build_query(session, collection, user, tableid, field_specs,
     replace_nulls = if True, replace null values with ""
 
     distinct = if True, group by all display fields, and return all record IDs associated with a row
+
+    series = (only for Collection Objects) if True, group by all display fields.
+    Group consecutive catalog numbers together and return all record IDs associated with each grouped row.
     """
     model = models.models_by_tableid[tableid]
     id_field = getattr(model, model._id)
+    catalog_number_field = model.catalogNumber if hasattr(model, 'catalogNumber') else None
 
     field_specs = [apply_absolute_date(field_spec) for field_spec in field_specs]
     field_specs = [apply_specify_user_name(field_spec, user) for field_spec in field_specs]
 
-
+    query_construct_query = None
+    if series and catalog_number_field:
+        # query_construct_query = session.query(func.group_concat(id_field.distinct(), separator=','))
+        query_construct_query = session.query(func.group_concat(id_field.distinct(), separator=','),
+                                              func.group_concat(catalog_number_field.distinct(), separator=','))
+    elif distinct:
+        query_construct_query = session.query(func.group_concat(id_field.distinct(), separator=','))
+    else:
+        query_construct_query = query_construct_query = session.query(id_field)
+    
     query = QueryConstruct(
         collection=collection,
         objectformatter=ObjectFormatter(collection, user, replace_nulls),
-        query=session.query(func.group_concat(id_field.distinct(), separator=',')) if distinct else session.query(id_field),
+        query=query_construct_query,
     )
 
     tables_to_read = set([
@@ -626,15 +677,22 @@ def build_query(session, collection, user, tableid, field_specs,
     order_by_exprs = []
     selected_fields = []
     predicates_by_field = defaultdict(list)
-    #augment_field_specs(field_specs, formatauditobjs)
+    # augment_field_specs(field_specs, formatauditobjs)
+    # catalog_number_field = None
     for fs in field_specs:
         sort_type = SORT_TYPES[fs.sort_type]
+
+        if series and fs.fieldspec.get_field().name.lower() == 'catalognumber':
+            continue
 
         query, field, predicate = fs.add_to_query(query, formatauditobjs=formatauditobjs)
         if fs.display:
             formatted_field = query.objectformatter.fieldformat(fs, field)
             query = query.add_columns(formatted_field)
             selected_fields.append(formatted_field)
+
+        # if hasattr(field, 'key') and field.key.lower() == 'catalognumber':
+        #     catalog_number_field = formatted_field
 
         if sort_type is not None:
             order_by_exprs.append(sort_type(field))
@@ -656,7 +714,21 @@ def build_query(session, collection, user, tableid, field_specs,
         where = reduce(sql.and_, (p for ps in predicates_by_field.values() for p in ps))
         query = query.filter(where)
 
-    if distinct:
+    # if series:
+    #     selected_fields_without_cat_number = []
+    #     for field in selected_fields:
+    #         if hasattr(field, 'clause') and hasattr(field.clause, 'key') and field.clause.key == 'CatalogNumber':
+    #             continue
+    #         selected_fields_without_cat_number.append(field)
+
+    #     if catalog_number_field is not None:
+    #         query = query.add_columns(
+    #             func.group_concat(catalog_number_field, separator=',')
+    #         )
+
+    if series:
+        query = group_by_displayed_fields(query, selected_fields, ignore_cat_num=True)
+    elif distinct:
         query = group_by_displayed_fields(query, selected_fields)
 
     internal_predicate = query.get_internal_filters()
@@ -664,3 +736,107 @@ def build_query(session, collection, user, tableid, field_specs,
 
     logger.warning("query: %s", query.query)
     return query.query, order_by_exprs
+
+def series_post_query(query):
+    def is_consecutive(a, b):
+        return int(b) == int(a) + 1
+
+    newListQuery = []
+    resultsFormList = list(query)
+
+    for item in resultsFormList:
+        #need to dertermine which item is the cat number and which is the id than group
+        fields = item[1:]  # Get all fields except the first one
+        catalog_numbers = item[0].split(',')
+        if len(catalog_numbers) == 1:
+            newListQuery.append(item)
+            continue
+
+        grouped_numbers = [catalog_numbers[0]]
+        for i in range(1, len(catalog_numbers)):
+            if is_consecutive(catalog_numbers[i - 1], catalog_numbers[i]):
+                grouped_numbers[-1] = f"{grouped_numbers[-1]},{catalog_numbers[i]}"
+            else:
+                newListQuery.append((grouped_numbers.pop(), *fields))
+                grouped_numbers.append(catalog_numbers[i])
+
+        if grouped_numbers:
+            newListQuery.append((grouped_numbers.pop(), *fields))
+
+    return newListQuery
+
+def find_consecutive_ranges(lst):
+    def group_consecutives(acc, x):
+        if not acc or acc[-1][-1] + 1 != x:
+            acc.append([x])
+        else:
+            acc[-1].append(x)
+        return acc
+    
+    grouped = reduce(group_consecutives, lst, [])
+    
+    return [f"{g[0]:04d} - {g[-1]:04d}" if len(g) > 1 else f"{g[0]:04d}" for g in grouped]
+
+def process_group_by_result(group_by_query_result, id_col_index = 0, group_col_index = 1):
+    def parse_numbers(num_str):
+        return sorted(map(int, filter(None, map(str.strip, num_str.replace(',', ' ').split()))))
+    
+    def format_record(record):
+        id_part = record[id_col_index]
+        id_values = id_part.split(',')
+        
+        num_ranges = find_consecutive_ranges(parse_numbers(record[group_col_index]))
+        formatted_records = [[id_values[0]] + [num_ranges[0]] + list(record[2:])] if len(id_values) == 1 else []
+        
+        if len(num_ranges) > 1:
+            for num_range in num_ranges[1:]:
+                formatted_records.append([id_values.pop()] + [num_range] + list(record[2:]))
+        
+        return formatted_records if formatted_records else [[id_part] + [num_ranges[0]] + list(record[2:])]
+    
+    formatted_records = [format_record(record[:]) for record in group_by_query_result]
+    
+    result = [item for sublist in formatted_records for item in sublist]
+    result.sort(key=lambda x: int(x[1].split(' - ')[0]))
+    
+    return result
+
+def series_post_query_func(query, co_id_col_index = 0, co_cat_num_col_index = 1):
+    return process_group_by_result(list(query), co_id_col_index, co_cat_num_col_index)
+
+def series_post_query_new(query):
+
+    query_results = list(query)
+    series_query_results = []
+
+    input = [["0012,0013,0014", "SomeText1", "Vial"],
+     ["0015", "OtherText", "Vial"],
+     ["0016,", "AnotherText", "Vial"],
+     ["0017,0018", "SomeText2", "Vial"],
+     ["0020, 0021, 0022", "SomeText3", "Vial"]]
+    
+    output = [["0012 - 0014", "SomeText1", "Vial"],
+     ["0015", "OtherText", "Vial"],
+     ["0016", "AnotherText", "Vial"],
+     ["0017 - 0018", "SomeText2", "Vial"],
+     ["0020 - 0022", "SomeText3", "Vial"]]
+
+
+    input = [
+        ["1,2,3", "0021,0022,0043", "SomeText1", "Vial"],
+        ["4", "0023", "OtherText", "Vial"],
+        ["5", "0024", "AnotherText", "Vial"],
+        ["6,7", "0025,0026", "SomeText2", "Vial"],
+        ["8,9,10", "0027,0028,0029", "SomeText3", "Vial"]
+    ]
+
+    output = [
+        ["1,2", "0021 - 0022", "SomeText1", "Vial"],
+        ["4", "0023", "OtherText", "Vial"],
+        ["5", "0024", "AnotherText", "Vial"],
+        ["6,7", "0025 - 0026", "SomeText2", "Vial"],
+        ["8,9,10", "0027 - 0029", "SomeText3", "Vial"],
+        ["3", "0043", "SomeText1", "Vial"]
+    ]
+
+    return series_query_results

--- a/specifyweb/stored_queries/group_concat.py
+++ b/specifyweb/stored_queries/group_concat.py
@@ -1,8 +1,6 @@
 # Based on stackoverflow answer from Wolph:
 # https://stackoverflow.com/questions/19205850/how-do-i-write-a-group-concat-function-in-sqlalchemy
 
-import re
-from attr import has
 import sqlalchemy
 from sqlalchemy.sql import expression
 from sqlalchemy.ext import compiler

--- a/specifyweb/stored_queries/group_concat.py
+++ b/specifyweb/stored_queries/group_concat.py
@@ -2,6 +2,7 @@
 # https://stackoverflow.com/questions/19205850/how-do-i-write-a-group-concat-function-in-sqlalchemy
 
 import re
+from attr import has
 import sqlalchemy
 from sqlalchemy.sql import expression
 from sqlalchemy.ext import compiler
@@ -43,8 +44,16 @@ def extract_clauses(element, compiler):
 
     return expr, separator, order_by
 
-def group_by_displayed_fields(query: QueryConstruct, fields):
+def group_by_displayed_fields(query: QueryConstruct, fields, ignore_cat_num=False):
     for field in fields:
+        if (
+            ignore_cat_num
+            and hasattr(field, "clause")
+            and field.clause is not None
+            and hasattr(field.clause, "key")
+            and field.clause.key == "CatalogNumber"
+        ):
+            continue
         query = query.group_by(field)
-    
+
     return query

--- a/specifyweb/stored_queries/views.py
+++ b/specifyweb/stored_queries/views.py
@@ -82,6 +82,7 @@ def query(request, id):
     with models.session_context() as session:
         sp_query = session.query(models.SpQuery).get(int(id))
         distinct = sp_query.selectDistinct
+        series = sp_query.selectSeries if sp_query.selectSeries else None
         tableid = sp_query.contextTableId
         count_only = sp_query.countOnly
 
@@ -89,7 +90,7 @@ def query(request, id):
                        for field in sorted(sp_query.fields, key=lambda field: field.position)]
 
         data = execute(session, request.specify_collection, request.specify_user,
-                       tableid, distinct, count_only, field_specs, limit, offset)
+                       tableid, distinct, series, count_only, field_specs, limit, offset)
 
     return HttpResponse(toJson(data), content_type='application/json')
 


### PR DESCRIPTION
Fixes #6116

Implement the front-end and back-end code for allowing Series queries to be performed in the QB.  Similar to the Series query functionality in Specify 6, this PR implements the functionality described in the issue here https://github.com/specify/specify7/issues/6166#issue-2816294154.  Note that we made the decision for now to not perform the series and distinct.  Also, not sure if this will work with the 'age' field, will see after adding unit tests.

### Checklist

- [ ] Self-review the PR after opening it to make sure the changes look good and
      self-explanatory (or properly documented)
- [ ] Add automated tests
- [x] Add relevant issue to release milestone
- [ ] Add relevant documentation (Tester - Dev)

### Testing instructions

TBD
