### PR TITLE
Prevent from choosing other tree node parent in treeViewer

### DIFF
--- a/specifyweb/frontend/js_src/lib/components/QueryComboBox/index.tsx
+++ b/specifyweb/frontend/js_src/lib/components/QueryComboBox/index.tsx
@@ -279,7 +279,9 @@ export function QueryComboBox({
                 )
             : undefined;
         } else if (resource?.specifyTable === tables.Taxon) {
-          return resource.get('definition') || resource.independentResources?.parent?.get('definition');
+          const definition = resource.get('definition')
+          const parentDefinition = (resource?.independentResources?.parent as SpecifyResource<AnySchema>)?.get?.('definition');
+          return definition || parentDefinition;
       }
         return undefined;
       }, [resource, resource?.collection?.related?.get('collectionObjectType')]),

--- a/specifyweb/frontend/js_src/lib/components/QueryComboBox/index.tsx
+++ b/specifyweb/frontend/js_src/lib/components/QueryComboBox/index.tsx
@@ -264,25 +264,27 @@ export function QueryComboBox({
     (typeof typeSearch === 'object' ? typeSearch?.table : undefined) ??
     field.relatedTable;
 
-  const [fetchedTreeDefinition] = useAsyncState(
-    React.useCallback(
-      async () =>
-        resource?.specifyTable === tables.Determination &&
-        resource.collection?.related?.specifyTable === tables.CollectionObject
-          ? (resource.collection?.related as SpecifyResource<CollectionObject>)
-              .rgetPromise('collectionObjectType')
-              .then(
-                (
-                  collectionObjectType:
-                    | SpecifyResource<CollectionObjectType>
-                    | undefined
-                ) => collectionObjectType?.get('taxonTreeDef')
-              )
-          : undefined,
-      [resource, resource?.collection?.related?.get('collectionObjectType')]
-    ),
-    false
-  );
+    const [fetchedTreeDefinition] = useAsyncState(
+      React.useCallback(async () => {
+        if (resource?.specifyTable === tables.Determination) {
+          return resource.collection?.related?.specifyTable === tables.CollectionObject
+            ? (resource.collection?.related as SpecifyResource<CollectionObject>)
+                .rgetPromise('collectionObjectType')
+                .then(
+                  (
+                    collectionObjectType:
+                      | SpecifyResource<CollectionObjectType>
+                      | undefined
+                  ) => collectionObjectType?.get('taxonTreeDef')
+                )
+            : undefined;
+        } else if (resource?.specifyTable === tables.Taxon) {
+          return resource.get('definition');
+        }
+        return undefined;
+      }, [resource, resource?.collection?.related?.get('collectionObjectType')]),
+      false
+    );
 
   // Tree Definition passed by a parent QCBX in the component tree
   const parentTreeDefinition = React.useContext(TreeDefinitionContext);

--- a/specifyweb/frontend/js_src/lib/components/QueryComboBox/index.tsx
+++ b/specifyweb/frontend/js_src/lib/components/QueryComboBox/index.tsx
@@ -279,8 +279,8 @@ export function QueryComboBox({
                 )
             : undefined;
         } else if (resource?.specifyTable === tables.Taxon) {
-          return resource.get('definition');
-        }
+          return resource.get('definition') || resource.independentResources?.parent?.get('definition');
+      }
         return undefined;
       }, [resource, resource?.collection?.related?.get('collectionObjectType')]),
       false


### PR DESCRIPTION
Fixes #6189
Fixes #6192 

### Checklist

- [x] Self-review the PR after opening it to make sure the changes look good and
      self-explanatory (or properly documented)
- [x] Add relevant issue to release milestone

### Testing instructions

A) 
- Open tree viewer 
- Click on a node 
- Click the edit button on the top right 
- Erase the parent 
- Search for a parent that is from another tree 
- [ ] Verify that nodes from other tree are not in the list 

B) 
- Open tree viewer 
- Click on a node 
- Click on + button on the top right 
- Erase parent 
- Search for a parent that is from another tree 
- [ ] Verify that nodes from other tree are not in the list 
