### PR TITLE
Allow to empty count for bulk carry

### DIFF
--- a/specifyweb/frontend/js_src/lib/components/Forms/Save.tsx
+++ b/specifyweb/frontend/js_src/lib/components/Forms/Save.tsx
@@ -256,6 +256,7 @@ export function SaveButton<SCHEMA extends AnySchema = AnySchema>({
             <Input.Integer
               aria-label={formsText.bulkCarryForwardCount()}
               className="!w-fit"
+              max={5000}
               min={1}
               placeholder="1"
               value={carryForwardAmount}

--- a/specifyweb/frontend/js_src/lib/components/Forms/Save.tsx
+++ b/specifyweb/frontend/js_src/lib/components/Forms/Save.tsx
@@ -260,9 +260,7 @@ export function SaveButton<SCHEMA extends AnySchema = AnySchema>({
               placeholder="1"
               value={carryForwardAmount}
               onValueChange={(value): void =>
-                Number.isNaN(value)
-                  ? setCarryForwardAmount(1)
-                  : setCarryForwardAmount(Number(value))
+                setCarryForwardAmount(Number(value))
               }
             />
           ) : null}


### PR DESCRIPTION
Fixes #5228

### Checklist

- [ ] Self-review the PR after opening it to make sure the changes look good and
      self-explanatory (or properly documented)
- [ ] Add relevant issue to release milestone

### Testing instructions

- Go to a record
- Make sure Carry Forward and Bulk Carry Forward are checked in the Form Meta menu
- [ ] Verify you can clear the count field next to the Carry Forward button and set it to whichever number you want

Notes: 
If the user enters 0, clears the count box, or leaves it empty, the standard carry-forward behavior will be triggered when the "Carry Forward" button is clicked. This will create a new record based on the carry-forward configuration.
