### PR TITLE
Disable batch edit for spAuditLog

### DIFF
--- a/specifyweb/frontend/js_src/lib/components/BatchEdit/index.tsx
+++ b/specifyweb/frontend/js_src/lib/components/BatchEdit/index.tsx
@@ -99,7 +99,7 @@ export function BatchEditFromQuery({
           queryFieldSpecs.some(hasHierarchyBaseTable) ||
           // TODO: Remove this when we have batch edit for tree tables #6127
           queryFieldSpecs.some(containsTreeTableOrSpecificRank) || 
-          queryFieldSpecs.some(spec => spec.baseTable?.name === "SpAuditLog")
+          query.get('contextName') === 'SpAuditLog'
         }
         onClick={() => {
           loading(

--- a/specifyweb/frontend/js_src/lib/components/BatchEdit/index.tsx
+++ b/specifyweb/frontend/js_src/lib/components/BatchEdit/index.tsx
@@ -97,7 +97,9 @@ export function BatchEditFromQuery({
         disabled={
           queryFieldSpecs.some(containsSystemTables) ||
           queryFieldSpecs.some(hasHierarchyBaseTable) ||
-          queryFieldSpecs.some(containsTreeTableOrSpecificRank) // TODO: Remove this when we have batch edit for tree tables #6127
+          // TODO: Remove this when we have batch edit for tree tables #6127
+          queryFieldSpecs.some(containsTreeTableOrSpecificRank) || 
+          queryFieldSpecs.some(spec => spec.baseTable?.name === "SpAuditLog")
         }
         onClick={() => {
           loading(


### PR DESCRIPTION
Fixes #6323

### Checklist

- [ ] Self-review the PR after opening it to make sure the changes look good and
      self-explanatory (or properly documented)
- [ ] Add relevant issue to release milestone

### Testing instructions

- Go to queries
- Select 'Sp audit log' as the base table
- Press query
- [ ] Verify that batch edit button is disabled
- Go to queries
- Select another table as the base table
- Press query
- [ ] Verify that batch edit button is enabled when it should 