### PR TITLE
Upgrade base docker image to ubuntu version 20.04

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:18.04 AS common
+FROM ubuntu:20.04 AS common
 
 LABEL maintainer="Specify Collections Consortium <github.com/specify>"
 
@@ -7,7 +7,7 @@ RUN apt-get update \
         gettext \
         python3.8 \
         libldap-2.4-2 \
-        libmariadbclient18 \
+        libmariadb3 \
         rsync \
  && apt-get clean \
  && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Fixes #3793

Upgrade base docker image to ubuntu version 20.04 by changing the docker file base image and updating the dependent linux and python libraries.

### Checklist

- [x] Self-review the PR after opening it to make sure the changes look good and
      self-explanatory (or properly documented)
- [x] Add relevant issue to release milestone

### Testing instructions

- [x] Build and open Specify 7
- [x] General testing of data entry forms
- [x] General testing of query builder
- [x] General testing of statistics page
- [x] General testing of workbench
