### PR TITLE
Do no send focus back to selected node when clicking in tree

### DIFF
--- a/specifyweb/frontend/js_src/lib/components/TreeView/Tree.tsx
+++ b/specifyweb/frontend/js_src/lib/components/TreeView/Tree.tsx
@@ -157,12 +157,6 @@ export function Tree<
         // If user wants to edit tree ranks, allow tree ranks to receive focus
         if (isEditingRanks) return;
         event.preventDefault();
-        // Unset and set focus path to trigger a useEffect hook in <TreeNode>
-        setFocusPath([-1]);
-        globalThis.setTimeout(
-          () => setFocusPath(focusPath.length > 0 ? focusPath : [0]),
-          0
-        );
       }}
     >
       <div role="none rowgroup">


### PR DESCRIPTION
Fixes #1982

### Checklist

- [ ] Self-review the PR after opening it to make sure the changes look good and
      self-explanatory (or properly documented)
- [ ] Add relevant issue to release milestone

### Testing instructions

- Open a tree 
- Select a node
- Select a new node 
- [ ] Verify the new node is selected 
- scroll down until you don't see you selected node 
- click in the white space (not on a node) 
- [ ] Verify you weren't send back to your selected node 
- [ ] Verify your node is still selected 
