### PR TITLE
Add save blocker when trying to delete a loaned prep

### DIFF
--- a/specifyweb/frontend/js_src/lib/components/DataModel/businessRuleDefs.ts
+++ b/specifyweb/frontend/js_src/lib/components/DataModel/businessRuleDefs.ts
@@ -10,6 +10,7 @@ import {
   DETERMINATION_TAXON_KEY,
   ensureSingleCollectionObjectCheck,
   hasNoCurrentDetermination,
+  PREPARATION_DISPOSED_KEY,
   PREPARATION_GIFTED_KEY,
   PREPARATION_LOANED_KEY,
 } from './businessRuleUtils';
@@ -615,6 +616,14 @@ export const businessRuleDefs: MappedBusinessRuleDefs = {
           preparation.specifyTable.field.isOnGift,
           [resourcesText.deleteGiftedPrep()],
           PREPARATION_GIFTED_KEY
+        )
+      }
+      if (preparation.get('isOnDisposal') === true) {
+        setSaveBlockers(
+          collection.related ?? preparation,
+          preparation.specifyTable.field.isOnDisposal,
+          [resourcesText.deleteDisposedPrep()],
+          PREPARATION_DISPOSED_KEY
         )
       }
     }

--- a/specifyweb/frontend/js_src/lib/components/DataModel/businessRuleDefs.ts
+++ b/specifyweb/frontend/js_src/lib/components/DataModel/businessRuleDefs.ts
@@ -11,6 +11,7 @@ import {
   ensureSingleCollectionObjectCheck,
   hasNoCurrentDetermination,
   PREPARATION_DISPOSED_KEY,
+  PREPARATION_EXCHANGED_IN_KEY,
   PREPARATION_EXCHANGED_OUT_KEY,
   PREPARATION_GIFTED_KEY,
   PREPARATION_LOANED_KEY,
@@ -633,6 +634,14 @@ export const businessRuleDefs: MappedBusinessRuleDefs = {
           preparation.specifyTable.field.isOnExchangeOut,
           [resourcesText.deleteExchangeOutPrep()],
           PREPARATION_EXCHANGED_OUT_KEY
+        )
+      }
+      if (preparation.get('isOnExchangeIn') === true) {
+        setSaveBlockers(
+          collection.related ?? preparation,
+          preparation.specifyTable.field.isOnExchangeIn,
+          [resourcesText.deleteExchangeInPrep()],
+          PREPARATION_EXCHANGED_IN_KEY
         )
       }
     }

--- a/specifyweb/frontend/js_src/lib/components/DataModel/businessRuleDefs.ts
+++ b/specifyweb/frontend/js_src/lib/components/DataModel/businessRuleDefs.ts
@@ -11,6 +11,7 @@ import {
   ensureSingleCollectionObjectCheck,
   hasNoCurrentDetermination,
   PREPARATION_DISPOSED_KEY,
+  PREPARATION_EXCHANGED_OUT_KEY,
   PREPARATION_GIFTED_KEY,
   PREPARATION_LOANED_KEY,
 } from './businessRuleUtils';
@@ -624,6 +625,14 @@ export const businessRuleDefs: MappedBusinessRuleDefs = {
           preparation.specifyTable.field.isOnDisposal,
           [resourcesText.deleteDisposedPrep()],
           PREPARATION_DISPOSED_KEY
+        )
+      }
+      if (preparation.get('isOnExchangeOut') === true) {
+        setSaveBlockers(
+          collection.related ?? preparation,
+          preparation.specifyTable.field.isOnExchangeOut,
+          [resourcesText.deleteExchangeOutPrep()],
+          PREPARATION_EXCHANGED_OUT_KEY
         )
       }
     }

--- a/specifyweb/frontend/js_src/lib/components/DataModel/businessRuleDefs.ts
+++ b/specifyweb/frontend/js_src/lib/components/DataModel/businessRuleDefs.ts
@@ -596,4 +596,16 @@ export const businessRuleDefs: MappedBusinessRuleDefs = {
       },
     },
   },
