### PR TITLE
Make Sp user read only in reports dialog

### DIFF
--- a/specifyweb/frontend/js_src/lib/components/Reports/index.tsx
+++ b/specifyweb/frontend/js_src/lib/components/Reports/index.tsx
@@ -14,6 +14,7 @@ import { className } from '../Atoms/className';
 import { icons } from '../Atoms/Icons';
 import { Link } from '../Atoms/Link';
 import { attachmentSettingsPromise } from '../Attachments/attachments';
+import { ReadOnlyContext } from '../Core/Contexts';
 import { getField } from '../DataModel/helpers';
 import type {
   SerializedRecord,
@@ -246,9 +247,11 @@ function ReportRow({
               <DateElement date={entry.appResource.timestampCreated} />
             </td>
             <td>
+              <ReadOnlyContext.Provider value>
               <FormattedResourceUrl
                 resourceUrl={entry.appResource.specifyUser}
               />
+              </ReadOnlyContext.Provider>
             </td>
             <td>
               <Link.Icon


### PR DESCRIPTION
Fixes #4391

### Checklist

- [ ] Self-review the PR after opening it to make sure the changes look good and
      self-explanatory (or properly documented)
- [ ] Add relevant issue to release milestone

### Testing instructions

- Go to the Reports dialog
- See the 'Created By Agent' column
- Click on one of the names (these are specify users, not agents)
- [ ] Verify that the resource is read only 
