### PR TITLE
Update start and end period in GeologicTimePeriod when reversed

### DIFF
--- a/specifyweb/patches/migrations/0004_chrono_start_end.py
+++ b/specifyweb/patches/migrations/0004_chrono_start_end.py
@@ -1,0 +1,37 @@
+from django.db import migrations, connection
+
+def reverse_faulty_end_start_period(apps, schema_editor):
+    from django.db import connection
+
+    with connection.cursor() as cursor:
+        # Check if the table geologictimeperiod exists
+        cursor.execute("""
+            SELECT COUNT(*)
+            FROM information_schema.tables
+            WHERE table_name = 'geologictimeperiod' AND table_schema = DATABASE();
+        """)
+        if cursor.fetchone()[0] == 1:
+            # If the table exists, perform the update
+            cursor.execute("""
+                UPDATE geologictimeperiod AS gtp
+                JOIN (
+                    SELECT GeologicTimePeriodID, StartPeriod AS orig_start
+                    FROM geologictimeperiod
+                    WHERE StartPeriod < EndPeriod
+                ) AS sub ON gtp.GeologicTimePeriodID = sub.GeologicTimePeriodID
+                SET 
+                    gtp.StartPeriod = gtp.EndPeriod,
+                    gtp.EndPeriod = sub.orig_start;
+            """)
+        else:
+            print("Table 'geologictimeperiod' does not exist. Skipping update.")
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('patches', '0003_coordinate_fields_fix'),
+    ]
+
+    operations = [
+        migrations.RunPython(reverse_faulty_end_start_period),
+    ]


### PR DESCRIPTION
Fixes #5412

> [!WARNING]  
> This PR affects database migrations. See [migration testing instructions](https://specify.github.io/testing/pull_requests.html#prs-tagged-with-label-migration).

### Checklist

- [ ] Self-review the PR after opening it to make sure the changes look good and
      self-explanatory (or properly documented)
- [ ] Add relevant issue to release milestone

### Testing instructions

- Open a db with production that has geologic time period tree 
- Open a node 
- Find a node that has a start period greater than the start or create one or update one => start 100 - end 200
- Save 
- Change the branch to use this pr and not prod 
- Open the node from the previous step 
- Verify the start period is now greater than the end. start 200 - end 100 
