### PR TITLE
Add dataentry_task.xml for geology config

### DIFF
--- a/config/geology/app_resources.xml
+++ b/config/geology/app_resources.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<files>
+    <file level="3" mimetype="text/xml" name="DataEntryTaskInit" description="DataEntryTaskInit" file="dataentry_task.xml"/>
+</files>

--- a/config/geology/dataentry_task.xml
+++ b/config/geology/dataentry_task.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<views>
+	<std>
+	    
+	     
+	    <view sidebar="true"  title="Collection Object"  view="CollectionObject"   iconname="CollectionObject"   tooltip=""/>    
+	    <view sidebar="false"  title="Collecting Event"   view="CollectingEvent"    iconname="CollectingEvent"    tooltip=""/>    
+	    <view sidebar="true"  title="Taxon"              view="Taxon"              iconname="Taxon"              tooltip=""/> 
+	    <view sidebar="true"  title="Agent"              view="Agent"              iconname="Agent"              tooltip=""/>    
+	    <view sidebar="true"  title="Geography"          view="Geography"          iconname="Geography"          tooltip=""/> 
+		<view sidebar="true"  title="Locality"           view="Locality"           iconname="Locality"           tooltip=""/> 
+	</std>
+	
+	<misc>
+        <!-- <view sidebar="true"  title="Deaccession"        viewset="Common"       view="Deaccession"        iconname="Deaccession"        tooltip=""/> -->
+		<view sidebar="true"  title="Storage"            view="Storage"            iconname="Storage"           tooltip=""/>
+	</misc>
+</views>


### PR DESCRIPTION
Fixes #6360

Add dataentry_task.xml file for geology config to avoid errors with the context API.

### Checklist

- [ ] Self-review the PR after opening it to make sure the changes look good and
      self-explanatory (or properly documented)
- [ ] Add relevant issue to release milestone

### Testing instructions

- Login to a geology discipline
- [x] Click on the data entry button from the home page, see that the data entry dialog opens correctly.
- [x] Open http://localhost/context/app.resource?name=DataEntryTaskInit and see that the xml file is returned.
