### PR TITLE
Reload the page after query title changed

### DIFF
--- a/specifyweb/frontend/js_src/lib/components/QueryBuilder/Edit.tsx
+++ b/specifyweb/frontend/js_src/lib/components/QueryBuilder/Edit.tsx
@@ -86,7 +86,7 @@ function EditQueryDialog({
       onAdd={undefined}
       onClose={handleClose}
       onDeleted={handleClose}
-      onSaved={(): void => window.location.reload()}
+      onSaved={(): void => globalThis.location.reload()}
     >
       {queryResource.isNew() ? undefined : (
         <div className="flex flex-col">

--- a/specifyweb/frontend/js_src/lib/components/QueryBuilder/Edit.tsx
+++ b/specifyweb/frontend/js_src/lib/components/QueryBuilder/Edit.tsx
@@ -87,7 +87,7 @@ function EditQueryDialog({
       onAdd={undefined}
       onClose={handleClose}
       onDeleted={handleClose}
-      onSaved={(): void => navigate(`/specify/query/${queryResource.id}/`)}
+      onSaved={(): void => window.location.reload()}
     >
       {queryResource.isNew() ? undefined : (
         <div className="flex flex-col">

--- a/specifyweb/frontend/js_src/lib/components/QueryBuilder/Edit.tsx
+++ b/specifyweb/frontend/js_src/lib/components/QueryBuilder/Edit.tsx
@@ -60,7 +60,6 @@ function EditQueryDialog({
   >('default');
 
   const loading = React.useContext(LoadingContext);
-  const navigate = useNavigate();
   return state === 'default' ? (
     <ResourceView
       dialog="modal"


### PR DESCRIPTION
Fixes #2234

### Checklist

- [ ] Self-review the PR after opening it to make sure the changes look good and
      self-explanatory (or properly documented)
- [ ] Add relevant issue to release milestone

### Testing instructions

- Use the ✏️ icon to change the name of a query
- Save
- [ ] Verify the page reload and you can see the new name 
