### PR TITLE
Add type search for `TaxonTreeDef` and `CollectionObjectType`

### DIFF
--- a/config/backstop/typesearch_def.xml
+++ b/config/backstop/typesearch_def.xml
@@ -68,6 +68,7 @@
     </typesearch>
     <typesearch tableid="65"  name="PrepType"               searchfield="name"            displaycols="name"               format="%s"     dataobjformatter=""/>
     <typesearch tableid="4"   name="Taxon"                  searchfield="fullName"        displaycols="fullName"           format="%s"     dataobjformatter="Taxon"/>
+    <typesearch tableid="76"  name="TaxonTreeDef"       searchfield="name"            displaycols="name"               format="%s"     dataobjformatter=""/>
     <typesearch tableid="77"  name="TaxonTreeDefItem"       searchfield="name"            displaycols="name"               format="%s"     dataobjformatter=""/>
     <typesearch tableid="1027"  name="TectonicUnit"         searchfield="fullName"        displaycols="fullName"           format="%s"     dataobjformatter="TectonicUnit"/>
     <typesearch tableid="1026"  name="TectonicUnitTreeDefItem"       searchfield="name"   displaycols="name"               format="%s"     dataobjformatter=""/>

--- a/config/backstop/typesearch_def.xml
+++ b/config/backstop/typesearch_def.xml
@@ -24,6 +24,7 @@
     <typesearch tableid="97"  name="CatAutoNumberingScheme" searchfield="schemeName"      displaycols="schemeName"         format="%s"     dataobjformatter=""/>
     <typesearch tableid="46"  name="ChronosStrat"           searchfield="name"            displaycols="fullName"           format="%s"     dataobjformatter=""/>
     <typesearch tableid="1"   name="CollectionObject"       searchfield="catalogNumber"   displaycols="catalogNumber"      uifieldformatter="CatalogNumber" dataobjformatter="CollectionObject"/>
+    <typesearch tableid="1015"   name="CollectionObjectType" searchfield="name" displaycols="name"    format="%s"     dataobjformatter=""/>
     <typesearch tableid="1016"   name="CollectionObjectGroup" searchfield="name" displaycols="name"    format="%s"     dataobjformatter=""/>
     <typesearch tableid="1018"   name="CollectionObjectGroupType" searchfield="name" displaycols="name"    format="%s"     dataobjformatter=""/>
     <typesearch tableid="98" name="CollectionRelType"       searchfield="name"            displaycols="name"               format="%s"     dataobjformatter=""/>  


### PR DESCRIPTION
Fixes #6272

### Testing instructions

- [ ] Make sure you can search for a Taxon tree def from the query combo box when creating a Collection Object Type (`taxonTreeDef`)
- [ ] Make sure you can search for a Collection Object Type from the query combo box on the Collection form (`collectionObjectType`)