### PR TITLE
Add key to display correct cat num format tooltip

### DIFF
--- a/specifyweb/frontend/js_src/lib/components/FormFields/Field.tsx
+++ b/specifyweb/frontend/js_src/lib/components/FormFields/Field.tsx
@@ -127,6 +127,7 @@ function Field({
   return (
     <Input.Generic
       forwardRef={validationRef}
+      key={parser.title}
       name={name}
       {...validationAttributes}
       className={


### PR DESCRIPTION
Fixes #6238

### Checklist

- [ ] Self-review the PR after opening it to make sure the changes look good and
      self-explanatory (or properly documented)
- [ ] Add relevant issue to release milestone

### Testing instructions

- Open a db with several cat num format for different COtypes
- Create a new CO with type 1 (CO type A cat num format A)
- Save 
- Hover over the cat number 
- [ ] verify the cat num format tooltip is correct for CO A
- Click the Add button 
- Create a new CO with a different type (CO type B cat num format B)
- Save 
- Hover over the cat number 
- [ ] verify the cat num format tooltip is correct for CO B 
- Using the top right arrows, switch to the first CO (CO type A) 
- [ ] verify the cat num format tooltip is correct for CO A
- Using the top right arrows, switch to the first CO (CO type B) 
- [ ] verify the cat num format tooltip is correct for CO B
