### PR TITLE
Display correct message when trying to enter value greater than limit

### DIFF
--- a/specifyweb/frontend/js_src/lib/components/FormFields/Field.tsx
+++ b/specifyweb/frontend/js_src/lib/components/FormFields/Field.tsx
@@ -212,6 +212,7 @@ function Field({
     <Input.Generic
       forwardRef={validationRef}
       key={parser.title}
+      max={Number.MAX_SAFE_INTEGER}
       name={name}
       placeholder={
         displayPrimaryCatNumberPlaceHolder &&


### PR DESCRIPTION
Fixes #2970

### Checklist

- [ ] Self-review the PR after opening it to make sure the changes look good and
      self-explanatory (or properly documented)
- [ ] Add relevant issue to release milestone

### Testing instructions

- Open form (i.e new locality) 
- Enter required field 
- Enter 9999999999999999 in max uncertainty 
- Save 
- See that save is blocked
- [ ] Verify there is an error message on max uncertainty saying: 'Value must be less or equal to 9007199254740991'

NOTES: 
The issue is due to a JavaScript number precision limitation. 
The maximum safe integer that can be accurately represented is 9007199254740991. 
If you enter a number like 9999999999999999, JavaScript rounds it to the nearest representable value, which is 10000000000000000, due to precision loss.
