### PR TITLE
Fix desynonymize message

### DIFF
--- a/specifyweb/frontend/js_src/lib/components/TreeView/Actions.tsx
+++ b/specifyweb/frontend/js_src/lib/components/TreeView/Actions.tsx
@@ -476,7 +476,7 @@ function ActiveAction<SCHEMA extends AnyTree>({
                     })
                   : treeText.desynonymizeNodeMessage({
                       nodeName: actionRow.fullName,
-                      synonymName: focusedRow.fullName,
+                      synonymName: focusedRow.acceptedName!,
                     })}
         </Dialog>
       ) : undefined}


### PR DESCRIPTION
Fixes #4477

### Checklist

- [ ] Self-review the PR after opening it to make sure the changes look good and
      self-explanatory (or properly documented)
- [ ] Add relevant issue to release milestone

### Testing instructions

- Open a tree 
- Synonymies 2 nodes i.e: A and B
- Click on the synonym node 
- Click desynonymize node action 
- [ ] Verify that the message in the dialog is " "A" will no longer be a synonym of "B"." instead of "A" will no longer be a synonym of "A".