+  Preparation: {
+    onRemoved: (preparation, collection): void => {
+      if (preparation.get('isOnLoan') === true) {
+        setSaveBlockers(
+          collection.related ?? preparation,
+          preparation.specifyTable.field.isOnLoan,
+          [resourcesText.deleteLoanedPrep()],
+          resourcesText.loanedPrepDeletionMessage()
+        )
+      }
+    }
+  }
 };

--- a/specifyweb/frontend/js_src/lib/components/DataModel/businessRuleDefs.ts
+++ b/specifyweb/frontend/js_src/lib/components/DataModel/businessRuleDefs.ts
@@ -9,6 +9,7 @@ import {
   DETERMINATION_TAXON_KEY,
   ensureSingleCollectionObjectCheck,
   hasNoCurrentDetermination,
+  PREPARATION_LOANED_KEY,
 } from './businessRuleUtils';
 import { cogTypes } from './helpers';
 import type { AnySchema, CommonFields, TableFields } from './helperTypes';
@@ -332,7 +333,7 @@ export const businessRuleDefs: MappedBusinessRuleDefs = {
           collection.related ?? cojo,
           cojo.specifyTable.field.parentCog,
           [resourcesText.deletePrimaryRecord()],
-          resourcesText.primaryDeletionErrorMessage()
+          COJO_PRIMARY_DELETE_KEY
         );
       }
       if (collection?.related?.specifyTable === tables.CollectionObjectGroup) {
@@ -603,7 +604,7 @@ export const businessRuleDefs: MappedBusinessRuleDefs = {
           collection.related ?? preparation,
           preparation.specifyTable.field.isOnLoan,
           [resourcesText.deleteLoanedPrep()],
-          resourcesText.loanedPrepDeletionMessage()
+          PREPARATION_LOANED_KEY
         )
       }
     }

--- a/specifyweb/frontend/js_src/lib/components/DataModel/businessRuleDefs.ts
+++ b/specifyweb/frontend/js_src/lib/components/DataModel/businessRuleDefs.ts
@@ -5,6 +5,7 @@ import type { BusinessRuleResult } from './businessRules';
 import {
   COG_PRIMARY_KEY,
   COG_TOITSELF,
+  COJO_PRIMARY_DELETE_KEY,
   CURRENT_DETERMINATION_KEY,
   DETERMINATION_TAXON_KEY,
   ensureSingleCollectionObjectCheck,

--- a/specifyweb/frontend/js_src/lib/components/DataModel/businessRuleDefs.ts
+++ b/specifyweb/frontend/js_src/lib/components/DataModel/businessRuleDefs.ts
@@ -10,6 +10,7 @@ import {
   DETERMINATION_TAXON_KEY,
   ensureSingleCollectionObjectCheck,
   hasNoCurrentDetermination,
+  PREPARATION_GIFTED_KEY,
   PREPARATION_LOANED_KEY,
 } from './businessRuleUtils';
 import { cogTypes } from './helpers';
@@ -606,6 +607,14 @@ export const businessRuleDefs: MappedBusinessRuleDefs = {
           preparation.specifyTable.field.isOnLoan,
           [resourcesText.deleteLoanedPrep()],
           PREPARATION_LOANED_KEY
+        )
+      }
+      if (preparation.get('isOnGift') === true) {
+        setSaveBlockers(
+          collection.related ?? preparation,
+          preparation.specifyTable.field.isOnGift,
+          [resourcesText.deleteGiftedPrep()],
+          PREPARATION_GIFTED_KEY
         )
       }
     }

--- a/specifyweb/frontend/js_src/lib/components/DataModel/businessRuleUtils.ts
+++ b/specifyweb/frontend/js_src/lib/components/DataModel/businessRuleUtils.ts
@@ -8,6 +8,8 @@ export const COG_TOITSELF = 'cog-toItself';
 export const PARENTCOG_KEY = 'cog-parentCog';
 export const COG_PRIMARY_KEY = 'cog-isPrimary';
 export const DETERMINATION_TAXON_KEY = 'determination-Taxon';
