### PR TITLE
Remove cat number format check in interaction dialog

### DIFF
--- a/specifyweb/frontend/js_src/lib/components/Interactions/InteractionDialog.tsx
+++ b/specifyweb/frontend/js_src/lib/components/Interactions/InteractionDialog.tsx
@@ -232,13 +232,12 @@ export function InteractionDialog({
     }
 
     if (collectionHasSeveralTypes === true) {
-      const parsedCatNumber = (split(catalogNumbers).map((catalogNumber) => parser.parser?.(catalogNumber) ?? catalogNumber))
-
-      setCatalogNumbers(parsedCatNumber.join('\n'))
-
+      const parsedCatNumber = split(catalogNumbers);
+    
+      setCatalogNumbers(parsedCatNumber.join('\n'));
       setState({ type: 'MainState' });
-
-      return(parsedCatNumber.map((cat) => (cat as number | string).toString()))
+    
+      return parsedCatNumber.map(String);
     }
 
     const parsed = f.unique(

--- a/specifyweb/frontend/js_src/lib/components/Interactions/InteractionDialog.tsx
+++ b/specifyweb/frontend/js_src/lib/components/Interactions/InteractionDialog.tsx
@@ -32,13 +32,12 @@ import type {
   SerializedResource,
 } from '../DataModel/helperTypes';
 import type { SpecifyResource } from '../DataModel/legacyTypes';
-import { getResourceViewUrl, resourceFromUrl } from '../DataModel/resource';
-import { fetchContext as fetchDomain, schema } from '../DataModel/schema';
+import { getResourceViewUrl } from '../DataModel/resource';
+import { fetchContext as fetchDomain } from '../DataModel/schema';
 import type { LiteralField } from '../DataModel/specifyField';
 import type { Collection, SpecifyTable } from '../DataModel/specifyTable';
 import { tables } from '../DataModel/tables';
 import type {
-  CollectionObjectType,
   DisposalPreparation,
   GiftPreparation,
   LoanPreparation,

--- a/specifyweb/frontend/js_src/lib/components/Interactions/InteractionDialog.tsx
+++ b/specifyweb/frontend/js_src/lib/components/Interactions/InteractionDialog.tsx
@@ -206,17 +206,6 @@ export function InteractionDialog({
     const parseResults = split(catalogNumbers).map((value) =>
       parseValue(parser, inputRef.current ?? undefined, value)
     );
-    const errorMessages = parseResults
-      .filter((result): result is InvalidParseResult => !result.isValid)
-      .map(({ reason, value }) => `${reason} (${value})`);
-    if (errorMessages.length > 0) {
-      setValidation(errorMessages);
-      setState({
-        type: 'InvalidState',
-        invalid: errorMessages,
-      });
-      return undefined;
-    }
 
     const parsed = f.unique(
       (parseResults as RA<ValidParseResult>)

--- a/specifyweb/frontend/js_src/lib/components/Interactions/InteractionDialog.tsx
+++ b/specifyweb/frontend/js_src/lib/components/Interactions/InteractionDialog.tsx
@@ -14,7 +14,6 @@ import {
   resolveParser,
 } from '../../utils/parser/definitions';
 import type {
-  InvalidParseResult,
   ValidParseResult,
 } from '../../utils/parser/parse';
 import { parseValue } from '../../utils/parser/parse';
@@ -100,7 +99,7 @@ export function InteractionDialog({
     | State<'MainState'>
   >({ type: 'MainState' });
 
-  const { validationRef, inputRef, setValidation } =
+  const { validationRef, inputRef } =
     useValidation<HTMLTextAreaElement>();
   const [catalogNumbers, setCatalogNumbers] = React.useState<string>('');
 

--- a/specifyweb/frontend/js_src/lib/components/Interactions/InteractionDialog.tsx
+++ b/specifyweb/frontend/js_src/lib/components/Interactions/InteractionDialog.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import type { State } from 'typesafe-reducer';
 
+import { useAsyncState } from '../../hooks/useAsyncState';
 import { useValidation } from '../../hooks/useValidation';
 import { commonText } from '../../localization/common';
 import { interactionsText } from '../../localization/interactions';
@@ -30,11 +31,13 @@ import type {
   SerializedResource,
 } from '../DataModel/helperTypes';
 import type { SpecifyResource } from '../DataModel/legacyTypes';
-import { getResourceViewUrl } from '../DataModel/resource';
+import { getResourceViewUrl, resourceFromUrl } from '../DataModel/resource';
+import { fetchContext as fetchDomain, schema } from '../DataModel/schema';
 import type { LiteralField } from '../DataModel/specifyField';
 import type { Collection, SpecifyTable } from '../DataModel/specifyTable';
 import { tables } from '../DataModel/tables';
 import type {
+  CollectionObjectType,
   DisposalPreparation,
   GiftPreparation,
   LoanPreparation,
@@ -201,10 +204,22 @@ export function InteractionDialog({
       })),
     });
 
+    const [collectionHasSeveralTypes] = useAsyncState(
+      React.useCallback(
+        async () =>
+          fetchDomain.then(async (schema) => Object.keys(schema.collectionObjectTypeCatalogNumberFormats).length > 1),
+        []
+      ),
+      false
+    );
+
   function handleParse(): RA<string> | undefined {
     const parseResults = split(catalogNumbers).map((value) =>
       parseValue(parser, inputRef.current ?? undefined, value)
     );
+
+    const form = parser.parser?.(split(catalogNumbers)[0])
+    console.log(form)
 
     const parsed = f.unique(
       (parseResults as RA<ValidParseResult>)


### PR DESCRIPTION
Fixes #6287

### Checklist

- [ ] Self-review the PR after opening it to make sure the changes look good and
      self-explanatory (or properly documented)
- [ ] Add relevant issue to release milestone

### Testing instructions

- Go to Interactions and choose Loan
- Choose the option "By entering catalog numbers"
- Enter a catalog number that is using a COT with a non-default catalog number
- Click Next
- [ ] Verify that you are directed to the prep dialog selection If the CO has preps
- [ ] Verify that a message "no prep found for this cat num" is displayed If the CO has no preps or even doesn't exist 

Notes: 
Since we now allow multiple catalog number formats within the same collection using the collection object type, we can no longer determine which type of CO corresponds to the catalog number entered in the interaction dialog. 

As a result, checking whether the catalog number follows the default collection format is no longer necessary for collections having multiple COType cat number format. Therefore, that check and the error message for catalog number format will be displayed only for collections that have a single cat number format COType.

For collections having several COTypes the parser will not be used anymore which means that to fins cat num 000001 entering only 1 will not work the user has to enter the entire format  