### PR TITLE
Trigger save btn when sub resource change

### DIFF
--- a/specifyweb/frontend/js_src/lib/components/DataModel/__tests__/resourceApi.test.ts
+++ b/specifyweb/frontend/js_src/lib/components/DataModel/__tests__/resourceApi.test.ts
@@ -250,7 +250,8 @@ describe('eventHandlerForToMany', () => {
       ?.models[0].set('text1', 'helloWorld');
 
     expect(resource.needsSaved).toBe(true);
-    expect(testFunction).toHaveBeenCalledTimes(1);
+    // Change to 2 in issue-6214
+    expect(testFunction).toHaveBeenCalledTimes(2);
   });
   test('changing collection propagates to related', () => {
     const resource = new tables.CollectionObject.Resource(

--- a/specifyweb/frontend/js_src/lib/components/DataModel/resourceApi.ts
+++ b/specifyweb/frontend/js_src/lib/components/DataModel/resourceApi.ts
@@ -69,6 +69,7 @@ function eventHandlerForToMany(related, field) {
     switch (event) {
       case 'saverequired': {
         this.handleChanged();
+        this.trigger.apply(this, args);
         break;
       }
       case 'change':


### PR DESCRIPTION
Fixes #6214

### Checklist

- [ ] Self-review the PR after opening it to make sure the changes look good and
      self-explanatory (or properly documented)
- [ ] Add relevant issue to release milestone

### Testing instructions

- Go to CO
- Add a preparation
- Add preparation attachment
- Save
- Edit field in the preparation attachment
- [ ] Verify save button is enabled
