### PR TITLE
Use automatic typeSearch if none defined in xml

### DIFF
--- a/specifyweb/frontend/js_src/lib/components/QueryComboBox/useTypeSearch.tsx
+++ b/specifyweb/frontend/js_src/lib/components/QueryComboBox/useTypeSearch.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 
 import { useAsyncState } from '../../hooks/useAsyncState';
 import { getAppResourceUrl } from '../../utils/ajax/helpers';
-import type { RA } from '../../utils/types';
 import { filterArray, localized } from '../../utils/types';
 import type { LiteralField, Relationship } from '../DataModel/specifyField';
 import type { SpecifyTable } from '../DataModel/specifyTable';

--- a/specifyweb/frontend/js_src/lib/components/QueryComboBox/useTypeSearch.tsx
+++ b/specifyweb/frontend/js_src/lib/components/QueryComboBox/useTypeSearch.tsx
@@ -2,9 +2,11 @@ import React from 'react';
 
 import { useAsyncState } from '../../hooks/useAsyncState';
 import { getAppResourceUrl } from '../../utils/ajax/helpers';
-import { filterArray } from '../../utils/types';
+import type { RA } from '../../utils/types';
+import { filterArray, localized } from '../../utils/types';
 import type { LiteralField, Relationship } from '../DataModel/specifyField';
 import type { SpecifyTable } from '../DataModel/specifyTable';
+import { getMainTableFields } from '../Formatters/formatters';
 import { load } from '../InitialContext';
 import { xmlToSpec } from '../Syncer/xmlUtils';
 import type { TypeSearch } from './spec';
@@ -36,6 +38,8 @@ export function useTypeSearch(
       ? initialTypeSearch.table
       : undefined);
 
+  const mainfields = relatedTable?.name ? getMainTableFields(relatedTable?.name) : undefined
+
   const [typeSearch] = useAsyncState<TypeSearch | false>(
     React.useCallback(async () => {
       if (typeof initialTypeSearch === 'object') return initialTypeSearch;
@@ -52,6 +56,16 @@ export function useTypeSearch(
         found =
           defaultSearches.find(({ name }) => name === initialTypeSearch) ??
           defaultSearches.find(({ table }) => table === relatedTable);
+      }
+
+      found ||= {
+        table: relatedTable,
+        title: localized(mainfields?.[0].name ?? ''),
+        searchFields: [mainfields?.slice(0,1) ?? []] ,
+        name: localized(relatedTable?.name),
+        formatter: localized(""), 
+        displayFields: undefined,
+        format: localized("%s")
       }
 
       return found ?? false;


### PR DESCRIPTION
Fixes #6278

### Checklist

- [ ] Self-review the PR after opening it to make sure the changes look good and
      self-explanatory (or properly documented)
- [ ] Add relevant issue to release milestone

### Testing instructions

- Open a form with a QCBX that does not have a defined typeSearch in xml 
- type inside the box and verify that you can search using the main field 

The code will check as follow: 
- Check the user defined custom type search
- Check type search in the default xml typeSearch
- If none of above use getMainTableFields and use the first field for the search 
