### PR TITLE
Set isPrimary to the last added collector

### DIFF
--- a/specifyweb/frontend/js_src/lib/components/DataModel/businessRuleDefs.ts
+++ b/specifyweb/frontend/js_src/lib/components/DataModel/businessRuleDefs.ts
@@ -32,6 +32,7 @@ import type {
   CollectionObject,
   CollectionObjectGroup,
   CollectionObjectGroupJoin,
+  Collector,
   Determination,
   DNASequence,
   LoanPreparation,
@@ -341,6 +342,31 @@ export const businessRuleDefs: MappedBusinessRuleDefs = {
         cog.businessRuleManager?.checkField('cogType');
       }
     },
+  },
+
+  Collector: {
+    fieldChecks:{
+      isPrimary: (
+        collector: SpecifyResource<Collector>
+      ): void => {
+        if (collector.get('isPrimary') && collector.collection !== undefined) {
+          collector.collection.models.map((other: SpecifyResource<Collector>) => {
+            if (other.cid !== collector.cid) {
+              other.set('isPrimary', false)
+            }
+          }
+        )
+        }
+      }
+    },
+    onRemoved: (collector, collection): void => {
+      if (collector.get('isPrimary') && collection.models.length > 0) {
+        collection.models[0].set('isPrimary', true);
+      }
+    },
+    onAdded: (collector): void => {
+      collector.set('isPrimary', true)
+    }
   },
 
   Determination: {

--- a/specifyweb/frontend/js_src/lib/components/DataModel/businessRuleDefs.ts
+++ b/specifyweb/frontend/js_src/lib/components/DataModel/businessRuleDefs.ts
@@ -364,8 +364,10 @@ export const businessRuleDefs: MappedBusinessRuleDefs = {
         collection.models[0].set('isPrimary', true);
       }
     },
-    onAdded: (collector): void => {
-      collector.set('isPrimary', true)
+    onAdded: (collector, collection): void => {
+      if (collection.models.length === 1){
+        collector.set('isPrimary', true)
+      }
     }
   },
 


### PR DESCRIPTION
Fixes #2300

### Checklist

- [ ] Self-review the PR after opening it to make sure the changes look good and
      self-explanatory (or properly documented)
- [ ] Add relevant issue to release milestone

### Testing instructions

- Open collecting event form 
- Verify that you have a subview for collector and that the field isPrimary is visible 
- Add a collector 
- Save 
- [ ] Verify the collector isPrimary field is set to true when first added 
- Add a second collector 
- Save 
- [ ] Verify the last collector added is not set to isPrimary true and that the first one added is still true
- Add a third collector 
- Save 
- Delete one collector that is not the primary 
- [ ] Verify the primary is still set to the correct collector 
- Delete the collector that is the primary 
- [ ] Verify that the other one has been set to isPrimary 

Notes: 
No save blockers were added to this new business rule because we still want to allow users to save the CE form without a primary collector if they want to. 