### PR TITLE
Improve the reliability of arm64 builds in the Docker GitHub Workflow action

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -67,9 +67,15 @@ jobs:
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
+        with:
+          platforms: all
 
       - name: Set up Docker Buildx
+        id: buildx
         uses: docker/setup-buildx-action@v3
+        with:
+          install: true
+          driver-opts: network=host
 
       - name: Login to Docker Hub
         uses: docker/login-action@v3
@@ -88,6 +94,9 @@ jobs:
           tags: ${{ steps.prep.outputs.tags }}
           push: true
           retries: 3
+          # Use GitHub Actions caching to speed up subsequent builds
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 
       - name: Export digest
         run: |

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -67,15 +67,9 @@ jobs:
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
-        with:
-          platforms: all
 
       - name: Set up Docker Buildx
-        id: buildx
         uses: docker/setup-buildx-action@v3
-        with:
-          install: true
-          driver-opts: network=host
 
       - name: Login to Docker Hub
         uses: docker/login-action@v3
@@ -94,9 +88,6 @@ jobs:
           tags: ${{ steps.prep.outputs.tags }}
           push: true
           retries: 3
-          # Use GitHub Actions caching to speed up subsequent builds
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
 
       - name: Export digest
         run: |


### PR DESCRIPTION
Experimenting to improve the reliability of arm64 builds in the Docker GitHub Workflow action.  Looking to solve the non-deterministic nature of the arm64 builds when they run on GitHub.  It seems that the arm64 emulation on QEMU within the GitHub workflow action environment might be somewhat flaky.  Resolving strategy is to try surrounding problematic docker install commands in re-try loops.  Also, looking at different config options in the docker.yml file defining the arm64 build in the GitHub workflow action.
