### PR TITLE
Remove age field from formatter and aggregator field

### DIFF
--- a/specifyweb/frontend/js_src/lib/components/Formatters/Components.tsx
+++ b/specifyweb/frontend/js_src/lib/components/Formatters/Components.tsx
@@ -36,6 +36,7 @@ import {
   relationshipIsToMany,
   valueIsPartialField,
 } from '../WbPlanView/mappingHelpers';
+import type { MappingLineData } from '../WbPlanView/navigator';
 import { getMappingLineData } from '../WbPlanView/navigator';
 import { navigatorSpecs } from '../WbPlanView/navigatorSpecs';
 import type { Aggregator, Formatter } from './spec';
@@ -195,6 +196,7 @@ export function ResourceMapping({
   }, [mappingPath, sourcePath]);
 
   const isReadOnly = React.useContext(ReadOnlyContext);
+
   const lineData = React.useMemo(
     () =>
       getMappingLineData({
@@ -203,7 +205,12 @@ export function ResourceMapping({
         showHiddenFields: true,
         generateFieldData: 'all',
         spec: navigatorSpecs.formatterEditor,
-      }),
+      }).map(line => ({
+        ...line,
+        fieldsData: Object.fromEntries(
+          Object.entries(line.fieldsData).filter(([key]) => key !== 'age')
+        ),
+      })) as RA<MappingLineData>,
     [table.name, mappingPath]
   );
 
@@ -265,7 +272,7 @@ export function ResourceMapping({
       }
     >
       {join(
-        mappingLineProps.map((mappingDetails, index) => (
+        lineData.map((mappingDetails, index) => (
           <li className="contents" key={index}>
             <MappingElement
               {...mappingDetails}

--- a/specifyweb/frontend/js_src/lib/components/Formatters/Components.tsx
+++ b/specifyweb/frontend/js_src/lib/components/Formatters/Components.tsx
@@ -210,7 +210,7 @@ export function ResourceMapping({
         fieldsData: Object.fromEntries(
           Object.entries(line.fieldsData).filter(([key]) => key !== 'age')
         ),
-      })) as RA<MappingLineData>,
+      })),
     [table.name, mappingPath]
   );
 

--- a/specifyweb/frontend/js_src/lib/components/Formatters/Components.tsx
+++ b/specifyweb/frontend/js_src/lib/components/Formatters/Components.tsx
@@ -272,7 +272,7 @@ export function ResourceMapping({
       }
     >
       {join(
-        lineData.map((mappingDetails, index) => (
+        mappingLineProps.map((mappingDetails, index) => (
           <li className="contents" key={index}>
             <MappingElement
               {...mappingDetails}

--- a/specifyweb/frontend/js_src/lib/components/Formatters/Components.tsx
+++ b/specifyweb/frontend/js_src/lib/components/Formatters/Components.tsx
@@ -36,7 +36,6 @@ import {
   relationshipIsToMany,
   valueIsPartialField,
 } from '../WbPlanView/mappingHelpers';
-import type { MappingLineData } from '../WbPlanView/navigator';
 import { getMappingLineData } from '../WbPlanView/navigator';
 import { navigatorSpecs } from '../WbPlanView/navigatorSpecs';
 import type { Aggregator, Formatter } from './spec';


### PR DESCRIPTION
Fixes #6370

### Checklist

- [ ] Self-review the PR after opening it to make sure the changes look good and
      self-explanatory (or properly documented)
- [ ] Add relevant issue to release milestone

### Testing instructions

- On any paleo DB go to record formatters
- In table format, click on Collection Object
- [ ] Verify that age field in not in the list 

