### PR TITLE
Fix setting loan prep quantities for consolidated prep siblings

### DIFF
--- a/specifyweb/interactions/cog_preps.py
+++ b/specifyweb/interactions/cog_preps.py
@@ -576,7 +576,7 @@ def enforce_interaction_sibling_prep_max_count(interaction_obj):
         return interaction_obj
 
     interaction_preps = InteractionPrepModel.objects.filter(**{filter_fld: interaction_obj})
-    interaction_prep_ids = set(interaction_preps.values_list("id", flat=True))
+    interaction_prep_ids = set(interaction_preps.values_list("preparation_id", flat=True))
     for interaction_prep in interaction_preps:
         prep = interaction_prep.preparation
         sibling_preps = get_all_sibling_preps_within_consolidated_cog(prep)

--- a/specifyweb/interactions/cog_preps.py
+++ b/specifyweb/interactions/cog_preps.py
@@ -596,5 +596,8 @@ def enforce_interaction_sibling_prep_max_count(interaction_obj):
         if is_max_quntity_used:
             interaction_prep.quantity = interaction_prep.preparation.countamt
             interaction_prep.save()
+        if len(sibling_preps) > 1:
+            interaction_prep.quantity = interaction_prep.preparation.countamt
+            interaction_prep.save()
 
     return interaction_obj

--- a/specifyweb/interactions/cog_preps.py
+++ b/specifyweb/interactions/cog_preps.py
@@ -1,7 +1,8 @@
 import logging
 from typing import Any, List, Optional, Set
-from django.db.models import Subquery
+from django.db.models import Subquery, Sum, F, Value, IntegerField, ExpressionWrapper, Q
 from django.db.models.query import QuerySet
