### PR TITLE
Add colored  dot to show connexion next to user name in Security & Acc

### DIFF
--- a/specifyweb/context/views.py
+++ b/specifyweb/context/views.py
@@ -321,6 +321,7 @@ def user(request):
         for c in users_collections_for_sp7(request.specify_user.id)
     ]
     data['agent'] = obj_to_data(request.specify_user_agent) if request.specify_user_agent != None else None
+    data['isloggedin'] = request.user.isloggedin
 
     if settings.RO_MODE or not request.user.is_authenticated:
         data['usertype'] = "readonly"

--- a/specifyweb/frontend/js_src/lib/components/InitialContext/userInformation.ts
+++ b/specifyweb/frontend/js_src/lib/components/InitialContext/userInformation.ts
@@ -19,6 +19,7 @@ export type UserInformation = SerializedRecord<SpecifyUser> & {
   readonly isauthenticated: boolean;
   readonly availableCollections: RA<SerializedResource<Collection>>;
   readonly agent: SerializedRecord<Agent>;
+  readonly isloggedin: boolean;
 };
 
 const userInfo: Writable<UserInformation> = {} as UserInformation;

--- a/specifyweb/frontend/js_src/lib/components/Security/Collection.tsx
+++ b/specifyweb/frontend/js_src/lib/components/Security/Collection.tsx
@@ -44,6 +44,7 @@ export type UserRoles = RA<{
   readonly userId: number;
   readonly userName: LocalizedString;
   readonly roles: RA<RoleBase>;
+  readonly isLoggedIn: boolean
 }>;
 
 export type SecurityCollectionOutlet = SecurityOutlet & {
@@ -158,7 +159,7 @@ export function CollectionView({
                 ) : (
                   <>
                     <Ul>
-                      {mergedUsers.map(({ userId, userName, roles }) => {
+                      {mergedUsers.map(({ userId, userName, roles, isLoggedIn }) => {
                         const canRead =
                           userId === userInformation.id ||
                           hasTablePermission('SpecifyUser', 'read');
@@ -172,6 +173,11 @@ export function CollectionView({
                                 )})`}
                               </span>
                             )}
+                              <span
+                                className={`ml-2 inline-block w-2.5 h-2.5 rounded-full  
+                                  ${isLoggedIn ? 'bg-green-500' : 'bg-red-500'}
+                                `}
+                              />
                           </>
                         );
                         return (

--- a/specifyweb/frontend/js_src/lib/components/Security/CollectionHooks.tsx
+++ b/specifyweb/frontend/js_src/lib/components/Security/CollectionHooks.tsx
@@ -62,9 +62,10 @@ export function useCollectionUserRoles(
                 headers: { Accept: 'application/json' },
               }
             ).then(({ data }) =>
-              data.map(({ userid, username, roles }) => ({
+              data.map(({ userid, username, roles, isloggedin }) => ({
                 userId: userid,
                 userName: username,
+                isLoggedIn: isloggedin,
                 roles: roles
                   .map(({ roleid, rolename }) => ({
                     roleId: roleid,
@@ -100,6 +101,8 @@ export const mergeCollectionUsers = (
             ({ userId, userName }) =>
               ({
                 userId,
+                // Need to chnage this
+                isLoggedIn: false,
                 userName,
                 roles: [],
               }) as const

--- a/specifyweb/frontend/js_src/lib/components/Security/CollectionHooks.tsx
+++ b/specifyweb/frontend/js_src/lib/components/Security/CollectionHooks.tsx
@@ -36,10 +36,12 @@ export function useCollectionUsersWithPolicies(
                     userName: await fetchResource('SpecifyUser', userId).then(
                       ({ name }) => localized(name)
                     ),
+                    isLoggedIn: await fetchResource('SpecifyUser', userId).then(
+                      ({ isLoggedIn }) => isLoggedIn)
                   }))
               )
             )
-          : [{ userId: userInformation.id, userName: userInformation.name }],
+          : [{ userId: userInformation.id, userName: userInformation.name,  isLoggedIn: userInformation.isloggedin}],
       [collectionId]
     ),
     false


### PR DESCRIPTION
Fixes #3608

### Checklist

- [ ] Self-review the PR after opening it to make sure the changes look good and
      self-explanatory (or properly documented)
- [ ] Add relevant issue to release milestone

### Testing instructions

- Open security and account 
- [ ] Verify there is a red or green dot next to each user under the user account section 

TODO: 

Set isLoggedIn to true upon login 