### PR TITLE
Only change CO -> catNum for new COs when COT changes

### DIFF
--- a/specifyweb/frontend/js_src/lib/components/DataModel/__tests__/businessRules.test.ts
+++ b/specifyweb/frontend/js_src/lib/components/DataModel/__tests__/businessRules.test.ts
@@ -193,13 +193,13 @@ describe('Collection Object business rules', () => {
 
   test('CollectionObject -> catalogNumber is not reset whenever existing CollectionObject -> collectionObjectType changes', async () => {
     const collectionObject = getBaseCollectionObject();
-    const expectedCatNum = '123';
-    expect(collectionObject.get('catalogNumber')).toBe(expectedCatNum);
+    const expectedCatNumber = '123';
+    expect(collectionObject.get('catalogNumber')).toBe(expectedCatNumber);
     collectionObject.set(
       'collectionObjectType',
       getResourceApiUrl('CollectionObjectType', 2)
     );
-    expect(collectionObject.get('catalogNumber')).toBe(expectedCatNum);
+    expect(collectionObject.get('catalogNumber')).toBe(expectedCatNumber);
     // Wait for any pending promise to complete before test finishes
     await collectionObject.businessRuleManager?.pendingPromise;
   });

--- a/specifyweb/frontend/js_src/lib/components/DataModel/__tests__/businessRules.test.ts
+++ b/specifyweb/frontend/js_src/lib/components/DataModel/__tests__/businessRules.test.ts
@@ -191,14 +191,15 @@ describe('Collection Object business rules', () => {
     await collectionObject.businessRuleManager?.pendingPromise;
   });
 
-  test('CollectionObject -> catalogNumber is reset whenever existing CollectionObject -> collectionObjectType changes', async () => {
+  test('CollectionObject -> catalogNumber is not reset whenever existing CollectionObject -> collectionObjectType changes', async () => {
     const collectionObject = getBaseCollectionObject();
-    expect(collectionObject.get('catalogNumber')).toBe('123');
+    const expectedCatNum = '123';
+    expect(collectionObject.get('catalogNumber')).toBe(expectedCatNum);
     collectionObject.set(
       'collectionObjectType',
       getResourceApiUrl('CollectionObjectType', 2)
     );
-    expect(collectionObject.get('catalogNumber')).toBe('2022-######');
+    expect(collectionObject.get('catalogNumber')).toBe(expectedCatNum);
     // Wait for any pending promise to complete before test finishes
     await collectionObject.businessRuleManager?.pendingPromise;
   });

--- a/specifyweb/frontend/js_src/lib/components/DataModel/businessRuleDefs.ts
+++ b/specifyweb/frontend/js_src/lib/components/DataModel/businessRuleDefs.ts
@@ -182,15 +182,17 @@ export const businessRuleDefs: MappedBusinessRuleDefs = {
     },
     fieldChecks: {
       collectionObjectType: async (resource): Promise<undefined> => {
-        const parser = resolveParser(
-          resource.specifyTable.strictGetLiteralField('catalogNumber'),
-          undefined,
-          resource
-        );
-        // REFACTOR: non-silent set causes infinite loop and silent set still triggers save blocker when parser value is empty string
-        resource.set('catalogNumber', parser.value as never, {
-          silent: (parser.value ?? '') === '',
-        });
+        if (resource.isNew()) {
+          const parser = resolveParser(
+            resource.specifyTable.strictGetLiteralField('catalogNumber'),
+            undefined,
+            resource
+          );
+          // REFACTOR: non-silent set causes infinite loop and silent set still triggers save blocker when parser value is empty string
+          resource.set('catalogNumber', parser.value as never, {
+            silent: (parser.value ?? '') === '',
+          });
+        }
 
         const determinations = resource.getDependentResource('determinations');
         if (determinations === undefined || determinations.models.length === 0)


### PR DESCRIPTION
Fixes #6299 

> Firstly -as far as I can tell- autonumbering has ever only worked when creating new records, and not when updating old records. This would mean that if you were to use the default CatalogNumberNumeric formatter and save an existing record with a `#########` catalogNumber, then Specify wouldn't even try to autonumber the CollectionObject. I'm unsure if this was an intentional design decision (that existing records would not be autonumbered) or not. Of course, it is much simpler to only apply autonumbering to new records, so that might be the case (or part of it)?
> 
> Secondly, technically the default pattern of the incrementing formatter is a valid value for the formatter! With CatalogNumberNumeric for example, `#########` _is_ a valid value for the format, so Specify sees nothing wrong with validating and saving a CollectionObject with the format. I think this goes hand-in-hand with the aforementioned assumption that only new records will have catalogNumbers which match the incrementing default pattern (`###`...).
>
> [This Issue is recreatable in  `v7.9.6.2`]. 
> Of course, with the changes relating to changing the catalogNumber when the CollectionObjectType changes, this is probably more apparent.
> 
> What would you suggest as a solution? Here are some potential solutions I came up with, any number of which can be implemented:
> 
> * Allow autonumbering to apply to existing records
> * Once a record exists in the database, treat `##`.. as an invalid value for the formatter
> * For existing CollectionObjects, don't change the CatalogNumber when the COT changes


From https://github.com/specify/specify7/pull/6261#issuecomment-2677662644

This PR implements the third suggestion of the above; that is, the Catalog Number will not change for existing CollectionObjects whenever the CollectionObjectType changes. 

### Checklist

- [x] Self-review the PR after opening it to make sure the changes look good and
      self-explanatory (or properly documented)
- [x] Add automated tests
- [ ] Add relevant issue to release milestone
- [ ] Add relevant documentation (Tester - Dev)

### Testing instructions
For a Collection which has more than one CollectionObjectType with differing CatalogNumberFormatNames, and at least one  CollectionObjectType with an auto-incrementing numeric Formatter: 

- Go to a new CollectionObject DataEntry Form
- [ ] Ensure that when the CollectionObjectType changes, the catalogNumber changes accordingly to match the CollectionObjectType's format 
- [ ] Save the CollectionObject with a Type which has an auto-incrementing portion and ensure that it is auto-incremented properly (does not save with any `#` placeholders from the format)


- Go to an existing CollectionObject's DataEntry form
- Change the CollectionObjectType to the type which has an auto-incrementing numeric portion
  - If the current CollectionObjectType is the only one which has an auto-incrementing numeric portion, change the CollectionObjectType to another Type and change it back to the original Type
- [ ] Ensure that changing the CollectionObjectType for the CollectionObject does not change the CollectionObject's CatalogNumber
