### PR TITLE
Fix ordering of query params

### DIFF
--- a/specifyweb/stored_queries/batch_edit.py
+++ b/specifyweb/stored_queries/batch_edit.py
@@ -1043,19 +1043,19 @@ def run_batch_edit_query(props: BatchEditProps):
 
     with props["session_maker"]() as session:
         rows = execute(
-            session,
-            props["collection"],
-            props["user"],
-            tableid,
-            True,
-            False,
-            query_with_hidden,
-            limit,
-            offset,
-            True,
-            recordsetid,
-            False,
-            True,
+            session=session,
+            collection=props["collection"],
+            user=props["user"],
+            tableid=tableid,
+            distinct=True,
+            count_only=False,
+            field_specs=query_with_hidden,
+            limit=limit,
+            offset=offset,
+            format_agent_type=True,
+            recordsetid=recordsetid,
+            formatauditobjs=False,
+            format_picklist=True,
         )
 
     to_many_planner = indexed.to_many_planner()

--- a/specifyweb/stored_queries/execution.py
+++ b/specifyweb/stored_queries/execution.py
@@ -537,16 +537,16 @@ def run_ephemeral_query(collection, user, spquery):
     with models.session_context() as session:
         field_specs = fields_from_json(spquery["fields"])
         return execute(
-            session,
-            collection,
-            user,
-            tableid,
-            distinct,
-            count_only,
-            field_specs,
-            limit,
-            offset,
-            recordsetid,
+            session=session,
+            collection=collection,
+            user=user,
+            tableid=tableid,
+            distinct=distinct,
+            count_only=count_only,
+            field_specs=field_specs,
+            limit=limit,
+            offset=offset,
+            recordsetid=recordsetid,
             formatauditobjs=format_audits,
         )
 

--- a/specifyweb/stored_queries/views.py
+++ b/specifyweb/stored_queries/views.py
@@ -89,8 +89,17 @@ def query(request, id):
         field_specs = [QueryField.from_spqueryfield(field, value_from_request(field, request.GET))
                        for field in sorted(sp_query.fields, key=lambda field: field.position)]
 
-        data = execute(session, request.specify_collection, request.specify_user,
-                       tableid, distinct, count_only, field_specs, limit, offset)
+        data = execute(
+            session=session, 
+            collection=request.specify_collection, 
+            user=request.specify_user,
+            tableid=tableid, 
+            distinct=distinct, 
+            count_only=count_only, 
+            field_specs=field_specs, 
+            limit=limit, 
+            offset=offset
+        )
 
     return HttpResponse(toJson(data), content_type='application/json')
 


### PR DESCRIPTION
Fixes #6317 

The query `execute` function was not being passed the params in the right order. <sub><sup>yay loosely typed languages 😄 </sub></sup>

<!--
> [!WARNING]  
> This PR affects database migrations. See [migration testing instructions](https://specify.github.io/testing/pull_requests.html#prs-tagged-with-label-migration).
-->

### Checklist

- [x] Self-review the PR after opening it to make sure the changes look good and
      self-explanatory (or properly documented)
- [ ] Add automated tests
- [x] Add relevant issue to release milestone
- [ ] Add relevant documentation (Tester - Dev)
- [ ] Add a reverse migration if a migration is present in the PR

### Testing instructions

<!-- What are the steps to verify the fixes/changes in this PR? -->
<!-- Can part of that be replaced by automated tests? -->
- Query from a record set (Open a RS -> Click on pencil icon -> Query)
- [ ] Verify results are restricted to records in the record set