### PR TITLE
Add a warning dialog when deleting attachment

### DIFF
--- a/specifyweb/frontend/js_src/lib/components/FormCells/FormTableCollection.tsx
+++ b/specifyweb/frontend/js_src/lib/components/FormCells/FormTableCollection.tsx
@@ -73,7 +73,6 @@ export function FormTableCollection({
       totalCount={collection._totalCount}
       onAdd={disableAdding ? undefined : handleAdd}
       onDelete={(resource): void => {
-        collection.remove(resource);
         setRecords(Array.from(collection.models));
         handleDelete?.(resource, records.indexOf(resource));
       }}

--- a/specifyweb/frontend/js_src/lib/components/FormSliders/AttachmentWarningDeletion.tsx
+++ b/specifyweb/frontend/js_src/lib/components/FormSliders/AttachmentWarningDeletion.tsx
@@ -52,7 +52,7 @@ export function AttachmentWarningDeletion({
           >
             {attachmentsText.deleteAttachmentWarning()}
             <span className="font-bold">
-              {resource?.dependentResources?.attachment?.get('title') ?? ''}
+            {(resource?.dependentResources?.attachment as SpecifyResource<AnySchema>)?.get('title') ?? ''}
             </span>
          </Dialog> 
 }

--- a/specifyweb/frontend/js_src/lib/components/FormSliders/AttachmentWarningDeletion.tsx
+++ b/specifyweb/frontend/js_src/lib/components/FormSliders/AttachmentWarningDeletion.tsx
@@ -1,0 +1,58 @@
+import React from 'react';
+
+import { attachmentsText } from '../../localization/attachments';
+import { commonText } from '../../localization/common';
+import { interactionsText } from '../../localization/interactions';
+import { Button } from '../Atoms/Button';
+import type { AnySchema } from '../DataModel/helperTypes';
+import type { SpecifyResource } from '../DataModel/legacyTypes';
+import type { Collection } from '../DataModel/specifyTable';
+import { Dialog } from '../Molecules/Dialog';
+
+export function AttachmentWarningDeletion({
+ formType,
+ onRemove: handleRemove,
+ collection, 
+ resource,
+ isCollapsed,
+ onExpand: handleExpand, 
+ onDelete: handleDelete,
+ index, 
+ closeWarning
+}:{
+ readonly formType: "form" | "formTable";
+ readonly onRemove: (source: "deleteButton" | "minusButton") => void;
+ readonly collection: Collection<AnySchema>;
+ readonly resource: SpecifyResource<AnySchema> | undefined;
+ readonly isCollapsed: boolean;
+ readonly onExpand: () => void;
+ readonly onDelete: ((index: number, source: "deleteButton" | "minusButton") => void) | undefined;
+ readonly index: number;
+ readonly closeWarning: () => void
+}): JSX.Element {
+ return <Dialog 
+          buttons={
+            <>
+              <Button.DialogClose>{commonText.close()}</Button.DialogClose>
+              <Button.Save onClick={():void => {
+                if (formType === 'form' ) {
+                  handleRemove('minusButton');
+                }
+                if (formType === 'formTable') {
+                  collection.remove(resource!);
+                  if (isCollapsed) handleExpand();
+                  handleDelete?.(index, 'minusButton');
+                }
+                closeWarning()
+              }}>{interactionsText.continue()}</Button.Save>
+            </>
+          } 
+          header={attachmentsText.attachmentDelition()}
+          onClose={closeWarning}
+          >
+            {attachmentsText.deleteAttachmentWarning()}
+            <span className="font-bold">
+              {resource?.dependentResources?.attachment?.get('title') ?? ''}
+            </span>
+         </Dialog> 
+}

--- a/specifyweb/frontend/js_src/lib/components/FormSliders/AttachmentWarningDeletion.tsx
+++ b/specifyweb/frontend/js_src/lib/components/FormSliders/AttachmentWarningDeletion.tsx
@@ -30,29 +30,30 @@ export function AttachmentWarningDeletion({
  readonly index: number;
  readonly closeWarning: () => void
 }): JSX.Element {
- return <Dialog 
-          buttons={
-            <>
-              <Button.DialogClose>{commonText.close()}</Button.DialogClose>
-              <Button.Save onClick={():void => {
-                if (formType === 'form' ) {
-                  handleRemove('minusButton');
-                }
-                if (formType === 'formTable') {
-                  collection.remove(resource!);
-                  if (isCollapsed) handleExpand();
-                  handleDelete?.(index, 'minusButton');
-                }
-                closeWarning()
-              }}>{interactionsText.continue()}</Button.Save>
-            </>
-          } 
-          header={attachmentsText.attachmentDelition()}
-          onClose={closeWarning}
-          >
-            {attachmentsText.deleteAttachmentWarning()}
-            <span className="font-bold">
-            {(resource?.dependentResources?.attachment as SpecifyResource<AnySchema>)?.get('title') ?? ''}
-            </span>
-         </Dialog> 
+ return (
+  <Dialog 
+    buttons={
+     <>
+       <Button.DialogClose>{commonText.close()}</Button.DialogClose>
+       <Button.Save onClick={():void => {
+         if (formType === 'form' ) {
+           handleRemove('minusButton');
+         }
+         if (formType === 'formTable') {
+           collection.remove(resource!);
+           if (isCollapsed) handleExpand();
+           handleDelete?.(index, 'minusButton');
+         }
+         closeWarning()
+       }}>{interactionsText.continue()}</Button.Save>
+     </>
+    } 
+    header={attachmentsText.attachmentDelition()}
+    onClose={closeWarning}
+    >
+      {attachmentsText.deleteAttachmentWarning()}
+      <span className="font-bold">
+      {(resource?.dependentResources?.attachment as SpecifyResource<AnySchema>)?.get('title') ?? ''}
+      </span>
+   </Dialog> )
 }

--- a/specifyweb/frontend/js_src/lib/components/FormSliders/AttachmentWarningDeletion.tsx
+++ b/specifyweb/frontend/js_src/lib/components/FormSliders/AttachmentWarningDeletion.tsx
@@ -10,50 +10,59 @@ import type { Collection } from '../DataModel/specifyTable';
 import { Dialog } from '../Molecules/Dialog';
 
 export function AttachmentWarningDeletion({
- formType,
- onRemove: handleRemove,
- collection, 
- resource,
- isCollapsed,
- onExpand: handleExpand, 
- onDelete: handleDelete,
- index, 
- closeWarning
-}:{
- readonly formType: "form" | "formTable";
- readonly onRemove: (source: "deleteButton" | "minusButton") => void;
- readonly collection: Collection<AnySchema>;
- readonly resource: SpecifyResource<AnySchema> | undefined;
- readonly isCollapsed: boolean;
- readonly onExpand: () => void;
- readonly onDelete: ((index: number, source: "deleteButton" | "minusButton") => void) | undefined;
- readonly index: number;
- readonly closeWarning: () => void
+  formType,
+  onRemove: handleRemove,
+  collection,
+  resource,
+  isCollapsed,
+  onExpand: handleExpand,
+  onDelete: handleDelete,
+  index,
+  closeWarning,
+}: {
+  readonly formType: 'form' | 'formTable';
+  readonly onRemove: (source: 'deleteButton' | 'minusButton') => void;
+  readonly collection: Collection<AnySchema>;
+  readonly resource: SpecifyResource<AnySchema> | undefined;
+  readonly isCollapsed: boolean;
+  readonly onExpand: () => void;
+  readonly onDelete:
+    | ((index: number, source: 'deleteButton' | 'minusButton') => void)
+    | undefined;
+  readonly index: number;
+  readonly closeWarning: () => void;
 }): JSX.Element {
- return (
-  <Dialog 
-    buttons={
-     <>
-       <Button.DialogClose>{commonText.close()}</Button.DialogClose>
-       <Button.Save onClick={():void => {
-         if (formType === 'form' ) {
-           handleRemove('minusButton');
-         }
-         if (formType === 'formTable') {
-           collection.remove(resource!);
-           if (isCollapsed) handleExpand();
-           handleDelete?.(index, 'minusButton');
-         }
-         closeWarning()
-       }}>{interactionsText.continue()}</Button.Save>
-     </>
-    } 
-    header={attachmentsText.attachmentDelition()}
-    onClose={closeWarning}
+  return (
+    <Dialog
+      buttons={
+        <>
+          <Button.DialogClose>{commonText.close()}</Button.DialogClose>
+          <Button.Save
+            onClick={(): void => {
+              if (formType === 'form') {
+                handleRemove('minusButton');
+              }
+              if (formType === 'formTable') {
+                collection.remove(resource!);
+                if (isCollapsed) handleExpand();
+                handleDelete?.(index, 'minusButton');
+              }
+              closeWarning();
+            }}
+          >
+            {interactionsText.continue()}
+          </Button.Save>
+        </>
+      }
+      header={attachmentsText.attachmentDelition()}
+      onClose={closeWarning}
     >
       {attachmentsText.deleteAttachmentWarning()}
       <span className="font-bold">
-      {(resource?.dependentResources?.attachment as SpecifyResource<AnySchema>)?.get('title') ?? ''}
+        {(
+          resource?.dependentResources?.attachment as SpecifyResource<AnySchema>
+        )?.get('title') ?? ''}
       </span>
-   </Dialog> )
+    </Dialog>
+  );
 }

--- a/specifyweb/frontend/js_src/lib/components/FormSliders/IntegratedRecordSelector.tsx
+++ b/specifyweb/frontend/js_src/lib/components/FormSliders/IntegratedRecordSelector.tsx
@@ -3,7 +3,9 @@ import type { State } from 'typesafe-reducer';
 
 import { useSearchParameter } from '../../hooks/navigation';
 import { useBooleanState } from '../../hooks/useBooleanState';
+import { attachmentsText } from '../../localization/attachments';
 import { commonText } from '../../localization/common';
+import { interactionsText } from '../../localization/interactions';
 import { f } from '../../utils/functools';
 import type { RA } from '../../utils/types';
 import { Button } from '../Atoms/Button';
@@ -29,6 +31,7 @@ import { SubViewContext } from '../Forms/SubView';
 import type { InteractionWithPreps } from '../Interactions/helpers';
 import { interactionPrepTables } from '../Interactions/helpers';
 import { InteractionDialog } from '../Interactions/InteractionDialog';
+import { Dialog } from '../Molecules/Dialog';
 import { hasTablePermission } from '../Permissions/helpers';
 import { relationshipIsToMany } from '../WbPlanView/mappingHelpers';
 import { AttachmentsCollection } from './AttachmentsCollection';
@@ -168,238 +171,275 @@ export function IntegratedRecordSelector({
     isLoanPrep &&
     (collection.related?.isNew() === true || collection.related?.needsSaved);
 
-  return (
-    <ReadOnlyContext.Provider value={isReadOnly}>
-      <RecordSelectorFromCollection
-        collection={collection}
-        defaultIndex={isToOne ? 0 : index}
-        relationship={relationship}
-        onAdd={(resources): void => {
-          if (isInteraction) {
-            setInteractionResource(resources[0]);
-            handleOpenDialog();
-          }
-          if (!isInteraction && formType !== 'formTable')
-            collection.add(resources);
-          handleAdding(resources);
-        }}
-        onDelete={(...args): void => {
-          if (isCollapsed) handleExpand();
-          handleDelete?.(...args);
-        }}
-        onFetch={handleFetch}
-        onSlide={(index): void => {
-          handleExpand();
-          if (typeof urlParameter === 'string') setIndex(index.toString());
-        }}
-        {...rest}
-      >
-        {({
-          dialogs,
-          slider,
-          resource,
-          onAdd: handleAdd,
-          onRemove: handleRemove,
-          showSearchDialog,
-          isLoading,
-        }): JSX.Element => (
-          <>
-            {isInteraction &&
-            typeof collection.related === 'object' &&
-            isDialogOpen ? (
-              <InteractionDialog
-                actionTable={
-                  collection.related
-                    .specifyTable as SpecifyTable<InteractionWithPreps>
-                }
-                interactionResource={interactionResource}
-                itemCollection={
-                  collection as Collection<AnyInteractionPreparation>
-                }
-                onClose={handleCloseDialog}
-              />
-            ) : undefined}
-            {formType === 'form' ? (
-              <ReadOnlyContext.Provider
-                value={
-                  isReadOnly ||
-                  (renderedResourceId !== undefined &&
-                    resource?.id === renderedResourceId)
-                }
-              >
-                <ResourceView
-                  containerRef={containerRef}
-                  dialog={dialog}
-                  headerButtons={(specifyNetworkBadge): JSX.Element => (
-                    <>
-                      <DataEntry.Visit
-                        /*
-                         * If dialog is not false, the visit button would be added
-                         * by ResourceView
-                         */
-                        resource={
-                          !isDependent && dialog === false
-                            ? resource
-                            : undefined
-                        }
-                      />
-                      {!isDependent &&
-                      hasTablePermission(
-                        relationship.relatedTable.name,
-                        'read'
-                      ) &&
-                      typeof handleAdd === 'function' ? (
-                        <DataEntry.Search
-                          disabled={
-                            isReadOnly ||
-                            (isToOne && collection.models.length > 0) ||
-                            isTaxonTreeDefItemTable
+    const [isWarningOpen, handleWarning,closeWarning] = useBooleanState()
+
+    return (
+      <ReadOnlyContext.Provider value={isReadOnly}>
+        <RecordSelectorFromCollection
+          collection={collection}
+          defaultIndex={isToOne ? 0 : index}
+          relationship={relationship}
+          onAdd={(resources): void => {
+            if (isInteraction) {
+              setInteractionResource(resources[0]);
+              handleOpenDialog();
+            }
+            if (!isInteraction && formType !== 'formTable')
+              collection.add(resources);
+            handleAdding(resources);
+          }}
+          onDelete={(...args): void => {
+            if (isCollapsed) handleExpand();
+            handleDelete?.(...args);
+          }}
+          onFetch={handleFetch}
+          onSlide={(index): void => {
+            handleExpand();
+            if (typeof urlParameter === 'string') setIndex(index.toString());
+          }}
+          {...rest}
+        >
+          {({
+            dialogs,
+            slider,
+            resource,
+            onAdd: handleAdd,
+            onRemove: handleRemove,
+            showSearchDialog,
+            isLoading,
+          }): JSX.Element => (
+            <>
+              {isInteraction &&
+              typeof collection.related === 'object' &&
+              isDialogOpen ? (
+                <InteractionDialog
+                  actionTable={
+                    collection.related
+                      .specifyTable as SpecifyTable<InteractionWithPreps>
+                  }
+                  interactionResource={interactionResource}
+                  itemCollection={
+                    collection as Collection<AnyInteractionPreparation>
+                  }
+                  onClose={handleCloseDialog}
+                />
+              ) : undefined}
+              {formType === 'form' ? (
+                <ReadOnlyContext.Provider
+                  value={
+                    isReadOnly ||
+                    (renderedResourceId !== undefined &&
+                      resource?.id === renderedResourceId)
+                  }
+                >
+                  <ResourceView
+                    containerRef={containerRef}
+                    dialog={dialog}
+                    headerButtons={(specifyNetworkBadge): JSX.Element => (
+                      <>
+                        <DataEntry.Visit
+                          /*
+                           * If dialog is not false, the visit button would be added
+                           * by ResourceView
+                           */
+                          resource={
+                            !isDependent && dialog === false
+                              ? resource
+                              : undefined
                           }
-                          onClick={showSearchDialog}
                         />
-                      ) : undefined}
-                      {hasTablePermission(
-                        relationship.relatedTable.name,
-                        'create'
-                      ) && typeof handleAdd === 'function' ? (
-                        isCOJO ? (
-                          <COJODialog
-                            collection={collection}
-                            parentResource={
-                              collection.related as SpecifyResource<CollectionObjectGroup>
-                            }
-                          />
-                        ) : (
-                          <DataEntry.Add
-                            aria-pressed={state.type === 'AddResourceState'}
+                        {!isDependent &&
+                        hasTablePermission(
+                          relationship.relatedTable.name,
+                          'read'
+                        ) &&
+                        typeof handleAdd === 'function' ? (
+                          <DataEntry.Search
                             disabled={
                               isReadOnly ||
                               (isToOne && collection.models.length > 0) ||
                               isTaxonTreeDefItemTable
                             }
-                            onClick={(): void => {
-                              const resource =
-                                new collection.table.specifyTable.Resource();
-
-                              if (
-                                isDependent ||
-                                viewName === relationship.relatedTable.view
-                              ) {
-                                focusFirstField();
-                                handleAdd([resource]);
-                                return;
+                            onClick={showSearchDialog}
+                          />
+                        ) : undefined}
+                        {hasTablePermission(
+                          relationship.relatedTable.name,
+                          'create'
+                        ) && typeof handleAdd === 'function' ? (
+                          isCOJO ? (
+                            <COJODialog
+                              collection={collection}
+                              parentResource={
+                                collection.related as SpecifyResource<CollectionObjectGroup>
                               }
-
-                              if (state.type === 'AddResourceState')
-                                setState({ type: 'MainState' });
-                              else
-                                setState({
-                                  type: 'AddResourceState',
-                                  resource,
-                                  handleAdd,
-                                });
+                            />
+                          ) : (
+                            <DataEntry.Add
+                              aria-pressed={state.type === 'AddResourceState'}
+                              disabled={
+                                isReadOnly ||
+                                (isToOne && collection.models.length > 0) ||
+                                isTaxonTreeDefItemTable
+                              }
+                              onClick={(): void => {
+                                const resource =
+                                  new collection.table.specifyTable.Resource();
+  
+                                if (
+                                  isDependent ||
+                                  viewName === relationship.relatedTable.view
+                                ) {
+                                  focusFirstField();
+                                  handleAdd([resource]);
+                                  return;
+                                }
+  
+                                if (state.type === 'AddResourceState')
+                                  setState({ type: 'MainState' });
+                                else
+                                  setState({
+                                    type: 'AddResourceState',
+                                    resource,
+                                    handleAdd,
+                                  });
+                              }}
+                            />
+                          )
+                        ) : undefined}
+                        {hasTablePermission(
+                          relationship.relatedTable.name,
+                          isDependent ? 'delete' : 'read'
+                        ) && typeof handleRemove === 'function' ? (
+                          <DataEntry.Remove
+                            disabled={
+                              isReadOnly ||
+                              collection.models.length === 0 ||
+                              resource === undefined ||
+                              (renderedResourceId !== undefined &&
+                                resource?.id === renderedResourceId) ||
+                              disableRemove
+                            }
+                            onClick={(): void => {
+                              if (isAttachmentTable) {
+                                handleWarning()
+                              } else {
+                                handleRemove('minusButton');
+                              }
                             }}
                           />
-                        )
-                      ) : undefined}
-                      {hasTablePermission(
-                        relationship.relatedTable.name,
-                        isDependent ? 'delete' : 'read'
-                      ) && typeof handleRemove === 'function' ? (
-                        <DataEntry.Remove
-                          disabled={
-                            isReadOnly ||
-                            collection.models.length === 0 ||
-                            resource === undefined ||
-                            (renderedResourceId !== undefined &&
-                              resource?.id === renderedResourceId) ||
-                            disableRemove
-                          }
-                          onClick={(): void => {
-                            handleRemove('minusButton');
-                          }}
+                        ) : undefined}
+                        <span
+                          className={`flex-1 ${
+                            dialog === false ? '-ml-2' : '-ml-4'
+                          }`}
                         />
-                      ) : undefined}
-                      <span
-                        className={`flex-1 ${
-                          dialog === false ? '-ml-2' : '-ml-4'
-                        }`}
-                      />
-
-                      {isAttachmentTable && (
-                        <AttachmentsCollection collection={collection} />
-                      )}
-                      {specifyNetworkBadge}
-                      {!isToOne && slider}
-                    </>
-                  )}
+                        {isAttachmentTable && (
+                          <AttachmentsCollection collection={collection} />
+                        )}
+                        {specifyNetworkBadge}
+                        {!isToOne && slider}
+                      </>
+                    )}
+                    isCollapsed={isCollapsed}
+                    isDependent={isDependent}
+                    isLoading={isLoading}
+                    isSubForm={dialog === false}
+                    key={resource?.cid}
+                    preHeaderButtons={collapsibleButton}
+                    resource={resource}
+                    title={relationship.label}
+                    onAdd={undefined}
+                    onDeleted={
+                      collection.models.length <= 1 ? handleClose : undefined
+                    }
+                    onSaved={handleClose}
+                    viewName={viewName}
+                    /*
+                     * Don't save the resource on save button click if it is a dependent
+                     * resource
+                     */
+                    onClose={handleClose}
+                  />
+                </ReadOnlyContext.Provider>
+              ) : null}
+              {formType === 'formTable' ? (
+                <FormTableCollection
+                  collection={collection}
+                  dialog={dialog}
+                  disableRemove={disableRemove}
                   isCollapsed={isCollapsed}
-                  isDependent={isDependent}
-                  isLoading={isLoading}
-                  isSubForm={dialog === false}
-                  key={resource?.cid}
                   preHeaderButtons={collapsibleButton}
-                  resource={resource}
-                  title={relationship.label}
-                  onAdd={undefined}
-                  onDeleted={
-                    collection.models.length <= 1 ? handleClose : undefined
-                  }
-                  onSaved={handleClose}
+                  sortField={sortField}
                   viewName={viewName}
-                  /*
-                   * Don't save the resource on save button click if it is a dependent
-                   * resource
-                   */
+                  onAdd={
+                    isTaxonTreeDefItemTable
+                      ? undefined
+                      : (resources): void => {
+                          if (!isInteraction) collection.add(resources);
+                          handleAdd?.(resources);
+                        }
+                  }
                   onClose={handleClose}
+                  onDelete={(resource, index): void => {
+                    if (isAttachmentTable) {
+                      handleWarning()
+                    } else {
+                      collection.remove(resource);
+                      if (isCollapsed) handleExpand();
+                      handleDelete?.(index, 'minusButton');
+                    }
+                  }}
+                  onFetchMore={handleFetch}
                 />
-              </ReadOnlyContext.Provider>
-            ) : null}
-            {formType === 'formTable' ? (
-              <FormTableCollection
-                collection={collection}
-                dialog={dialog}
-                disableRemove={disableRemove}
-                isCollapsed={isCollapsed}
-                preHeaderButtons={collapsibleButton}
-                sortField={sortField}
-                viewName={viewName}
-                onAdd={
-                  isTaxonTreeDefItemTable
-                    ? undefined
-                    : (resources): void => {
-                        if (!isInteraction) collection.add(resources);
-                        handleAdd?.(resources);
-                      }
-                }
-                onClose={handleClose}
-                onDelete={(_resource, index): void => {
-                  if (isCollapsed) handleExpand();
-                  handleDelete?.(index, 'minusButton');
-                }}
-                onFetchMore={handleFetch}
-              />
-            ) : null}
-            {dialogs}
-            {state.type === 'AddResourceState' &&
-            typeof handleAdd === 'function' ? (
-              <ResourceView
-                dialog="nonModal"
-                isDependent={isDependent}
-                isSubForm={false}
-                resource={state.resource}
-                onAdd={undefined}
-                onClose={(): void => setState({ type: 'MainState' })}
-                onDeleted={undefined}
-                onSaved={(): void => {
-                  state.handleAdd([state.resource]);
-                  setState({ type: 'MainState' });
-                }}
-              />
-            ) : null}
-          </>
-        )}
-      </RecordSelectorFromCollection>
-    </ReadOnlyContext.Provider>
-  );
-}
+              ) : null}
+              {dialogs}
+              {state.type === 'AddResourceState' &&
+              typeof handleAdd === 'function' ? (
+                <ResourceView
+                  dialog="nonModal"
+                  isDependent={isDependent}
+                  isSubForm={false}
+                  resource={state.resource}
+                  onAdd={undefined}
+                  onClose={(): void => setState({ type: 'MainState' })}
+                  onDeleted={undefined}
+                  onSaved={(): void => {
+                    state.handleAdd([state.resource]);
+                    setState({ type: 'MainState' });
+                  }}
+                />
+              ) : null}
+              {isWarningOpen && typeof handleRemove === 'function' && isAttachmentTable?
+                <Dialog 
+                  buttons={
+                    <>
+                      <Button.DialogClose>{commonText.close()}</Button.DialogClose>
+                      <Button.Save onClick={():void => {
+                        if (formType === 'form' ) {
+                          handleRemove('minusButton');
+                        }
+                        if (formType === 'formTable') {
+                          collection.remove(resource!);
+                          if (isCollapsed) handleExpand();
+                          handleDelete?.(index, 'minusButton');
+                        }
+                        closeWarning()
+                      }}>{interactionsText.continue()}</Button.Save>
+                    </>
+                  } 
+                  header={attachmentsText.attachmentDelition()}
+                  onClose={closeWarning}
+                  >
+                    {attachmentsText.deleteAttachmentWarning()}
+                    <span className="font-bold">
+                      {resource?.dependentResources?.attachment?.get('title') ?? ''}
+                    </span>
+                  </Dialog> : undefined
+              }
+            </>
+          )}
+        </RecordSelectorFromCollection>
+      </ReadOnlyContext.Provider>
+    );
+  }

--- a/specifyweb/frontend/js_src/lib/components/FormSliders/IntegratedRecordSelector.tsx
+++ b/specifyweb/frontend/js_src/lib/components/FormSliders/IntegratedRecordSelector.tsx
@@ -3,9 +3,7 @@ import type { State } from 'typesafe-reducer';
 
 import { useSearchParameter } from '../../hooks/navigation';
 import { useBooleanState } from '../../hooks/useBooleanState';
-import { attachmentsText } from '../../localization/attachments';
 import { commonText } from '../../localization/common';
-import { interactionsText } from '../../localization/interactions';
 import { f } from '../../utils/functools';
 import type { RA } from '../../utils/types';
 import { Button } from '../Atoms/Button';
@@ -31,10 +29,10 @@ import { SubViewContext } from '../Forms/SubView';
 import type { InteractionWithPreps } from '../Interactions/helpers';
 import { interactionPrepTables } from '../Interactions/helpers';
 import { InteractionDialog } from '../Interactions/InteractionDialog';
-import { Dialog } from '../Molecules/Dialog';
 import { hasTablePermission } from '../Permissions/helpers';
 import { relationshipIsToMany } from '../WbPlanView/mappingHelpers';
 import { AttachmentsCollection } from './AttachmentsCollection';
+import { AttachmentWarningDeletion } from './AttachmentWarningDeletion';
 import { RecordSelectorFromCollection } from './RecordSelectorFromCollection';
 
 /** A wrapper for RecordSelector to integrate with Backbone.Collection */
@@ -411,31 +409,17 @@ export function IntegratedRecordSelector({
                 />
               ) : null}
               {isWarningOpen && typeof handleRemove === 'function' && isAttachmentTable?
-                <Dialog 
-                  buttons={
-                    <>
-                      <Button.DialogClose>{commonText.close()}</Button.DialogClose>
-                      <Button.Save onClick={():void => {
-                        if (formType === 'form' ) {
-                          handleRemove('minusButton');
-                        }
-                        if (formType === 'formTable') {
-                          collection.remove(resource!);
-                          if (isCollapsed) handleExpand();
-                          handleDelete?.(index, 'minusButton');
-                        }
-                        closeWarning()
-                      }}>{interactionsText.continue()}</Button.Save>
-                    </>
-                  } 
-                  header={attachmentsText.attachmentDelition()}
-                  onClose={closeWarning}
-                  >
-                    {attachmentsText.deleteAttachmentWarning()}
-                    <span className="font-bold">
-                      {resource?.dependentResources?.attachment?.get('title') ?? ''}
-                    </span>
-                  </Dialog> : undefined
+                  <AttachmentWarningDeletion 
+                    closeWarning={closeWarning} 
+                    collection={collection} 
+                    formType={formType} 
+                    index={index}
+                    isCollapsed={isCollapsed}
+                    resource={resource} 
+                    onDelete={handleDelete} 
+                    onExpand={handleExpand} 
+                    onRemove={handleRemove}/> 
+                : undefined
               }
             </>
           )}

--- a/specifyweb/frontend/js_src/lib/localization/attachments.ts
+++ b/specifyweb/frontend/js_src/lib/localization/attachments.ts
@@ -682,4 +682,10 @@ export const attachmentsText = createDictionary({
   downloadAllDescription: {
     'en-us': 'Download all found attachments',
   },
+  deleteAttachmentWarning: {
+    'en-us': 'Are you sure you want to delete this attachment?'
+  },
+  attachmentDelition: {
+    'en-us': 'Attachment deletion'
+  }
 } as const);


### PR DESCRIPTION
Fixes #6378

### Checklist

- [ ] Self-review the PR after opening it to make sure the changes look good and
      self-explanatory (or properly documented)
- [ ] Add relevant issue to release milestone

### Testing instructions

- Open a CO with an attachment or create one 
- Click on delete button trash can or - button in subheader for the attachment 
- [ ] Verify a dialog opens with the warning: Are you sure you want to delete this attachment? {Attachment title}
- Click cancel 
- [ ] Verify that the warning closes and your attachment is still there 
- Click on delete again 
- This time click on continue 
- [ ] Verify your attachment has been deleted 
- [ ] Verified for attachment as button 
- [ ] Verified for attachment as subview form 
- [ ] Verified for attachment as subview table

Notes: 
Works with other tables, not just attachment on CO 