### PR TITLE
Remove silent option when setting specify user in QCBX

### DIFF
--- a/specifyweb/frontend/js_src/lib/components/Forms/SubView.tsx
+++ b/specifyweb/frontend/js_src/lib/components/Forms/SubView.tsx
@@ -15,6 +15,7 @@ import type { CollectionFetchFilters } from '../DataModel/collection';
 import type { AnySchema } from '../DataModel/helperTypes';
 import type { SpecifyResource } from '../DataModel/legacyTypes';
 import { resourceOn } from '../DataModel/resource';
+import { schema } from '../DataModel/schema';
 import type { Relationship } from '../DataModel/specifyField';
 import type { SpecifyTable } from '../DataModel/specifyTable';
 import { tables } from '../DataModel/tables';
@@ -24,7 +25,6 @@ import { IntegratedRecordSelector } from '../FormSliders/IntegratedRecordSelecto
 import { isTreeTable } from '../InitialContext/treeRanks';
 import { TableIcon } from '../Molecules/TableIcon';
 import { relationshipIsToMany } from '../WbPlanView/mappingHelpers';
-import { schema } from '../DataModel/schema';
 
 type SubViewContextType =
   | {

--- a/specifyweb/frontend/js_src/lib/components/QueryComboBox/index.tsx
+++ b/specifyweb/frontend/js_src/lib/components/QueryComboBox/index.tsx
@@ -261,29 +261,32 @@ export function QueryComboBox({
     (typeof typeSearch === 'object' ? typeSearch?.table : undefined) ??
     field.relatedTable;
 
-    const [fetchedTreeDefinition] = useAsyncState(
-      React.useCallback(async () => {
-        if (resource?.specifyTable === tables.Determination) {
-          return resource.collection?.related?.specifyTable === tables.CollectionObject
-            ? (resource.collection?.related as SpecifyResource<CollectionObject>)
-                .rgetPromise('collectionObjectType')
-                .then(
-                  (
-                    collectionObjectType:
-                      | SpecifyResource<CollectionObjectType>
-                      | undefined
-                  ) => collectionObjectType?.get('taxonTreeDef')
-                )
-            : undefined;
-        } else if (resource?.specifyTable === tables.Taxon) {
-          const definition = resource.get('definition')
-          const parentDefinition = (resource?.independentResources?.parent as SpecifyResource<AnySchema>)?.get?.('definition');
-          return definition || parentDefinition;
+  const [fetchedTreeDefinition] = useAsyncState(
+    React.useCallback(async () => {
+      if (resource?.specifyTable === tables.Determination) {
+        return resource.collection?.related?.specifyTable ===
+          tables.CollectionObject
+          ? (resource.collection?.related as SpecifyResource<CollectionObject>)
+              .rgetPromise('collectionObjectType')
+              .then(
+                (
+                  collectionObjectType:
+                    | SpecifyResource<CollectionObjectType>
+                    | undefined
+                ) => collectionObjectType?.get('taxonTreeDef')
+              )
+          : undefined;
+      } else if (resource?.specifyTable === tables.Taxon) {
+        const definition = resource.get('definition');
+        const parentDefinition = (
+          resource?.independentResources?.parent as SpecifyResource<AnySchema>
+        )?.get?.('definition');
+        return definition || parentDefinition;
       }
-        return undefined;
-      }, [resource, resource?.collection?.related?.get('collectionObjectType')]),
-      false
-    );
+      return undefined;
+    }, [resource, resource?.collection?.related?.get('collectionObjectType')]),
+    false
+  );
 
   // Tree Definition passed by a parent QCBX in the component tree
   const parentTreeDefinition = React.useContext(TreeDefinitionContext);

--- a/specifyweb/frontend/js_src/lib/components/QueryComboBox/index.tsx
+++ b/specifyweb/frontend/js_src/lib/components/QueryComboBox/index.tsx
@@ -105,10 +105,7 @@ export function QueryComboBox({
       const record = toTable(resource, 'RecordSet');
       record?.set(
         'specifyUser',
-        record?.get('specifyUser') ?? userInformation.resource_uri,
-        {
-          silent: true,
-        }
+        record?.get('specifyUser') ?? userInformation.resource_uri
       );
     }
     if (field.name === 'receivedBy') {


### PR DESCRIPTION
Fixes #6199

Setting the specify user with the silent mode led to the save blocker not detecting the change and blocking save until a re-render occurred. This couldn't be reproduced locally because of strict mode, which renders everything twice in dev mode.

<!--
> [!WARNING]  
> This PR affects database migrations. See [migration testing instructions](https://specify.github.io/testing/pull_requests.html#prs-tagged-with-label-migration).
-->

### Checklist

- [x] Self-review the PR after opening it to make sure the changes look good and
      self-explanatory (or properly documented)
- [ ] Add automated tests
- [x] Add relevant issue to release milestone
- [ ] Add relevant documentation (Tester - Dev)
- [ ] Add a reverse migration if a migration is present in the PR

### Testing instructions

<!-- What are the steps to verify the fixes/changes in this PR? -->
<!-- Can part of that be replaced by automated tests? -->
- Create a CO query
- Select a few COs and click on Create Record Set
- [ ] Verify save is not blocked due to the owner field