### PR TITLE
Treat configurable embedded relationships as to-one when applicable

### DIFF
--- a/specifyweb/frontend/js_src/lib/components/DataModel/__tests__/resourceApi.test.ts
+++ b/specifyweb/frontend/js_src/lib/components/DataModel/__tests__/resourceApi.test.ts
@@ -10,7 +10,11 @@ import { getResourceApiUrl } from '../resource';
 import { deserializeResource, serializeResource } from '../serializers';
 import type { Collection } from '../specifyTable';
 import { tables } from '../tables';
-import type { CollectionObjectAttribute, Determination } from '../types';
+import type {
+  CollectionObjectAttribute,
+  CollectionObjectType,
+  Determination,
+} from '../types';
 
 requireContext();
 
@@ -40,6 +44,21 @@ const determinationsResponse: RA<Partial<SerializedRecord<Determination>>> = [
     number1: null,
   },
 ];
+
+const collectionObjectTypeResponse: Partial<
+  SerializedRecord<CollectionObjectType>
+> = {
+  id: 1,
+  name: 'TestType',
+  taxontreedef: getResourceApiUrl('TaxonTreeDef', 1),
+  collection: getResourceApiUrl('Collection', 4),
+  resource_uri: getResourceApiUrl('CollectionObjectType', 1),
+};
+
+overrideAjax(
+  getResourceApiUrl('CollectionObjectType', 1),
+  collectionObjectTypeResponse
+);
 
 const collectionObjectResponse = {
   id: collectionObjectId,
@@ -230,6 +249,11 @@ describe('rgetCollection', () => {
 });
 
 describe('eventHandlerForToMany', () => {
+  overrideAjax(getResourceApiUrl('Taxon', 1), {
+    id: 1,
+    resource_uri: getResourceApiUrl('Taxon', 1),
+  });
+
   test('saverequired', () => {
     const resource = new tables.CollectionObject.Resource(
       addMissingFields('CollectionObject', {

--- a/specifyweb/frontend/js_src/lib/components/DataModel/helperTypes.ts
+++ b/specifyweb/frontend/js_src/lib/components/DataModel/helperTypes.ts
@@ -1,5 +1,5 @@
 import type { IR, RA, ValueOf } from '../../utils/types';
-import type { Preparation, Tables } from './types';
+import type { PaleoContext, Preparation, Tables } from './types';
 
 /**
  * Represents a schema for any table
@@ -64,6 +64,15 @@ export type AnyInteractionPreparation = Extract<
   } & {
     readonly toOneIndependent: {
       readonly preparation: Preparation | null;
+    };
+  }
+>;
+
+export type AnyPaleoContextChild = Extract<
+  ValueOf<Tables>,
+  {
+    readonly toOneIndependent: {
+      readonly paleoContext: PaleoContext | null;
     };
   }
 >;

--- a/specifyweb/frontend/js_src/lib/components/DataModel/tables.ts
+++ b/specifyweb/frontend/js_src/lib/components/DataModel/tables.ts
@@ -18,6 +18,7 @@ import { load } from '../InitialContext';
 import { isTreeTable } from '../InitialContext/treeRanks';
 import { formatUrl } from '../Router/queryString';
 import type { AnySchema, AnyTree } from './helperTypes';
+import { fetchContext as fetchSchema } from './schema';
 import { schemaExtras } from './schemaExtras';
 import { LiteralField, Relationship } from './specifyField';
 import { type TableDefinition, SpecifyTable } from './specifyTable';
@@ -89,6 +90,7 @@ export const fetchContext = f
       'application/json'
     ),
     localization: fetchSchemaLocalization(),
+    schema: fetchSchema,
   })
   .then(({ dataModel, localization }) => {
     schemaLocalization = localization;

--- a/specifyweb/frontend/js_src/lib/components/FormSliders/IntegratedRecordSelector.tsx
+++ b/specifyweb/frontend/js_src/lib/components/FormSliders/IntegratedRecordSelector.tsx
@@ -69,8 +69,7 @@ export function IntegratedRecordSelector({
   const focusFirstField = useFirstFocus(containerRef);
 
   const isDependent = collection instanceof DependentCollection;
-  const isToOne =
-    !relationshipIsToMany(relationship) || relationship.type === 'zero-to-one';
+  const isToOne = !relationship.type.includes('-to-many');
   const isReadOnly = augmentMode(
     React.useContext(ReadOnlyContext),
     false,


### PR DESCRIPTION
Fixes #6154

There are two possible relationships which can be configured as embedded: 

- CollectionObject -> collectingEvent
  - Dependent on the `Collection -> IsEmbeddedCollectingEvent` field

And one of: 
- `CollectionObject -> paleoContext`
- `Locality -> paleoContext`
- `CollectingEvent -> paleoContext`

This is dependent on the `Discipline -> IsPaleoContextEmbedded` and `Discipline -> PaleoContextChildTable` fields. 

For a more information, view the related Speciforum docs: https://discourse.specifysoftware.org/t/shared-vs-embedded-records-configuration/1712

The datamodel however still has a static definition of the relationship type: e.g., `CollectingEvent -> collectionObjects` is always considered a `one-to-many` relationship regardless of whether `CollectionObject -> collectingEvent` is embedded or not (the same applies for the PaleoContext relationships). 
This means that without changes to how the datamodel is constructed/defined, it is up to the application to enforce that only  one related record can be added through the reverse of an embedded `to-one` relationship. 

This PR makes it so that after fetching the domain and datamodel information, the frontend overrides the relationship type for the reverse of embedded relationships - from `one-to-many` to `zero-to-one`. 

This change is a global change on the frontend! Similar changes can be made to the backend if needed, but none are included in this PR at the time of writing this. 

### Checklist

- [x] Self-review the PR after opening it to make sure the changes look good and
      self-explanatory (or properly documented)
- [ ] Add automated tests
- [x] Add relevant issue to release milestone
- [ ] Add relevant documentation (Tester - Dev)

### Testing instructions
- Find a database which has `Collection -> IsEmbeddedCollectingEvent` equal to True (or edit the Collection to make CollectingEvents embedded)
- Create a new CollectionObject with a CollectingEvent, or find a CollectingEvent which is already associated with a CollectionObject
- Show the `collectionObjects` relationship on the CollectingEvent form via a Subview
- [ ] Ensure you can not add another CollectionObject to the CollectingEvent through any means (the plus button, the query button, or via subview or querycombobox from `CollecitonObject -> collectingEvent`)
- [ ] Ensure you can still upload CollectingEvents via the workbench, and that only one CollectionObject is permitted to be mapped through the `collectionObjects` relationship
- [ ] In a version of Specify which is not this branch (e.g., production), ensure that a WorkBench mapping using CollectingEvent as a base table which includes the `collectionObjects` relationship created on this branch preserves its mapping and can still be uploaded

- Find a database which has `Discipline -> IsPaleoContextEmbedded` equal to True (or edit the Discipline to make PaleoContexts embedded)
- For future use, note the Discipline's `PaleoContextChildTable`
  - This means the ` <PaleoContextChildTable> -> paleoContext` relationship should not be shared (i.e., embedded)
- Create a new record of the PaleoContextChildTable, or find a PaleoContext record which is already associated with a PaleoContextChildTable record
- Show the reverse of the ` <PaleoContextChildTable> -> paleoContext` relationship (and at least one other of the possible relationships) on the PaleoContext form via a Subview
  - The possible relationships are: 
    - PaleoContext -> collectingEvents
    - PaleoContext -> collectionObjects
    - PaleoContext -> localities  
- [ ] Ensure you can not add another PaleoContextChildTable to the PaleoContext through any means (the plus button, the query button, or via subview or querycombobox from `PaleoContextChildTable -> paleoContext`)
- [ ] Ensure the other relationships on PaleoContext which are not embdedded (collectingEvents, collectionObjects, localities) are not restricted and can still associate with more than of the PaleoContextChildTable records
- [ ] Ensure you can still upload PaleoContexts via the workbench, and that only one PaleoContextChildTable is permitted to be mapped through the corresponding relationship
- [ ] In a version of Specify which is not this branch (e.g., production), ensure that a WorkBench mapping using PaleoContext as a base table which includes the embdedded relationship created on this branch preserves its mapping and can still be uploaded