### PR TITLE
Allow to click on RS in interaction dialog after errored entries

### DIFF
--- a/specifyweb/frontend/js_src/lib/components/Interactions/InteractionDialog.tsx
+++ b/specifyweb/frontend/js_src/lib/components/Interactions/InteractionDialog.tsx
@@ -113,7 +113,8 @@ export function InteractionDialog({
   function handleProceed(
     recordSet: SerializedResource<RecordSet> | undefined
   ): void {
-    const catalogNumbers = handleParse();
+    const fromRecordSet = recordSet !== undefined;
+    const catalogNumbers = handleParse(fromRecordSet);
     if (catalogNumbers === undefined) return undefined;
     if (isLoanReturn)
       loading(
@@ -217,7 +218,10 @@ export function InteractionDialog({
     false
   );
 
-  function handleParse(): RA<string> | undefined {
+  function handleParse(fromRecordSet: boolean): RA<string> | undefined {
+    if (fromRecordSet) {
+      return [];
+    }
     const parseResults = split(catalogNumbers).map((value) =>
       parseValue(parser, inputRef.current ?? undefined, value)
     );


### PR DESCRIPTION
Fixes #4851

### Checklist

- [ ] Self-review the PR after opening it to make sure the changes look good and
      self-explanatory (or properly documented)
- [ ] Add relevant issue to release milestone

### Testing instructions

- Click on Interactions
- Create Loan or Gift by entering catalog numbers
- Enter a number or character that does not follow the required format (for example, a letter or a number like '999999999'), click Next and see 'Required Format' message
- Click on 'By Choosing a Recordset,' then click on a record set
- [ ] Verify it brings you to the next dialog prep interaction 
