### PR TITLE
Handle unassociated item in interactions

### DIFF
--- a/specifyweb/interactions/cog_preps.py
+++ b/specifyweb/interactions/cog_preps.py
@@ -70,6 +70,10 @@ def get_the_top_consolidated_parent_cog_of_prep(prep: Preparation) -> Optional[C
     """
     Get the topmost consolidated parent CollectionObjectGroup of the preparation.
     """
+
+    if prep is None:
+        return None  
+
     # Get the CollectionObject of the preparation
     co = prep.collectionobject
     if co is None:
@@ -568,7 +572,10 @@ def enforce_interaction_sibling_prep_max_count(interaction_obj):
         return model_map.get(interaction_obj._meta.model_name, (None, None, None))
 
     def is_max_quantity_used(sibling_preps, interaction_prep_id, interaction_prep_ids, prep_id_fld, InteractionPrepModel):
+
         for sibling_prep in sibling_preps:
+            if sibling_prep is None:
+                return False
             if sibling_prep.id not in interaction_prep_ids:
                 continue
             # count = sibling_prep.countamt
@@ -595,6 +602,9 @@ def enforce_interaction_sibling_prep_max_count(interaction_obj):
         if is_max_quantity_used(
             sibling_preps, interaction_prep.id, interaction_prep_ids, id_fld, InteractionPrepModel
         ) or (sibling_preps is not None and len(sibling_preps) > 0):
+            if interaction_prep.preparation is None: 
+                continue
+
             if interaction_prep.quantity == interaction_prep.preparation.countamt:
                 continue
             available_count = get_availability_count(prep, interaction_prep.id, "loanpreparations__id") or 0

--- a/specifyweb/interactions/cog_preps.py
+++ b/specifyweb/interactions/cog_preps.py
@@ -563,19 +563,6 @@ def modify_update_of_loan_return_sibling_preps(original_interaction_obj, updated
     return updated_interaction_data
 
 def enforce_interaction_sibling_prep_max_count(interaction_obj):
-    # if interaction_obj._meta.model_name == 'preparation' or interaction_obj._meta.model_name == 'loanpreparation' : 
-
-    #     if interaction_obj._meta.model_name == 'preparation': 
-    #         collection_object = interaction_obj.collectionobject
-
-    #     if interaction_obj._meta.model_name == 'loanpreparation': 
-    #         collection_object = interaction_obj.preparation.collectionobject
-
-    #     cojo = Collectionobjectgroupjoin.objects.filter(childco=collection_object).first()
-
-    #     if cojo is None: 
-    #         return interaction_obj
-
     def get_interaction_prep_model_and_filter_field(interaction_obj):
         model_map = {
             'loan': (Loanpreparation, 'loan', 'loanpreparations__id'),

--- a/specifyweb/interactions/cog_preps.py
+++ b/specifyweb/interactions/cog_preps.py
@@ -104,7 +104,7 @@ def get_all_sibling_preps_within_consolidated_cog(prep: Preparation) -> List[Pre
     """
     Get all the sibling preparations within the consolidated cog
     """
-    # Get the topmost consolidated parent cog of the preparation
+    # Get the top most consolidated parent cog of the preparation
     top_consolidated_cog = get_the_top_consolidated_parent_cog_of_prep(prep)
     if top_consolidated_cog is None:
         return []

--- a/specifyweb/interactions/cog_preps.py
+++ b/specifyweb/interactions/cog_preps.py
@@ -107,7 +107,7 @@ def get_all_sibling_preps_within_consolidated_cog(prep: Preparation) -> List[Pre
     # Get the topmost consolidated parent cog of the preparation
     top_consolidated_cog = get_the_top_consolidated_parent_cog_of_prep(prep)
     if top_consolidated_cog is None:
-        return [prep]
+        return []
 
     # Get all the sibling preparations
     sibling_preps = get_cog_consolidated_preps(top_consolidated_cog)
@@ -115,7 +115,7 @@ def get_all_sibling_preps_within_consolidated_cog(prep: Preparation) -> List[Pre
     # Remove the prep.id from the sibling preparations
     sibling_preps = [p for p in sibling_preps if p.id != prep.id]
 
-    return sibling_preps
+    return [prep, *sibling_preps]
 
 
 def is_cog_recordset(rs: Recordset) -> bool:
@@ -563,6 +563,19 @@ def modify_update_of_loan_return_sibling_preps(original_interaction_obj, updated
     return updated_interaction_data
 
 def enforce_interaction_sibling_prep_max_count(interaction_obj):
+    # if interaction_obj._meta.model_name == 'preparation' or interaction_obj._meta.model_name == 'loanpreparation' : 
+
+    #     if interaction_obj._meta.model_name == 'preparation': 
+    #         collection_object = interaction_obj.collectionobject
+
+    #     if interaction_obj._meta.model_name == 'loanpreparation': 
+    #         collection_object = interaction_obj.preparation.collectionobject
+
+    #     cojo = Collectionobjectgroupjoin.objects.filter(childco=collection_object).first()
+
+    #     if cojo is None: 
+    #         return interaction_obj
+
     def get_interaction_prep_model_and_filter_field(interaction_obj):
         model_map = {
             'loan': (Loanpreparation, 'loan', 'loanpreparations__id'),


### PR DESCRIPTION
Fixes #6258

### Checklist

- [ ] Self-review the PR after opening it to make sure the changes look good and
      self-explanatory (or properly documented)
- [ ] Add relevant issue to release milestone

### Testing instructions

- [ ] Verify you can create loan with consolidated prep 
- [ ] Verify the quantity for consolidated prep is set to their max after save 
- [ ] Verify the siblings to a consolidated prep are added 
- [ ] Verify the quantity for consolidated prep siblings is set to their max after save 
- [ ] Verify you can create loan with non consolidate prep 
- [ ] Verify the quantity for the non consolidated prep is set to the quantity you defined 
- [ ] Verify you can return a consolidated prep loan 
- [ ] Verify all the siblings are return with the consolidated prep 
- [ ] Verify you can create a loan with a unassociated item 
- [ ] Verify you can return loan with a unassociated item 