+export const PREPARATION_LOANED_KEY = 'preparation-isLoaned';
+export const COJO_PRIMARY_DELETE_KEY = 'primary-cojo-delete'
 
 /**
  *

--- a/specifyweb/frontend/js_src/lib/components/DataModel/businessRuleUtils.ts
+++ b/specifyweb/frontend/js_src/lib/components/DataModel/businessRuleUtils.ts
@@ -9,6 +9,7 @@ export const PARENTCOG_KEY = 'cog-parentCog';
 export const COG_PRIMARY_KEY = 'cog-isPrimary';
 export const DETERMINATION_TAXON_KEY = 'determination-Taxon';
 export const PREPARATION_LOANED_KEY = 'preparation-isLoaned';
+export const PREPARATION_GIFTED_KEY = 'preparation-isGifted';
 export const COJO_PRIMARY_DELETE_KEY = 'primary-cojo-delete'
 
 /**

--- a/specifyweb/frontend/js_src/lib/components/DataModel/businessRuleUtils.ts
+++ b/specifyweb/frontend/js_src/lib/components/DataModel/businessRuleUtils.ts
@@ -12,6 +12,7 @@ export const PREPARATION_LOANED_KEY = 'preparation-isLoaned';
 export const PREPARATION_GIFTED_KEY = 'preparation-isGifted';
 export const PREPARATION_DISPOSED_KEY = 'preparation-isDisposed';
 export const PREPARATION_EXCHANGED_OUT_KEY = 'preparation-isExchangedOut';
+export const PREPARATION_EXCHANGED_IN_KEY = 'preparation-isExchangedIn';
 export const COJO_PRIMARY_DELETE_KEY = 'primary-cojo-delete'
 
 /**

--- a/specifyweb/frontend/js_src/lib/components/DataModel/businessRuleUtils.ts
+++ b/specifyweb/frontend/js_src/lib/components/DataModel/businessRuleUtils.ts
@@ -11,6 +11,7 @@ export const DETERMINATION_TAXON_KEY = 'determination-Taxon';
 export const PREPARATION_LOANED_KEY = 'preparation-isLoaned';
 export const PREPARATION_GIFTED_KEY = 'preparation-isGifted';
 export const PREPARATION_DISPOSED_KEY = 'preparation-isDisposed';
+export const PREPARATION_EXCHANGED_OUT_KEY = 'preparation-isExchangedOut';
 export const COJO_PRIMARY_DELETE_KEY = 'primary-cojo-delete'
 
 /**

--- a/specifyweb/frontend/js_src/lib/components/DataModel/businessRuleUtils.ts
+++ b/specifyweb/frontend/js_src/lib/components/DataModel/businessRuleUtils.ts
@@ -10,6 +10,7 @@ export const COG_PRIMARY_KEY = 'cog-isPrimary';
 export const DETERMINATION_TAXON_KEY = 'determination-Taxon';
 export const PREPARATION_LOANED_KEY = 'preparation-isLoaned';
 export const PREPARATION_GIFTED_KEY = 'preparation-isGifted';
+export const PREPARATION_DISPOSED_KEY = 'preparation-isDisposed';
 export const COJO_PRIMARY_DELETE_KEY = 'primary-cojo-delete'
 
 /**

--- a/specifyweb/frontend/js_src/lib/components/DataModel/schemaExtras.ts
+++ b/specifyweb/frontend/js_src/lib/components/DataModel/schemaExtras.ts
@@ -339,6 +339,14 @@ export const schemaExtras: {
         unique: false,
       }),
       new LiteralField(table, {
+        name: 'isOnDisposal',
+        required: false,
+        readOnly: true,
+        type: 'java.lang.Boolean',
+        indexed: false,
+        unique: false,
+      }),
+      new LiteralField(table, {
         name: 'actualCountAmt',
         required: false,
         readOnly: true,

--- a/specifyweb/frontend/js_src/lib/components/DataModel/schemaExtras.ts
+++ b/specifyweb/frontend/js_src/lib/components/DataModel/schemaExtras.ts
@@ -331,6 +331,14 @@ export const schemaExtras: {
         unique: false,
       }),
       new LiteralField(table, {
+        name: 'isOnGift',
+        required: false,
+        readOnly: true,
+        type: 'java.lang.Boolean',
+        indexed: false,
+        unique: false,
+      }),
+      new LiteralField(table, {
         name: 'actualCountAmt',
         required: false,
         readOnly: true,

--- a/specifyweb/frontend/js_src/lib/components/DataModel/schemaExtras.ts
+++ b/specifyweb/frontend/js_src/lib/components/DataModel/schemaExtras.ts
@@ -347,6 +347,14 @@ export const schemaExtras: {
         unique: false,
       }),
       new LiteralField(table, {
+        name: 'isOnExchangeOut',
+        required: false,
+        readOnly: true,
+        type: 'java.lang.Boolean',
+        indexed: false,
+        unique: false,
+      }),
+      new LiteralField(table, {
         name: 'actualCountAmt',
         required: false,
         readOnly: true,

--- a/specifyweb/frontend/js_src/lib/components/DataModel/schemaExtras.ts
+++ b/specifyweb/frontend/js_src/lib/components/DataModel/schemaExtras.ts
@@ -355,6 +355,14 @@ export const schemaExtras: {
         unique: false,
       }),
       new LiteralField(table, {
+        name: 'isOnExchangeIn',
+        required: false,
+        readOnly: true,
+        type: 'java.lang.Boolean',
+        indexed: false,
+        unique: false,
+      }),
+      new LiteralField(table, {
         name: 'actualCountAmt',
         required: false,
         readOnly: true,

--- a/specifyweb/frontend/js_src/lib/components/DataModel/types.ts
+++ b/specifyweb/frontend/js_src/lib/components/DataModel/types.ts
@@ -4387,6 +4387,7 @@ export type Preparation = {
     readonly integer2: number | null;
     readonly isOnLoan: boolean | null;
     readonly isOnGift: boolean | null;
+    readonly isOnDisposal: boolean | null;
     readonly number1: number | null;
     readonly number2: number | null;
     readonly preparedDate: string | null;

--- a/specifyweb/frontend/js_src/lib/components/DataModel/types.ts
+++ b/specifyweb/frontend/js_src/lib/components/DataModel/types.ts
@@ -4389,6 +4389,7 @@ export type Preparation = {
     readonly isOnGift: boolean | null;
     readonly isOnDisposal: boolean | null;
     readonly isOnExchangeOut: boolean | null;
+    readonly isOnExchangeIn: boolean | null;
     readonly number1: number | null;
     readonly number2: number | null;
     readonly preparedDate: string | null;

--- a/specifyweb/frontend/js_src/lib/components/DataModel/types.ts
+++ b/specifyweb/frontend/js_src/lib/components/DataModel/types.ts
@@ -4388,6 +4388,7 @@ export type Preparation = {
     readonly isOnLoan: boolean | null;
     readonly isOnGift: boolean | null;
     readonly isOnDisposal: boolean | null;
+    readonly isOnExchangeOut: boolean | null;
     readonly number1: number | null;
     readonly number2: number | null;
     readonly preparedDate: string | null;

--- a/specifyweb/frontend/js_src/lib/components/DataModel/types.ts
+++ b/specifyweb/frontend/js_src/lib/components/DataModel/types.ts
@@ -4386,6 +4386,7 @@ export type Preparation = {
     readonly integer1: number | null;
     readonly integer2: number | null;
     readonly isOnLoan: boolean | null;
+    readonly isOnGift: boolean | null;
     readonly number1: number | null;
     readonly number2: number | null;
     readonly preparedDate: string | null;

--- a/specifyweb/frontend/js_src/lib/localization/resources.ts
+++ b/specifyweb/frontend/js_src/lib/localization/resources.ts
@@ -858,6 +858,9 @@ export const resourcesText = createDictionary({
   deleteDisposedPrep: {
     'en-us': 'A disposed preparation cannot be deleted',
   },
+  deleteExchangeOutPrep: {
+    'en-us': 'A exchanged out preparation cannot be deleted',
+  },
   invalidDeterminationTaxon: {
     'en-us':
       'Determination does not belong to the taxon tree associated with the Collection Object Type',

--- a/specifyweb/frontend/js_src/lib/localization/resources.ts
+++ b/specifyweb/frontend/js_src/lib/localization/resources.ts
@@ -854,10 +854,10 @@ export const resourcesText = createDictionary({
       'This record cannot be deleted as it is the primary record of the Collection Object Group. Please reload the page, then assign another CO as the primary record if a change is desired.',
   },
   deleteLoanedPrep: {
-    'en-us': 'A loaned preparation cannot be deleted'
+    'en-us': 'A loaned preparation cannot be deleted',
   },
   loanedPrepDeletionMessage: {
-  'en-us': 'This record cannot be delted because it is used in a loan.'
+    'en-us': 'This record cannot be delted because it is used in a loan.',
   },
   invalidDeterminationTaxon: {
     'en-us':

--- a/specifyweb/frontend/js_src/lib/localization/resources.ts
+++ b/specifyweb/frontend/js_src/lib/localization/resources.ts
@@ -853,6 +853,12 @@ export const resourcesText = createDictionary({
     'en-us':
       'This record cannot be deleted as it is the primary record of the Collection Object Group. Please reload the page, then assign another CO as the primary record if a change is desired.',
   },
+  deleteLoanedPrep: {
+    'en-us': 'A loaned preparation cannot be deleted'
+  },
+  loanedPrepDeletionMessage: {
+  'en-us': 'This record cannot be delted because it is used in a loan.'
+  },
   invalidDeterminationTaxon: {
     'en-us':
       'Determination does not belong to the taxon tree associated with the Collection Object Type',

--- a/specifyweb/frontend/js_src/lib/localization/resources.ts
+++ b/specifyweb/frontend/js_src/lib/localization/resources.ts
@@ -849,15 +849,8 @@ export const resourcesText = createDictionary({
   deletePrimaryRecord: {
     'en-us': 'Primary record CO cannot be deleted.',
   },
-  primaryDeletionErrorMessage: {
-    'en-us':
-      'This record cannot be deleted as it is the primary record of the Collection Object Group. Please reload the page, then assign another CO as the primary record if a change is desired.',
-  },
   deleteLoanedPrep: {
     'en-us': 'A loaned preparation cannot be deleted',
-  },
-  loanedPrepDeletionMessage: {
-    'en-us': 'This record cannot be delted because it is used in a loan.',
   },
   invalidDeterminationTaxon: {
     'en-us':

--- a/specifyweb/frontend/js_src/lib/localization/resources.ts
+++ b/specifyweb/frontend/js_src/lib/localization/resources.ts
@@ -852,6 +852,9 @@ export const resourcesText = createDictionary({
   deleteLoanedPrep: {
     'en-us': 'A loaned preparation cannot be deleted',
   },
+  deleteGiftedPrep: {
+    'en-us': 'A gifted preparation cannot be deleted',
+  },
   invalidDeterminationTaxon: {
     'en-us':
       'Determination does not belong to the taxon tree associated with the Collection Object Type',

--- a/specifyweb/frontend/js_src/lib/localization/resources.ts
+++ b/specifyweb/frontend/js_src/lib/localization/resources.ts
@@ -861,6 +861,9 @@ export const resourcesText = createDictionary({
   deleteExchangeOutPrep: {
     'en-us': 'A exchanged out preparation cannot be deleted',
   },
+  deleteExchangeInPrep: {
+    'en-us': 'A exchanged in preparation cannot be deleted',
+  },
   invalidDeterminationTaxon: {
     'en-us':
       'Determination does not belong to the taxon tree associated with the Collection Object Type',

--- a/specifyweb/frontend/js_src/lib/localization/resources.ts
+++ b/specifyweb/frontend/js_src/lib/localization/resources.ts
@@ -855,6 +855,9 @@ export const resourcesText = createDictionary({
   deleteGiftedPrep: {
     'en-us': 'A gifted preparation cannot be deleted',
   },
+  deleteDisposedPrep: {
+    'en-us': 'A disposed preparation cannot be deleted',
+  },
   invalidDeterminationTaxon: {
     'en-us':
       'Determination does not belong to the taxon tree associated with the Collection Object Type',

--- a/specifyweb/specify/calculated_fields.py
+++ b/specifyweb/specify/calculated_fields.py
@@ -60,6 +60,10 @@ def calculate_extra_fields(obj, data: Dict[str, Any]) -> Dict[str, Any]:
 
         extra["actualCountAmt"] = actual_count_amount
         extra["isonloan"] = obj.isonloan()
+        extra["isongift"] = obj.isongift()
+        extra["isondisposal"] = obj.isondisposal()
+        extra["isonexchangeout"] = obj.isonexchangeout()
+        extra["isonexchangein"] = obj.isonexchangein()
 
     elif isinstance(obj, Specifyuser):
         extra["isadmin"] = obj.is_admin()

--- a/specifyweb/specify/model_extras.py
+++ b/specifyweb/specify/model_extras.py
@@ -144,6 +144,70 @@ class Preparation(models.Model):
         result = cursor.fetchone()
         return result[0] > 0
 
+    def isongift(self):
+        # TODO: needs unit tests
+        from django.db import connection
+        cursor = connection.cursor()
+
+        cursor.execute("""
+        SELECT COALESCE(
+        SUM({GREATEST}(0, COALESCE(Quantity, 0))),
+        0)
+        FROM giftpreparation
+        WHERE PreparationID = %s
+        """.format(GREATEST='MAX' if connection.vendor == 'sqlite' else 'GREATEST'), [self.id])
+
+        result = cursor.fetchone()
+        return result[0] > 0
+
+    def isondisposal(self):
+        # TODO: needs unit tests
+        from django.db import connection
+        cursor = connection.cursor()
+
+        cursor.execute("""
+        SELECT COALESCE(
+        SUM({GREATEST}(0, COALESCE(Quantity, 0))),
+        0)
+        FROM disposalpreparation
+        WHERE PreparationID = %s
+        """.format(GREATEST='MAX' if connection.vendor == 'sqlite' else 'GREATEST'), [self.id])
+
+        result = cursor.fetchone()
+        return result[0] > 0
+    
+    def isonexchangeout(self):
+        # TODO: needs unit tests
+        from django.db import connection
+        cursor = connection.cursor()
+
+        cursor.execute("""
+        SELECT COALESCE(
+        SUM({GREATEST}(0, COALESCE(Quantity, 0))),
+        0)
+        FROM exchangeoutprep
+        WHERE PreparationID = %s
+        """.format(GREATEST='MAX' if connection.vendor == 'sqlite' else 'GREATEST'), [self.id])
+
+        result = cursor.fetchone()
+        return result[0] > 0
+    
+    def isonexchangein(self):
+        # TODO: needs unit tests
+        from django.db import connection
+        cursor = connection.cursor()
+
+        cursor.execute("""
+        SELECT COALESCE(
+        SUM({GREATEST}(0, COALESCE(Quantity, 0))),
+        0)
+        FROM exchangeinprep
+        WHERE PreparationID = %s
+        """.format(GREATEST='MAX' if connection.vendor == 'sqlite' else 'GREATEST'), [self.id])
+
+        result = cursor.fetchone()
+        return result[0] > 0
+
     class Meta:
         abstract = True
 


### PR DESCRIPTION
Fixes #1431

### Checklist

- [ ] Self-review the PR after opening it to make sure the changes look good and
      self-explanatory (or properly documented)
- [ ] Add relevant issue to release milestone

### Testing instructions

- Open an existing CO or create one 
- Add a loanable prep type prep 
- Create a loan with that CO and that prep
- Save the loan 
- Go back to the CO form 
- Try to delete the prep that is used in the loan 
- [ ] Verify there is a safe blocker telling you that you cannot delete a prep that is on loan 

TODO: 
- Add isOnGift documentation and other interactions 