+from django.db.models.functions import Coalesce
 from specifyweb.specify.models import (
     Collectionobject,
     Collectionobjectgroup,
@@ -558,46 +559,109 @@ def modify_update_of_loan_return_sibling_preps(original_interaction_obj, updated
     return updated_interaction_data
 
 def enforce_interaction_sibling_prep_max_count(interaction_obj):
-    InteractionPrepModel = None
-    filter_fld = None
+    def get_interaction_prep_model_and_filter_field(interaction_obj):
+        model_map = {
+            'loan': (Loanpreparation, 'loan'),
+            'gift': (Giftpreparation, 'gift'),
+            'disposal': (Disposalpreparation, 'disposal')
+        }
+        return model_map.get(interaction_obj._meta.model_name, (None, None))
+
+    def is_max_quantity_used(sibling_preps, interaction_prep_id, interaction_prep_ids, InteractionPrepModel):
+        for sibling_prep in sibling_preps:
+            if sibling_prep.id not in interaction_prep_ids:
+                continue
+            # count = sibling_prep.countamt
+            available_count = get_availability_count(sibling_prep, interaction_prep_id, "loanpreparations__id") or 0
+            interaction_sibling_prep = InteractionPrepModel.objects.filter(preparation=sibling_prep).first()
+            if interaction_sibling_prep and interaction_sibling_prep.quantity == available_count:
+                return True
+        return False
+
     if interaction_obj is None:
         return interaction_obj
-    if interaction_obj._meta.model_name == 'loan':
-        if hasattr(interaction_obj, 'loanpreparations'):
-            filter_fld = "loan"
-            InteractionPrepModel = Loanpreparation
-    elif interaction_obj._meta.model_name == 'gift':
-        filter_fld = "gift"
-        InteractionPrepModel = Giftpreparation
-    elif interaction_obj._meta.model_name == 'disposal':
-        filter_fld = "disposal"
-        InteractionPrepModel = Disposalpreparation
-    else:
+
+    InteractionPrepModel, filter_fld = get_interaction_prep_model_and_filter_field(interaction_obj)
+    if InteractionPrepModel is None:
         return interaction_obj
 
     interaction_preps = InteractionPrepModel.objects.filter(**{filter_fld: interaction_obj})
     interaction_prep_ids = set(interaction_preps.values_list("preparation_id", flat=True))
+
     for interaction_prep in interaction_preps:
         prep = interaction_prep.preparation
         sibling_preps = get_all_sibling_preps_within_consolidated_cog(prep)
-        is_max_quntity_used = False 
-        for sibling_prep in sibling_preps:
-            if sibling_prep.id not in interaction_prep_ids:
-                continue
-            count = sibling_prep.countamt
-            quantity = 0
-            interaction_sibling_prep = InteractionPrepModel.objects.filter(preparation=sibling_prep).first()
-            if interaction_sibling_prep is not None:
-                quantity = interaction_sibling_prep.quantity
-            if quantity == count:
-                is_max_quntity_used = True
-                break
 
-        if is_max_quntity_used:
-            interaction_prep.quantity = interaction_prep.preparation.countamt
-            interaction_prep.save()
-        if len(sibling_preps) > 1:
-            interaction_prep.quantity = interaction_prep.preparation.countamt
+        if is_max_quantity_used(
+            sibling_preps, interaction_prep.id, interaction_prep_ids, InteractionPrepModel
+        ) or (sibling_preps is not None and len(sibling_preps) > 0):
+            if interaction_prep.quantity == interaction_prep.preparation.countamt:
+                continue
+            available_count = get_availability_count(prep, interaction_prep.id, "loanpreparations__id") or 0
+            interaction_prep.quantity = available_count
             interaction_prep.save()
 
     return interaction_obj
+
+def get_availability_count(prep, iprepid, iprepid_fld):
+    """
+    Computes:
+       preparation.countamt
+       - sum(loanpreparations.quantity - loanpreparations.quantityresolved)
+       - sum(giftpreparations.quantity)
+       - sum(exchangeoutpreps.quantity)
+    
+    If iprepid is given then for the join that uses the field specified by
+    iprepid_fld we exclude rows where that field equals iprepid.
+    
+    Note: iprepid_fld is assumed to be a string like 'loanpreparations__id' or 'giftpreparations__id' etc.
+    """
+    loan_filter = Q()
+    gift_filter = Q()
+    exchange_filter = Q()
+
+    if iprepid is not None and iprepid_fld:
+        if iprepid_fld.startswith('loanpreparations__'):
+            loan_filter = ~Q(**{iprepid_fld: iprepid})
+        elif iprepid_fld.startswith('giftpreparations__'):
+            gift_filter = ~Q(**{iprepid_fld: iprepid})
+        elif iprepid_fld.startswith('exchangeoutpreps__'):
+            exchange_filter = ~Q(**{iprepid_fld: iprepid})
+        else:
+            loan_filter = ~Q(**{iprepid_fld: iprepid})
+            gift_filter = ~Q(**{iprepid_fld: iprepid})
+            exchange_filter = ~Q(**{iprepid_fld: iprepid})
+
+    qs = (prep.__class__.objects
+          .filter(id=prep.id)
+          .annotate(
+              loan_sum=Coalesce(
+                  Sum(
+                      ExpressionWrapper(
+                          F('loanpreparations__quantity') - F('loanpreparations__quantityresolved'),
+                          output_field=IntegerField()
+                      ),
+                      filter=loan_filter
+                  ),
+                  Value(0),
+                  output_field=IntegerField()
+              ),
+              gift_sum=Coalesce(
+                  Sum('giftpreparations__quantity', filter=gift_filter, output_field=IntegerField()),
+                  Value(0),
+                  output_field=IntegerField()
+              ),
+              exchange_sum=Coalesce(
+                  Sum('exchangeoutpreps__quantity', filter=exchange_filter, output_field=IntegerField()),
+                  Value(0),
+                  output_field=IntegerField()
+              ),
+          )
+          .values('countamt', 'loan_sum', 'gift_sum', 'exchange_sum')
+         )
+
+    row = qs.first()
+    if row is None:
+        return prep.countamt
+    else:
+        return row['countamt'] - row['loan_sum'] - row['gift_sum'] - row['exchange_sum']

--- a/specifyweb/specify/api.py
+++ b/specifyweb/specify/api.py
@@ -528,6 +528,7 @@ def create_obj(collection, agent, model, data: Dict[str, Any], parent_obj=None, 
 
     handle_remote_to_ones(obj)
     handle_to_many(collection, agent, obj, data)
+    _handle_special_update_posts(obj)
     return obj
 
 FieldChangeInfo = TypedDict('FieldChangeInfo', {'field_name': str, 'old_value': Any, 'new_value': Any})
@@ -916,6 +917,7 @@ def update_obj(collection, agent, name: str, id, version, data: Dict[str, Any], 
         delete_obj(dep, parent_obj=obj, collection=collection, agent=agent)
     handle_remote_to_ones(obj)
     handle_to_many(collection, agent, obj, data)
+    _handle_special_update_posts(obj)
     return obj
 
 def bump_version(obj, version) -> None:
@@ -1183,6 +1185,10 @@ def rows(request, model_name: str) -> HttpResponse:
 
     data = list(query)
     return HttpResponse(toJson(data), content_type='application/json')
+
+def _handle_special_update_posts(obj):
+    from specifyweb.interactions.cog_preps import enforce_interaction_sibling_prep_max_count
+    enforce_interaction_sibling_prep_max_count(obj)
 
 def _handle_special_update_priors(obj, data):
     from specifyweb.interactions.cog_preps import (


### PR DESCRIPTION
Fixes #6223

Fix setting loan prep quantities for consolidated prep siblings.  When one sibling's quantity is set to its max amount, then all of the consolidated siblings should be set to there max.  The max amount is set when the loan prep's quantity is equal to the count of the associated prep.

### Checklist

- [x] Self-review the PR after opening it to make sure the changes look good and
      self-explanatory (or properly documented)
- [x] Add relevant issue to release milestone

### Testing instructions

- Create a new consolidated collection object group.  Create three collection objects in the group.  For each collection object, create a preparation.  Set the count of the first prep to >= 2, the second to >= 2, and the third to >= 2.

<img width="960" alt="image" src="https://github.com/user-attachments/assets/365c50e5-9817-4aef-b14a-a27125872147" />

- Navigate to the "Interactions" tab on the side menu and then select "Loan".
- Select "By CIDA/Catalog Numbers", and add the catalog number of the first CO in your new COG, and press "Next"
- Select only the first CO in the list, and set the "Selected" amount to the "Available" amount.  Press "Apply"

<img width="486" alt="image" src="https://github.com/user-attachments/assets/86e42bd2-46a1-48ec-a25d-221db3682289" />

- Enter a loan number and press "Save".
- [x] See that all the loan preps are set to their max quantity, where the quantity equals the count.

<img width="906" alt="image" src="https://github.com/user-attachments/assets/59e6e8db-bd9d-4b00-b63f-99aba7e8fd05" />


NOTE: 
- the quantity will be set to its max only once you have saved your loan

