### PR TITLE
fix migration defintion of the UserRole specifyuser relationship

### DIFF
--- a/specifyweb/permissions/migrations/0002_role_rolepolicy_userrole.py
+++ b/specifyweb/permissions/migrations/0002_role_rolepolicy_userrole.py
@@ -30,7 +30,7 @@ class Migration(migrations.Migration):
             fields=[
                 ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
                 ('role', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, to='permissions.Role')),
-                ('specifyuser', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, to=settings.AUTH_USER_MODEL)),
+                ('specifyuser', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, related_name='roles', to=settings.AUTH_USER_MODEL)),
             ],
             options={
                 'db_table': 'spuserrole',


### PR DESCRIPTION
Fixes #6221

Fix migration definition of the UserRole specifyuser relationship.  Fixed by matching `related_name='roles'` from the model definition to the migration definition.

Both of the related lines were commited by Ben 3 years ago, so it's odd that this error hadn't come up before.

https://github.com/specify/specify7/blob/fa69325b31f5b41fe2a2beefc6c06d7ae81b9856/specifyweb/permissions/models.py#L47

https://github.com/specify/specify7/blob/fa69325b31f5b41fe2a2beefc6c06d7ae81b9856/specifyweb/permissions/migrations/0002_role_rolepolicy_userrole.py#L33

### Checklist

- [x] Self-review the PR after opening it to make sure the changes look good and
      self-explanatory (or properly documented)
- [x] Add relevant issue to release milestone

### Testing instructions

- Configure Specify 7 to point to a database that has never been used with 7, only Specify 6 ([download one here](https://drive.google.com/open?id=15FKmerO7yiiZxtEgRwmEXd9ju0dJY4tE&usp=drive_fs), freshly made in Specify 6)
    - Remember to drop and create a new database before you restore!
- Run `docker compose up` and start the container
- [x] See that all the migrations complete successfully upon startup

![image](https://github.com/user-attachments/assets/c89384b4-6f4f-4c33-8278-f440e4270fca)

