### PR TITLE
Age Extension Query with Formatted Age Range

### DIFF
--- a/specifyweb/frontend/js_src/lib/components/DataModel/resourceApi.ts
+++ b/specifyweb/frontend/js_src/lib/components/DataModel/resourceApi.ts
@@ -69,7 +69,11 @@ function eventHandlerForToMany(related, field) {
     switch (event) {
       case 'saverequired': {
         this.handleChanged();
-        if (related.models?.[0]?.specifyTable?.name !== 'CollectionRelationship') {this.trigger.apply(this, args)}
+        if (
+          related.models?.[0]?.specifyTable?.name !== 'CollectionRelationship'
+        ) {
+          this.trigger.apply(this, args);
+        }
         break;
       }
       case 'change':

--- a/specifyweb/specify/geo_time.py
+++ b/specifyweb/specify/geo_time.py
@@ -913,9 +913,19 @@ def modify_query_add_meta_age_range(query, start_time, end_time, require_full_ov
     
     # Build the filter condition based on require_full_overlap.
     if require_full_overlap:
-        filter_condition = and_(
-            ranked_ages.c.MaxStartPeriod - start_uncertainty_case <= start_time,
-            ranked_ages.c.MinEndPeriod + end_uncertainty_case >= end_time
+        # filter_condition = and_(
+        #     ranked_ages.c.MaxStartPeriod - start_uncertainty_case <= start_time,
+        #     ranked_ages.c.MinEndPeriod + end_uncertainty_case >= end_time
+        # )
+        filter_condition = or_(
+            and_(
+                ranked_ages.c.MaxStartPeriod - start_uncertainty_case <= start_time,
+                ranked_ages.c.MinEndPeriod + end_uncertainty_case >= end_time
+            ),
+            and_(
+                ranked_ages.c.MaxStartPeriod + start_uncertainty_case >= start_time,
+                ranked_ages.c.MinEndPeriod - end_uncertainty_case <= end_time
+            )
         )
     else:
         filter_condition = or_(

--- a/specifyweb/specify/geo_time.py
+++ b/specifyweb/specify/geo_time.py
@@ -913,20 +913,20 @@ def modify_query_add_meta_age_range(query, start_time, end_time, require_full_ov
     
     # Build the filter condition based on require_full_overlap.
     if require_full_overlap:
-        # filter_condition = and_(
-        #     ranked_ages.c.MaxStartPeriod - start_uncertainty_case <= start_time,
-        #     ranked_ages.c.MinEndPeriod + end_uncertainty_case >= end_time
-        # )
-        filter_condition = or_(
-            and_(
-                ranked_ages.c.MaxStartPeriod - start_uncertainty_case <= start_time,
-                ranked_ages.c.MinEndPeriod + end_uncertainty_case >= end_time
-            ),
-            and_(
-                ranked_ages.c.MaxStartPeriod + start_uncertainty_case >= start_time,
-                ranked_ages.c.MinEndPeriod - end_uncertainty_case <= end_time
-            )
+        filter_condition = and_(
+            ranked_ages.c.MaxStartPeriod - start_uncertainty_case <= start_time,
+            ranked_ages.c.MinEndPeriod + end_uncertainty_case >= end_time
         )
+        # filter_condition = or_(
+        #     and_(
+        #         ranked_ages.c.MaxStartPeriod - start_uncertainty_case <= start_time,
+        #         ranked_ages.c.MinEndPeriod + end_uncertainty_case >= end_time
+        #     ),
+        #     and_(
+        #         ranked_ages.c.MaxStartPeriod + start_uncertainty_case >= start_time,
+        #         ranked_ages.c.MinEndPeriod - end_uncertainty_case <= end_time
+        #     )
+        # )
     else:
         filter_condition = or_(
             and_(

--- a/specifyweb/specify/geo_time.py
+++ b/specifyweb/specify/geo_time.py
@@ -736,8 +736,8 @@ def geo_time_period_query(time_period_name: str, require_full_overlap: bool = Fa
         return set()
     start_time = time_period.startperiod
     end_time = time_period.endperiod
-    start_time += Decimal(time_period.startuncertainty) if time_period.startuncertainty else Decimal('0.1')
-    end_time += Decimal(time_period.enduncertainty) if time_period.enduncertainty else Decimal('0.1')
+    # start_time += Decimal(time_period.startuncertainty) if time_period.startuncertainty else Decimal('0.1')
+    # end_time += Decimal(time_period.enduncertainty) if time_period.enduncertainty else Decimal('0.1')
     if start_time is None:
         start_time = 13800 # max start time, 13800 is the age of the Universe
     if end_time is None:

--- a/specifyweb/specify/geo_time.py
+++ b/specifyweb/specify/geo_time.py
@@ -622,51 +622,51 @@ def modify_query_add_age_range(query, start_time: float, end_time: float, requir
     )
 
     # Build the PaleoContext subquery
-    c = aliased(CollectionObject, name="c")
+    co = aliased(CollectionObject, name="co")
     ce = aliased(CollectingEvent, name="ce")
-    l = aliased(Locality, name="l")
-    p = aliased(PaleoContext, name="p")
+    loc = aliased(Locality, name="loc")
+    pc = aliased(PaleoContext, name="pc")
     cs = aliased(GeologicTimePeriod, name="cs")
     csend = aliased(GeologicTimePeriod, name="csend")
 
-    paleo_start_expr = build_paleo_expr(is_start=True, cs=cs, csend=csend, p=p)
-    paleo_end_expr = build_paleo_expr(is_start=False, cs=cs, csend=csend, p=p)
+    paleo_start_expr = build_paleo_expr(is_start=True, cs=cs, csend=csend, p=pc)
+    paleo_end_expr = build_paleo_expr(is_start=False, cs=cs, csend=csend, p=pc)
 
     join_structure = join(
-        c, ce, c.CollectingEventID == ce.collectingEventId, isouter=True
+        co, ce, co.CollectingEventID == ce.collectingEventId, isouter=True
     )
     join_structure = join(
-        join_structure, l, ce.LocalityID == l.localityId, isouter=True
+        join_structure, loc, ce.LocalityID == loc.localityId, isouter=True
     )
     join_structure = join(
         join_structure,
-        p,
+        pc,
         or_(
-            c.PaleoContextID == p.paleoContextId,
-            ce.PaleoContextID == p.paleoContextId,
-            l.PaleoContextID == p.paleoContextId
+            co.PaleoContextID == pc.paleoContextId,
+            ce.PaleoContextID == pc.paleoContextId,
+            loc.PaleoContextID == pc.paleoContextId
         ),
         isouter=True
     )
     join_structure = join(
-        join_structure, cs, p.ChronosStratID == cs.geologicTimePeriodId, isouter=True
+        join_structure, cs, pc.ChronosStratID == cs.geologicTimePeriodId, isouter=True
     )
     join_structure = join(
-        join_structure, csend, p.ChronosStratEndID == csend.geologicTimePeriodId, isouter=True
+        join_structure, csend, pc.ChronosStratEndID == csend.geologicTimePeriodId, isouter=True
     )
 
     paleo_sel = select([
-        c.collectionObjectId.label("coid"),
+        co.collectionObjectId.label("coid"),
         paleo_start_expr.label("startperiod"),
         paleo_end_expr.label("endperiod")
     ]).select_from(join_structure).where(
         and_(
-            p.paleoContextId != None,
+            pc.paleoContextId != None,
             cs.startPeriod != None,
             cs.endPeriod != None,
             cs.startPeriod >= cs.endPeriod,
             or_(
-                p.ChronosStratEndID == None,
+                pc.ChronosStratEndID == None,
                 and_(
                     csend.startPeriod != None,
                     csend.endPeriod != None,

--- a/specifyweb/stored_queries/execution.py
+++ b/specifyweb/stored_queries/execution.py
@@ -631,6 +631,8 @@ def build_query(session, collection, user, tableid, field_specs,
         sort_type = SORT_TYPES[fs.sort_type]
 
         query, field, predicate = fs.add_to_query(query, formatauditobjs=formatauditobjs)
+        if field is None:
+            continue
         if fs.display:
             formatted_field = query.objectformatter.fieldformat(fs, field)
             query = query.add_columns(formatted_field)

--- a/specifyweb/stored_queries/query_ops.py
+++ b/specifyweb/stored_queries/query_ops.py
@@ -2,7 +2,16 @@ from collections import namedtuple
 import re
 import sqlalchemy
 
-from specifyweb.specify.geo_time import search_co_ids_in_time_range, query_co_in_time_range, query_co_in_time_range_with_joins, search_co_ids_in_time_period
+from specifyweb.specify.geo_time import (
+    modify_query_add_age_range,
+    query_co_ids_in_time_period,
+    search_co_ids_in_time_range,
+    query_co_in_time_range,
+    query_co_in_time_range_with_joins,
+    search_co_ids_in_time_period,
+    search_co_ids_in_time_range_mysql,
+    search_co_ids_in_time_range_mysql_with_age_range,
+)
 from specifyweb.specify.uiformatters import CNNField, FormatMismatch
 
 
@@ -118,6 +127,8 @@ class QueryOps(namedtuple("QueryOps", "uiformatter")):
         values = [self.format(v.strip()) for v in value.split(',')[:2]]
         start_time, end_time = float(values[0]), float(values[1])
         co_ids = search_co_ids_in_time_range(start_time, end_time, require_full_overlap=is_strict)
+        # co_ids = search_co_ids_in_time_range_mysql(start_time, end_time, require_full_overlap=is_strict)
+        # co_ids = search_co_ids_in_time_range_mysql_2(start_time, end_time, require_full_overlap=is_strict)[:][0]
         return field.in_(co_ids)
 
     def op_age_range_query(self, field, value, query, is_strict=False):
@@ -128,14 +139,16 @@ class QueryOps(namedtuple("QueryOps", "uiformatter")):
     def op_age_range_query_joins(self, field, value, query, is_strict=False):
         values = [self.format(v.strip()) for v in value.split(',')[:2]]
         start_time, end_time = float(values[0]), float(values[1])
-        return query_co_in_time_range_with_joins(query.query, start_time, end_time, session=None, require_full_overlap=is_strict)
+        # return query_co_in_time_range_with_joins(query.query, start_time, end_time, session=None, require_full_overlap=is_strict)
+        return modify_query_add_age_range(query.query, start_time, end_time, require_full_overlap=is_strict)
 
     def op_age_range(self, field, value, query, is_strict=False):
         # Choose implementation of age range filtering
-        return self.op_age_range_set(field, value, is_strict)
+        # return self.op_age_range_set(field, value, is_strict)
         # return self.op_age_range_query(field, value, query, is_strict)
-        # return self.op_age_range_query_joins(field, value, query=query, is_strict=is_strict)
+        return self.op_age_range_query_joins(field, value, query=query, is_strict=is_strict)
 
     def op_age_period(self, field, value, query, is_strict=False):
         time_period_name = value
-        return field.in_(search_co_ids_in_time_period(time_period_name, require_full_overlap=is_strict))
+        # return field.in_(search_co_ids_in_time_period(time_period_name, require_full_overlap=is_strict))
+        return query_co_ids_in_time_period(query.query, time_period_name, require_full_overlap=is_strict)

--- a/specifyweb/stored_queries/queryfieldspec.py
+++ b/specifyweb/stored_queries/queryfieldspec.py
@@ -5,10 +5,12 @@ from collections import namedtuple, deque
 from typing import NamedTuple, Optional, Tuple
 
 from sqlalchemy import sql
+from sqlalchemy.orm.query import Query
 
 from specifyweb.specify.load_datamodel import Field, Table
 from specifyweb.specify.models import datamodel
 from specifyweb.specify.uiformatters import get_uiformatter
+from specifyweb.stored_queries.query_construct import QueryConstruct
 # from specifyweb.specify.geo_time import query_co_in_time_range
 from . import models
 from .query_ops import QueryOps
@@ -228,6 +230,10 @@ class QueryFieldSpec(namedtuple("QueryFieldSpec", "root_table root_sql_table joi
                 # new_query = op(orm_field, value, query, is_strict=strict)
                 # query = query._replace(query=new_query)
                 # f = None
+                if isinstance(f, Query):
+                    query = query._replace(query=f)
+                    query = query.reset_joinpoint()
+                    return query, None, None
             else:
                 f = op(orm_field, value)
             predicate = sql.not_(f) if negate else f


### PR DESCRIPTION
Fixes #6089
Fixes #6016
Fixes #6271

Creates a new functions that builds a SQLAlchemy subquery that, in addition to the previous implementation's use case of filter CollectionObjects by all it's paths to chronostrat age, returns a formatted age range for a CollectionObject's maximum start age to its minimum end age.  This allows the query QB to display this formatted range in the age column in the query results.  This PR also implements the strict query behavior described in #6271.

<img width="1150" alt="image" src="https://github.com/user-attachments/assets/058f974d-e73a-4492-8064-ed14096f20d5" />
<img width="1142" alt="image" src="https://github.com/user-attachments/assets/b4fb3c35-b7e6-4f17-a853-437977f7ea11" />

Here is a compiled SQLAlchemy query that get generated for a simple CollectionObject Age query:
```sql
SELECT
	collectionobject.`CollectionObjectID`,
	concat_ws(' - ',
			  ifnull(regexp_replace(CAST(agg_subq.max_start_period AS CHAR), '\\.(0+)$', ''), ''),
			  ifnull(regexp_replace(CAST(agg_subq.min_end_period AS CHAR), '\\.(0+)$', ''), '')) AS age
FROM
	collectionobject
INNER JOIN (
	SELECT
		unioned.coid AS coid,
		min(unioned.endperiod) AS min_end_period,
		max(unioned.startperiod) AS max_start_period
	FROM
		(
		SELECT
			absoluteage.`CollectionObjectID` AS coid,
			CAST(absoluteage.`AbsoluteAge` AS DECIMAL(10, 6)) - coalesce(absoluteage.`AgeUncertainty`, 0) AS startperiod,
			CAST(absoluteage.`AbsoluteAge` AS DECIMAL(10, 6)) + coalesce(absoluteage.`AgeUncertainty`, 0) AS endperiod
		FROM
			absoluteage
		WHERE
			CAST(absoluteage.`AbsoluteAge` AS DECIMAL(10, 6)) - coalesce(absoluteage.`AgeUncertainty`, 0) <= 2000.0
			AND CAST(absoluteage.`AbsoluteAge` AS DECIMAL(10, 6)) + coalesce(absoluteage.`AgeUncertainty`, 0) >= 2.0
	UNION ALL
		SELECT
			r.`CollectionObjectID` AS coid,
			CASE
				WHEN (r.`AgeNameEndID` IS NOT NULL) THEN greatest(CAST(a.`StartPeriod` AS DECIMAL(10, 6)) + coalesce(a.`StartUncertainty`, 0) + coalesce(r.`AgeUncertainty`, 0), CAST(aend.`StartPeriod` AS DECIMAL(10, 6)) + coalesce(aend.`StartUncertainty`, 0) + coalesce(r.`AgeUncertainty`, 0))
				ELSE CAST(a.`StartPeriod` AS DECIMAL(10, 6)) + coalesce(a.`StartUncertainty`, 0) + coalesce(r.`AgeUncertainty`, 0)
			END AS startperiod,
			CASE
				WHEN (r.`AgeNameEndID` IS NOT NULL) THEN least((CAST(a.`EndPeriod` AS DECIMAL(10, 6)) - coalesce(a.`EndUncertainty`, 0)) - coalesce(r.`AgeUncertainty`, 0), (CAST(aend.`EndPeriod` AS DECIMAL(10, 6)) - coalesce(aend.`EndUncertainty`, 0)) - coalesce(r.`AgeUncertainty`, 0))
				ELSE (CAST(a.`EndPeriod` AS DECIMAL(10, 6)) - coalesce(a.`EndUncertainty`, 0)) - coalesce(r.`AgeUncertainty`, 0)
			END AS endperiod
		FROM
			relativeage AS r
		INNER JOIN geologictimeperiod AS a ON
			r.`AgeNameID` = a.`GeologicTimePeriodID`
		LEFT OUTER JOIN geologictimeperiod AS aend ON
			r.`AgeNameEndID` = aend.`GeologicTimePeriodID`
		WHERE
			a.`StartPeriod` IS NOT NULL
			AND a.`EndPeriod` IS NOT NULL
			AND a.`StartPeriod` >= a.`EndPeriod`
			AND (r.`AgeNameEndID` IS NULL
				OR aend.`StartPeriod` IS NOT NULL
				AND aend.`EndPeriod` IS NOT NULL
				AND aend.`StartPeriod` >= aend.`EndPeriod`)
			AND CASE
				WHEN (r.`AgeNameEndID` IS NOT NULL) THEN greatest(CAST(a.`StartPeriod` AS DECIMAL(10, 6)) + coalesce(a.`StartUncertainty`, 0) + coalesce(r.`AgeUncertainty`, 0), CAST(aend.`StartPeriod` AS DECIMAL(10, 6)) + coalesce(aend.`StartUncertainty`, 0) + coalesce(r.`AgeUncertainty`, 0))
				ELSE CAST(a.`StartPeriod` AS DECIMAL(10, 6)) + coalesce(a.`StartUncertainty`, 0) + coalesce(r.`AgeUncertainty`, 0)
			END <= 2000.0
			AND CASE
				WHEN (r.`AgeNameEndID` IS NOT NULL) THEN least((CAST(a.`EndPeriod` AS DECIMAL(10, 6)) - coalesce(a.`EndUncertainty`, 0)) - coalesce(r.`AgeUncertainty`, 0), (CAST(aend.`EndPeriod` AS DECIMAL(10, 6)) - coalesce(aend.`EndUncertainty`, 0)) - coalesce(r.`AgeUncertainty`, 0))
				ELSE (CAST(a.`EndPeriod` AS DECIMAL(10, 6)) - coalesce(a.`EndUncertainty`, 0)) - coalesce(r.`AgeUncertainty`, 0)
			END >= 2.0
	UNION ALL
		SELECT
			DISTINCT c.`CollectionObjectID` AS coid,
			CASE
				WHEN (p.`ChronosStratEndID` IS NOT NULL) THEN least(CAST(cs.`StartPeriod` AS DECIMAL(10, 6)) + coalesce(cs.`StartUncertainty`, 0), CAST(csend.`StartPeriod` AS DECIMAL(10, 6)) + coalesce(csend.`StartUncertainty`, 0))
				ELSE CAST(cs.`StartPeriod` AS DECIMAL(10, 6)) + coalesce(cs.`StartUncertainty`, 0)
			END AS startperiod,
			CASE
				WHEN (p.`ChronosStratEndID` IS NOT NULL) THEN greatest(CAST(cs.`EndPeriod` AS DECIMAL(10, 6)) - coalesce(cs.`EndUncertainty`, 0), CAST(csend.`EndPeriod` AS DECIMAL(10, 6)) - coalesce(csend.`EndUncertainty`, 0))
				ELSE CAST(cs.`EndPeriod` AS DECIMAL(10, 6)) - coalesce(cs.`EndUncertainty`, 0)
			END AS endperiod
		FROM
			collectionobject AS c
		LEFT OUTER JOIN collectingevent AS ce ON
			c.`CollectingEventID` = ce.`CollectingEventID`
		LEFT OUTER JOIN locality AS l ON
			ce.`LocalityID` = l.`LocalityID`
		LEFT OUTER JOIN paleocontext AS p ON
			c.`PaleoContextID` = p.`PaleoContextID`
			OR ce.`PaleoContextID` = p.`PaleoContextID`
			OR l.`PaleoContextID` = p.`PaleoContextID`
		LEFT OUTER JOIN geologictimeperiod AS cs ON
			p.`ChronosStratID` = cs.`GeologicTimePeriodID`
		LEFT OUTER JOIN geologictimeperiod AS csend ON
			p.`ChronosStratEndID` = csend.`GeologicTimePeriodID`
		WHERE
			p.`PaleoContextID` IS NOT NULL
			AND cs.`StartPeriod` IS NOT NULL
			AND cs.`EndPeriod` IS NOT NULL
			AND cs.`StartPeriod` >= cs.`EndPeriod`
			AND (p.`ChronosStratEndID` IS NULL
				OR csend.`StartPeriod` IS NOT NULL
				AND csend.`EndPeriod` IS NOT NULL
				AND csend.`StartPeriod` >= csend.`EndPeriod`)
			AND CASE
				WHEN (p.`ChronosStratEndID` IS NOT NULL) THEN least(CAST(cs.`StartPeriod` AS DECIMAL(10, 6)) + coalesce(cs.`StartUncertainty`, 0), CAST(csend.`StartPeriod` AS DECIMAL(10, 6)) + coalesce(csend.`StartUncertainty`, 0))
				ELSE CAST(cs.`StartPeriod` AS DECIMAL(10, 6)) + coalesce(cs.`StartUncertainty`, 0)
			END <= 2000.0
			AND CASE
				WHEN (p.`ChronosStratEndID` IS NOT NULL) THEN greatest(CAST(cs.`EndPeriod` AS DECIMAL(10, 6)) - coalesce(cs.`EndUncertainty`, 0), CAST(csend.`EndPeriod` AS DECIMAL(10, 6)) - coalesce(csend.`EndUncertainty`, 0))
				ELSE CAST(cs.`EndPeriod` AS DECIMAL(10, 6)) - coalesce(cs.`EndUncertainty`, 0)
			END >= 2.0) AS unioned
	GROUP BY
		unioned.coid) AS agg_subq ON
	collectionobject.`CollectionObjectID` = agg_subq.coid
WHERE
	collectionobject.`CollectionID` = 98304;
```

### Checklist

- [ ] Self-review the PR after opening it to make sure the changes look good and
      self-explanatory (or properly documented)
- [x] Add relevant issue to release milestone

### Testing instructions

- Select a database with chronostart records, like ciscollections_2_15_24
- Create an age query with a large range that will include lots of COs with an associated chronostrat.
- [x] See that the "Collection Object - Age" column has a date range.
