### PR TITLE
Close record set dialog on merge instead of reload

### DIFF
--- a/specifyweb/frontend/js_src/lib/components/Toolbar/MergeRecordSets.tsx
+++ b/specifyweb/frontend/js_src/lib/components/Toolbar/MergeRecordSets.tsx
@@ -14,8 +14,10 @@ import { RecordSetSelection } from '../SearchDialog/SelectRecordSet';
 
 export function MergeRecordSets({
   recordSets,
+  closeParent
 }: {
   readonly recordSets: RA<SerializedResource<RecordSet>> | undefined;
+  readonly closeParent: () => void
 }): JSX.Element {
   const [isOpen, handleOpen, handleClose] = useBooleanState();
 
@@ -67,7 +69,7 @@ export function MergeRecordSets({
       }).then(({ response }) => {
         if (!response.ok) return;
         handleClose();
-        globalThis.location.assign('/specify/overlay/record-sets/');
+        closeParent()
       })
     );
   };

--- a/specifyweb/frontend/js_src/lib/components/Toolbar/RecordSets.tsx
+++ b/specifyweb/frontend/js_src/lib/components/Toolbar/RecordSets.tsx
@@ -209,7 +209,10 @@ export function RecordSetsDialog({
           buttons={
             <>
               {!isReadOnly && hasToolPermission('recordSets', 'create') && (
-                <MergeRecordSets closeParent={handleClose} recordSets={data?.records} />
+                <MergeRecordSets
+                  closeParent={handleClose}
+                  recordSets={data?.records}
+                />
               )}
               <span className="-ml-2 flex-1" />
               <Button.DialogClose>{commonText.cancel()}</Button.DialogClose>

--- a/specifyweb/frontend/js_src/lib/components/Toolbar/RecordSets.tsx
+++ b/specifyweb/frontend/js_src/lib/components/Toolbar/RecordSets.tsx
@@ -209,7 +209,7 @@ export function RecordSetsDialog({
           buttons={
             <>
               {!isReadOnly && hasToolPermission('recordSets', 'create') && (
-                <MergeRecordSets recordSets={data?.records} />
+                <MergeRecordSets closeParent={handleClose} recordSets={data?.records} />
               )}
               <span className="-ml-2 flex-1" />
               <Button.DialogClose>{commonText.cancel()}</Button.DialogClose>


### PR DESCRIPTION
Fixes #6174

### Checklist

- [ ] Self-review the PR after opening it to make sure the changes look good and
      self-explanatory (or properly documented)
- [ ] Add relevant issue to release milestone

### Testing instructions

Open a data entry form
Enter data into a number of fields, relationships, etc.
Open the Record Sets dialog
Merge record sets
- [ ] Verify the RS dialog closes without a reload 