### PR TITLE
Add min=0 to quantityResolved & quantityReturn for LoanReturnPrep view

### DIFF
--- a/config/common/common.views.xml
+++ b/config/common/common.views.xml
@@ -4943,9 +4943,9 @@
 				</row>
 				<row>
 					<cell type="label" labelfor="3"/>
-					<cell type="field" id="3" name="quantityReturned" uitype="spinner" initialize="max=5000"/>
+					<cell type="field" id="3" name="quantityReturned" uitype="spinner" initialize="max=5000; min=0"/>
 					<cell type="label" labelfor="5"/>
-					<cell type="field" id="5" name="quantityResolved" uitype="spinner" initialize="max=5000"/>
+					<cell type="field" id="5" name="quantityResolved" uitype="spinner" initialize="max=5000; min=0"/>
 				</row>
 				<row>
 					<cell type="label" labelfor="4"/>


### PR DESCRIPTION
Fixes #5031

### Checklist

- [ ] Self-review the PR after opening it to make sure the changes look good and
      self-explanatory (or properly documented)
- [ ] Add relevant issue to release milestone

### Testing instructions

- Create or use an existing loan record
- Return the record and save
- Click on the "LrP" icon to open the Loan Return Preparations form
- [ ] Verify that you cannot lower the value to a negative number

Notes: 
The form for Loan Return Preparations is generated automatically so the best way to prevent the negative number is to add in your view def `initialize="min=0"` for `quantityReturned` field in `LoanReturnPreparation viewdef` and same for `quantityResolved` field. 
I think this is something that could be the 'default' for everyone so I went ahead and added those attribute to the `common view xml`. 