### PR TITLE
Handle geo field in imported query for non-geo collection

### DIFF
--- a/specifyweb/frontend/js_src/lib/components/WbPlanView/navigator.ts
+++ b/specifyweb/frontend/js_src/lib/components/WbPlanView/navigator.ts
@@ -130,6 +130,17 @@ function navigator({
   const childrenAreRanks =
     isTreeTable(table.name) && !valueIsTreeMeta(parentPartName);
 
+  const disciplineType = getSystemInfo().discipline_type?.toLowerCase();
+  const geoPaleoDisciplines = ['geology', 'invertpaleo', 'vertpaleo'];
+  const isNonGeoDiscipline = !geoPaleoDisciplines.includes(disciplineType);
+
+  if (
+    isNonGeoDiscipline &&
+    (table.name === 'PaleoContext' || table.name === 'LithoStrat')
+  ) {
+    return;
+  }
+
   const callbackPayload = {
     table,
     parentRelationship,


### PR DESCRIPTION
Fixes #3337

### Checklist

- [ ] Self-review the PR after opening it to make sure the changes look good and
      self-explanatory (or properly documented)
- [ ] Add relevant issue to release milestone

### Testing instructions

- Open a geo db 
- Create a query choosing CO as base table 
- Add litho field to your fields 
- Save 
- Export the query 
- Open a new branch with a non geo db 
- Open query builder side menu 
- Click new 
- Choose import 
- Import your query with litho 
- [ ] See that there is now a message "The following fields are hidden in the query you imported: CO Paleo Context"
- Click close 
- Verify the query opens and there is no crash 
