### PR TITLE
Add missing shebang to `docker_entrypoint`

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 set -e
 if [ -z "$(ls -A /volumes/static-files/specify-config)" ]; then
   mkdir -p /volumes/static-files/specify-config/config/


### PR DESCRIPTION
Fixes #6366

<!--
> [!WARNING]  
> This PR affects database migrations. See [migration testing instructions](https://specify.github.io/testing/pull_requests.html#prs-tagged-with-label-migration).
-->

### Testing instructions

1. Run `docker run -it specifyconsortium/specify7-service:production`
2. Verify that it fails

	```bash
	worf@usstitan:~$ docker run -it specifyconsortium/specify7-service:production
	exec /opt/specify7/docker-entrypoint.sh: exec format error
	```

1. Run `docker run -it specifyconsortium/specify7-service:issue-6366`
2. Verify that it succeeds
