### PR TITLE
Fix WB Rollback

### DIFF
--- a/specifyweb/workbench/views.py
+++ b/specifyweb/workbench/views.py
@@ -774,8 +774,8 @@ def unupload(request, ds) -> http.HttpResponse:
         ds.uploaderstatus = {"operation": "unuploading", "taskid": taskid}
         ds.save(update_fields=["uploaderstatus"])
 
-    return http.JsonResponse("w", safe=False)
-
+    # return http.JsonResponse("w", safe=False)
+    return http.JsonResponse(async_result.id, safe=False)
 
 # @login_maybe_required
 @openapi(


### PR DESCRIPTION
Fixes #6401 

There seems to be an issue with rolling back workbench uploads through the unupload API.

From this commit for batch edit https://github.com/specify/specify7/commit/25eef3ff00c78b1387db6907cbc1d33b1c084780

The return value for the unupload view function changed from 
`return http.JsonResponse(async_result.id, safe=False)`
to
`return http.JsonResponse("w", safe=False)`

It seems reverting it might fix this issue.

A follow-up issue is that in the an unupload task might get stuck, and no new unupload task can be made on the dataset until the existing tasks finishes.  So, we might want the user to be able to reset the task state from the UI.

One other thing is to allow for the option of running the unupload task in the main Specify container, rather than as a background task.  This is to match this option we created for the upload task, to help with debugging.

### Checklist

- [ ] Self-review the PR after opening it to make sure the changes look good and
      self-explanatory (or properly documented)
- [ ] Add relevant issue to release milestone
- [ ] Add relevant documentation (Tester - Dev)
- [ ] Add automated tests
- [ ] Add a reverse migration if a migration is present in the PR

### Testing instructions

<!-- What are the steps to verify the fixes/changes in this PR? -->
<!-- Can part of that be replaced by automated tests? -->
