### PR TITLE
In prep dialog, display 'not available' if no taxon

### DIFF
--- a/specifyweb/frontend/js_src/lib/components/Interactions/PrepDialogRow.tsx
+++ b/specifyweb/frontend/js_src/lib/components/Interactions/PrepDialogRow.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import type { LocalizedString } from 'typesafe-i18n';
 import type { State } from 'typesafe-reducer';
 
-import { commonText } from '../../localization/common';
 import { interactionsText } from '../../localization/interactions';
 import type { RA, RR } from '../../utils/types';
 import { localized } from '../../utils/types';

--- a/specifyweb/frontend/js_src/lib/components/Interactions/PrepDialogRow.tsx
+++ b/specifyweb/frontend/js_src/lib/components/Interactions/PrepDialogRow.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import type { LocalizedString } from 'typesafe-i18n';
 import type { State } from 'typesafe-reducer';
 
+import { commonText } from '../../localization/common';
 import { interactionsText } from '../../localization/interactions';
 import type { RA, RR } from '../../utils/types';
 import { localized } from '../../utils/types';
@@ -81,9 +82,13 @@ export function PrepDialogRow({
           </Link.NewTab>
         </td>
         <td>
-          <Link.NewTab href={getResourceViewUrl('Taxon', preparation.taxonId)}>
-            {localized(preparation.taxon)}
-          </Link.NewTab>
+          {preparation.taxon ? (
+            <Link.NewTab href={getResourceViewUrl('Taxon', preparation.taxonId)}>
+              {localized(preparation.taxon)}
+            </Link.NewTab>
+          ) : (
+            <span>{interactionsText.notAvailable()}</span> 
+          )}
         </td>
         <td>{preparation.prepType}</td>
         <td>

--- a/specifyweb/frontend/js_src/lib/localization/interactions.ts
+++ b/specifyweb/frontend/js_src/lib/localization/interactions.ts
@@ -387,4 +387,7 @@ export const interactionsText = createDictionary({
     'ru-ru': 'Продолжить без подготовки',
     'uk-ua': 'Продовжуйте без підготовки',
   },
+  notAvailable: {
+    'en-us': 'Not available'
+  }
 } as const);


### PR DESCRIPTION
Fixes #3882

### Checklist

- [ ] Self-review the PR after opening it to make sure the changes look good and
      self-explanatory (or properly documented)
- [ ] Add relevant issue to release milestone

### Testing instructions

- Create a CO with preps only, no other information for taxon
- Create a New Loan and enter the Cat # for the record you just made
- For the "Taxon" column in the prep dialog:
- [ ] Verify there is the message 'Not available' instead of the broken 404 link 
- [ ] For prep that do have a taxon, verify the Taxon link is still present and functioning 
