### PR TITLE
Add save blocker on primary CO deletion+ protect blocker if CO in COJO

### DIFF
--- a/specifyweb/frontend/js_src/lib/components/DataModel/businessRuleDefs.ts
+++ b/specifyweb/frontend/js_src/lib/components/DataModel/businessRuleDefs.ts
@@ -7,6 +7,7 @@ import {
   CURRENT_DETERMINATION_KEY,
   ensureSingleCollectionObjectCheck,
   hasNoCurrentDetermination,
+  PRIMARY_RECORD,
 } from './businessRuleUtils';
 import { cogTypes } from './helpers';
 import type { AnySchema, TableFields } from './helperTypes';
@@ -308,8 +309,16 @@ export const businessRuleDefs: MappedBusinessRuleDefs = {
         cog.businessRuleManager?.checkField('cogType');
       }
     },
-    onRemoved(_, collection) {
+    onRemoved(cojo, collection) {
       // Trigger Consolidated COGs field check when a child is deleted
+      if (cojo.get('isPrimary')) {
+        setSaveBlockers(
+          collection.related!,
+          cojo.specifyTable.field.parentCog,
+          [resourcesText.deletePrimaryRecord()],
+          PRIMARY_RECORD
+        );
+      }
       if (collection?.related?.specifyTable === tables.CollectionObjectGroup) {
         const cog =
           collection.related as SpecifyResource<CollectionObjectGroup>;

--- a/specifyweb/frontend/js_src/lib/components/DataModel/businessRuleUtils.ts
+++ b/specifyweb/frontend/js_src/lib/components/DataModel/businessRuleUtils.ts
@@ -7,6 +7,7 @@ export const CURRENT_DETERMINATION_KEY = 'determination-isCurrent';
 export const COG_TOITSELF = 'cog-toItself';
 export const PARENTCOG_KEY = 'cog-parentCog';
 export const COG_PRIMARY_KEY = 'cog-isPrimary';
+export const PRIMARY_RECORD = 'This record cannot be deleted as it is the primary record of the Collection Object Group. Please reload the page, then assign another CO as the primary record if a change is desired.';
 
 /**
  *

--- a/specifyweb/frontend/js_src/lib/localization/resources.ts
+++ b/specifyweb/frontend/js_src/lib/localization/resources.ts
@@ -846,4 +846,7 @@ export const resourcesText = createDictionary({
     'en-us':
       'A Consolidated Collection Object Group must have a primary Collection Object child',
   },
+  deletePrimaryRecord:{
+    'en-us': 'Primary record CO cannot be deleted.'
+  }
 } as const);

--- a/specifyweb/specify/models.py
+++ b/specifyweb/specify/models.py
@@ -7610,7 +7610,7 @@ class Collectionobjectgroupjoin(models.Model): # aka. CoJo or CogJoin
 
     # Relationships: One-to-One
     childcog = models.OneToOneField('CollectionObjectGroup', db_column='ChildCOGID', related_name='cojo', null=True, on_delete=models.CASCADE)
-    childco = models.OneToOneField('CollectionObject', db_column='ChildCOID', related_name='cojo', null=True, on_delete=models.CASCADE)
+    childco = models.OneToOneField('CollectionObject', db_column='ChildCOID', related_name='cojo', null=True, on_delete=protect_with_blockers)
 
     class Meta:
         db_table = 'collectionobjectgroupjoin'


### PR DESCRIPTION
Fixes #6179

<!--
> [!WARNING]  
> This PR affects database migrations. See [migration testing instructions](https://specify.github.io/testing/pull_requests.html#prs-tagged-with-label-migration).
-->

### Checklist

- [ ] Self-review the PR after opening it to make sure the changes look good and
      self-explanatory (or properly documented)
- [ ] Add relevant issue to release milestone
- [ ] Add a reverse migration if a migration is present in the PR

### Testing instructions

A) 
- Create a CO
- Create a new parent consolidated COG
- Save
- Add another child to the COG
- Verify the CO is the primary record in the COG 
- Delete the COG parent on the CO form using the - button in the COJO header
- Save the CO form
- [ ] Verify a save blocker is being displayed 

B) 
- Create a CO
- Create a new parent COG
- Save
- Delete CO 
- [ ] Verify there is a blocker 
