### PR TITLE
Remove isPrimary from uniq field for carry & clone config

### DIFF
--- a/specifyweb/frontend/js_src/lib/components/DataModel/resource.ts
+++ b/specifyweb/frontend/js_src/lib/components/DataModel/resource.ts
@@ -277,7 +277,6 @@ const uniqueFields = [
   'timestampCreated',
   'version',
   'isCurrent',
-  'isPrimary',
   'timestampModified',
 ];
 

--- a/specifyweb/frontend/js_src/lib/components/DataModel/schemaOverrides.ts
+++ b/specifyweb/frontend/js_src/lib/components/DataModel/schemaOverrides.ts
@@ -226,6 +226,7 @@ const fieldOverwrites: typeof globalFieldOverrides = {
     definition: { visibility: 'hidden' },
     definitionItem: { visibility: 'hidden' },
     orderNumber: { visibility: 'hidden' },
+    isPrimary: { visibility: 'hidden' },
     isHybrid: { visibility: 'hidden' },
     isAccepted: { visibility: 'hidden' },
     fullName: { visibility: 'readOnly' },

--- a/specifyweb/frontend/js_src/lib/components/DataModel/schemaOverrides.ts
+++ b/specifyweb/frontend/js_src/lib/components/DataModel/schemaOverrides.ts
@@ -226,7 +226,6 @@ const fieldOverwrites: typeof globalFieldOverrides = {
     definition: { visibility: 'hidden' },
     definitionItem: { visibility: 'hidden' },
     orderNumber: { visibility: 'hidden' },
-    isPrimary: { visibility: 'hidden' },
     isHybrid: { visibility: 'hidden' },
     isAccepted: { visibility: 'hidden' },
     fullName: { visibility: 'readOnly' },

--- a/specifyweb/frontend/js_src/lib/components/DataModel/uniqueFields.json
+++ b/specifyweb/frontend/js_src/lib/components/DataModel/uniqueFields.json
@@ -22,7 +22,6 @@
     "timestampCreated",
     "version",
     "isCurrent",
-    "isPrimary",
     "timestampModified"
   ],
   "addressofrecord": ["timestampCreated", "version", "timestampModified"],
@@ -200,7 +199,6 @@
   "collector": [
     "timestampCreated",
     "version",
-    "isPrimary",
     "timestampModified"
   ],
   "commonnametx": ["timestampCreated", "version", "timestampModified"],
@@ -285,7 +283,6 @@
   "determiner": [
     "timestampCreated",
     "version",
-    "isPrimary",
     "timestampModified"
   ],
   "discipline": ["timestampCreated", "version", "timestampModified"],
@@ -375,7 +372,6 @@
   "fundingagent": [
     "timestampCreated",
     "version",
-    "isPrimary",
     "timestampModified"
   ],
   "geocoorddetail": ["timestampCreated", "version", "timestampModified"],
@@ -648,7 +644,6 @@
   "collectionobjectgroupjoin": [
     "timestampCreated",
     "version",
-    "isPrimary",
     "timestampModified"
   ],
   "collectionobjectgrouptype": [


### PR DESCRIPTION
Fixes #6229

### Checklist

- [ ] Self-review the PR after opening it to make sure the changes look good and
      self-explanatory (or properly documented)
- [ ] Add relevant issue to release milestone

### Testing instructions

- Open Collecting Event data entry form 
- Add required field 
- Add a collector 
- Set its isPrimary field to true 
- Save 
- Open the carry forward config dialog 
- Open the carry forward config dialog for the relationship Collector 
- [ ] Verify you can check and uncheck isPrimary field 
- Keep is primary checked 
- Carry forward the record 
- [ ] Verify the isPrimary as been carried over for the collector 

Notes: 
Since isPrimary field has an override attribute hidden=true in our code even if you uncheck is hidden in the schema config (which will affect other places) it will still stays a hidden field in this context 