### PR TITLE
Fix duplicate ID for Collecting Trip

### DIFF
--- a/config/geology/geology.views.xml
+++ b/config/geology/geology.views.xml
@@ -1265,8 +1265,8 @@
 								<cell type="field" id="4" name="locality" uitype="querycbx" initialize="name=Locality;title=Locality;clonebtn=true" colspan="10"/>
 							</row>
 							<row>
-								<cell type="label" labelfor="10"/>
-								<cell type="field" id="10" name="collectingTrip" uitype="querycbx" initialize="name=CollectingTrip;title=CollectingTrip" colspan="10"/>
+								<cell type="label" labelfor="colTrip"/>
+								<cell type="field" id="colTrip" name="collectingTrip" uitype="querycbx" initialize="name=CollectingTrip;title=CollectingTrip" colspan="10"/>
 							</row>
 							<row>
 								<cell type="label" labelfor="remarks"/>

--- a/config/geology/geology.views.xml
+++ b/config/geology/geology.views.xml
@@ -1181,8 +1181,8 @@
 					<cell type="field" id="4" name="locality" uitype="querycbx" initialize="name=Locality;title=Locality;clonebtn=true" colspan="10"/>
 				</row>
 				<row>
-					<cell type="label" labelfor="10"/>
-					<cell type="field" id="10" name="collectingTrip" uitype="querycbx" initialize="name=CollectingTrip;title=CollectingTrip" colspan="10"/>
+					<cell type="label" labelfor="colTrip"/>
+					<cell type="field" id="colTrip" name="collectingTrip" uitype="querycbx" initialize="name=CollectingTrip;title=CollectingTrip" colspan="10"/>
 				</row>
 				<row>
 					<cell type="label" labelfor="6"/>


### PR DESCRIPTION
Fixes #6288 

This fixes a case where there is a single form field ID shared between `endDate` and `collectingTrip` in the `geology.views.xml`.

### Testing instructions

**Before:**
<img width="897" alt="image" src="https://github.com/user-attachments/assets/059baa4a-b4af-43fe-8e5d-7e7c3e12c4dd" />

**After:**
<img width="891" alt="image" src="https://github.com/user-attachments/assets/d5a7a9ac-fc7e-4356-a950-3e98fbc44c79" />

- [ ] Add the `geology` default form definition to app resources
- [ ] Verify that "End Date" appears correctly on the form