### PR TITLE
Display record set button in search dialog only for to-many

### DIFF
--- a/specifyweb/frontend/js_src/lib/components/SearchDialog/index.tsx
+++ b/specifyweb/frontend/js_src/lib/components/SearchDialog/index.tsx
@@ -82,6 +82,7 @@ export function SearchDialog<SCHEMA extends AnySchema>(
   const [useQueryBuilder, handleUseQueryBuilder] = useBooleanState(
     props.onlyUseQueryBuilder ? true : alwaysUseQueryBuilder
   );
+  console.log(props.multiple)
   return useQueryBuilder ? (
     <QueryBuilderSearch
       // BUG: pass on extraFilters
@@ -92,7 +93,7 @@ export function SearchDialog<SCHEMA extends AnySchema>(
       }}
     />
   ) : (
-    <SearchForm {...props} onUseQueryBuilder={handleUseQueryBuilder} />
+    <SearchForm {...props} multiple={props.multiple} onUseQueryBuilder={handleUseQueryBuilder}/>
   );
 }
 
@@ -185,6 +186,7 @@ function SearchForm<SCHEMA extends AnySchema>({
   onClose: handleClose,
   onUseQueryBuilder: handleUseQueryBuilder,
   onAdd: handleAdd,
+  multiple
 }: {
   readonly forceCollection: number | undefined;
   readonly extraFilters: RA<QueryComboBoxFilter<SCHEMA>> | undefined;
@@ -196,6 +198,7 @@ function SearchForm<SCHEMA extends AnySchema>({
   readonly onAdd?:
     | ((resources: RA<SpecifyResource<SCHEMA>>) => void)
     | undefined;
+  readonly multiple?: boolean
 }): JSX.Element | null {
   const templateResource = React.useMemo(
     () =>
@@ -208,6 +211,7 @@ function SearchForm<SCHEMA extends AnySchema>({
     [table]
   );
   const viewName = viewNameExceptions[table.name] ?? `${table.name}Search`;
+  console.log(multiple)
 
   const resolvedName = searchView ?? viewName;
   const viewDefinition = useViewDefinition({
@@ -239,11 +243,11 @@ function SearchForm<SCHEMA extends AnySchema>({
               {queryText.queryBuilder()}
             </Button.Info>
           </ProtectedAction>
-          <SelectRecordSets
+          {multiple === true && <SelectRecordSets
             handleParentClose={handleClose}
             table={table}
             onAdd={handleAdd}
-          />
+          />}
           <Submit.Success form={id('form')}>
             {commonText.search()}
           </Submit.Success>

--- a/specifyweb/frontend/js_src/lib/components/SearchDialog/index.tsx
+++ b/specifyweb/frontend/js_src/lib/components/SearchDialog/index.tsx
@@ -82,7 +82,7 @@ export function SearchDialog<SCHEMA extends AnySchema>(
   const [useQueryBuilder, handleUseQueryBuilder] = useBooleanState(
     props.onlyUseQueryBuilder ? true : alwaysUseQueryBuilder
   );
-  console.log(props.multiple)
+
   return useQueryBuilder ? (
     <QueryBuilderSearch
       // BUG: pass on extraFilters

--- a/specifyweb/frontend/js_src/lib/components/SearchDialog/index.tsx
+++ b/specifyweb/frontend/js_src/lib/components/SearchDialog/index.tsx
@@ -93,7 +93,7 @@ export function SearchDialog<SCHEMA extends AnySchema>(
       }}
     />
   ) : (
-    <SearchForm {...props} multiple={props.multiple} onUseQueryBuilder={handleUseQueryBuilder}/>
+    <SearchForm {...props} onUseQueryBuilder={handleUseQueryBuilder}/>
   );
 }
 
@@ -211,7 +211,6 @@ function SearchForm<SCHEMA extends AnySchema>({
     [table]
   );
   const viewName = viewNameExceptions[table.name] ?? `${table.name}Search`;
-  console.log(multiple)
 
   const resolvedName = searchView ?? viewName;
   const viewDefinition = useViewDefinition({


### PR DESCRIPTION
Fixes #5453

### Checklist

- [ ] Self-review the PR after opening it to make sure the changes look good and
      self-explanatory (or properly documented)
- [ ] Add relevant issue to release milestone

### Testing instructions

- Go to data entry for Collection Object
- Click on the Search button on a QCBX, like cataloger
- [ ] Verify Record Set button is not an option
- Go to accession data entry 
- Click on the + button next to collection object subview 
- [ ] Verify Record Set button is an option 

==> Record set button should not be available for to-one and should be for the to-many