### PR TITLE
Avoid null original_loan_return_data

### DIFF
--- a/specifyweb/interactions/cog_preps.py
+++ b/specifyweb/interactions/cog_preps.py
@@ -461,27 +461,20 @@ def modify_update_of_loan_return_sibling_preps(original_interaction_obj, updated
         original_loan_prep_data = None
         original_loan_return_data_lst = None
         original_loan_return_data = None
-        if len(orginal_prep_ids) == 1:
-            original_prep_id = orginal_prep_ids.pop()
-            original_loan_prep_idx = map_prep_id_to_loan_prep_idx[original_prep_id]
-            original_loan_prep_data = updated_interaction_data[
-                "loanpreparations"][original_loan_prep_idx]
-            original_loan_return_data_lst = original_loan_prep_data["loanreturnpreparations"]
-            original_loan_return_data = (
-                original_loan_return_data_lst[-1]
-                if original_loan_return_data_lst is not None
-                and len(original_loan_return_data_lst) > 0
-                else None
-            )
-            if original_loan_return_data is None:
-                logger.warning(
-                    "No loan return preparation data found for this consolidated COG preparation.")
-                continue
-        elif len(orginal_prep_ids) > 1:
-            logger.warning(
-                "Multiple partial loan returns found for this consolidated COG preparation.")
-        else:
+        if len(orginal_prep_ids) < 1:
             continue
+        if len(orginal_prep_ids) > 1:
+            logger.warning("Multiple partial loan returns found for this consolidated COG preparation.")
+        original_prep_id = orginal_prep_ids.pop()
+        original_loan_prep_idx = map_prep_id_to_loan_prep_idx[original_prep_id]
+        original_loan_prep_data = updated_interaction_data["loanpreparations"][original_loan_prep_idx]
+        original_loan_return_data_lst = original_loan_prep_data["loanreturnpreparations"]
+        original_loan_return_data = (
+            original_loan_return_data_lst[-1]
+            if original_loan_return_data_lst is not None
+            and len(original_loan_return_data_lst) > 0
+            else None
+        )
 
         # Set the return and resolved quantity to the max amount.
         # In the future, maybe have more complex logic for partial returns/resolves of consolidated cogs.


### PR DESCRIPTION
Fixes #6217

Avoid null original_loan_return_data when multiple partial loan returns found for the target consolidated COG preparation.

### Checklist

- [x] Self-review the PR after opening it to make sure the changes look good and
      self-explanatory (or properly documented)
- [x] Add relevant issue to release milestone


### Testing instructions

- Create (or find) a COG with at least 3 childCO with preparations
- Create loan 
- Add childCOs to loan 
- Save  
- Return loan 
- Select 2 preparations 
- Apply 
- Save 
- [x] See that the record saved successfully
- [x] Ensure that the error in the video does not occur:

https://github.com/user-attachments/assets/cf866e42-fb9f-435c-a98e-71c66bf55bc6 
