### PR TITLE
Handle self join aggregation

### DIFF
--- a/specifyweb/stored_queries/format.py
+++ b/specifyweb/stored_queries/format.py
@@ -299,7 +299,7 @@ class ObjectFormatter(object):
         aliased_orm_table = aliased(orm_table)
 
         if is_self_join_aggregation: # Handle self join aggregation
-            if field.name == 'children' and field.relatedModelName == 'CollectionObject':
+            if field.name in {'children', 'components'} and field.relatedModelName == 'CollectionObject':
                 # Child = aliased(orm_table)
                 subquery_query = Query([]) \
                     .select_from(aliased_orm_table) \

--- a/specifyweb/stored_queries/format.py
+++ b/specifyweb/stored_queries/format.py
@@ -7,7 +7,8 @@ from xml.etree.ElementTree import Element
 from xml.sax.saxutils import quoteattr
 
 from specifyweb.specify.utils import get_picklists
-from sqlalchemy import orm, Table as SQLTable, inspect
+from sqlalchemy import Table as SQLTable, inspect
+from sqlalchemy.orm import aliased, Query
 from sqlalchemy.sql.expression import case, func, cast, literal, Label
 from sqlalchemy.sql.functions import concat
 from sqlalchemy.orm.attributes import InstrumentedAttribute
@@ -277,16 +278,33 @@ class ObjectFormatter(object):
 
         join_column = list(inspect(
             getattr(orm_table, field.otherSideName)).property.local_columns)[0]
+        subquery_query = Query([]) \
+            .select_from(orm_table) \
+            .filter(join_column == getattr(rel_table, rel_table._id)) \
+            .correlate(rel_table)
+
+        is_self_join_aggregation = specify_model.name.lower() == query.query.selectable.froms[0].name.lower()
+        # is_self_join_aggregation = orm_table.name.lower() == query.query.selectable.froms[0].name.lower()
+        aliased_orm_table = aliased(orm_table)
+
+        if is_self_join_aggregation: # Handle self join aggregation
+            # TODO: Handle self join aggregation in the general case
+            if field.name == 'children' and field.relatedModelName == 'CollectionObject':
+                # Child = aliased(orm_table)
+                subquery_query = Query([]) \
+                    .select_from(aliased_orm_table) \
+                    .filter(aliased_orm_table.ParentCOID == getattr(rel_table, rel_table._id)) \
+                    .correlate(rel_table)
+
         subquery = QueryConstruct(
             collection=query.collection,
             objectformatter=self,
-            query=orm.Query([]).select_from(orm_table) \
-                .filter(join_column == getattr(rel_table, rel_table._id)) \
-                .correlate(rel_table)
+            query=subquery_query
         )
 
-        subquery, formatted = self.objformat(subquery, orm_table,
-                                             formatter_name, cycle_with_self)
+        subquery, formatted = self.objformat(subquery, orm_table, formatter_name, cycle_with_self) \
+            if not is_self_join_aggregation \
+            else self.objformat(subquery, aliased_orm_table, formatter_name, cycle_with_self) 
 
         if order_by != '':
             subquery, order_by_expr, _ = self.make_expr(subquery, order_by, {}, orm_table, specify_model, do_blank_null=False)
@@ -295,7 +313,6 @@ class ObjectFormatter(object):
             order_by_expr = []
 
         aggregated = blank_nulls(group_concat(formatted, separator, *order_by_expr))
-
 
         aggregator_label = f"aggregator_{self.aggregator_count}"
         self.aggregator_count += 1

--- a/specifyweb/stored_queries/format.py
+++ b/specifyweb/stored_queries/format.py
@@ -283,7 +283,11 @@ class ObjectFormatter(object):
             .filter(join_column == getattr(rel_table, rel_table._id)) \
             .correlate(rel_table)
 
-        is_self_join_aggregation = specify_model.name.lower() == query.query.selectable.froms[0].name.lower()
+        is_self_join_aggregation = len(query.query.column_descriptions) > 0 and \
+            query.query.selectable is not None and \
+            query.query.selectable.froms is not None and \
+            len(query.query.selectable.froms) > 0 and \
+            specify_model.name.lower() == query.query.selectable.froms[0].name.lower()
         # is_self_join_aggregation = orm_table.name.lower() == query.query.selectable.froms[0].name.lower()
         aliased_orm_table = aliased(orm_table)
 
@@ -295,6 +299,8 @@ class ObjectFormatter(object):
                     .select_from(aliased_orm_table) \
                     .filter(aliased_orm_table.ParentCOID == getattr(rel_table, rel_table._id)) \
                     .correlate(rel_table)
+            else:
+                is_self_join_aggregation = False
 
         subquery = QueryConstruct(
             collection=query.collection,

--- a/specifyweb/stored_queries/format.py
+++ b/specifyweb/stored_queries/format.py
@@ -283,11 +283,15 @@ class ObjectFormatter(object):
             .filter(join_column == getattr(rel_table, rel_table._id)) \
             .correlate(rel_table)
 
+        try:
+            from_table_name = query.query.selectable.froms[0].name.lower()
+        except AttributeError:
+            from_table_name = None
         is_self_join_aggregation = len(query.query.column_descriptions) > 0 and \
             query.query.selectable is not None and \
             query.query.selectable.froms is not None and \
             len(query.query.selectable.froms) > 0 and \
-            specify_model.name.lower() == query.query.selectable.froms[0].name.lower()
+            specify_model.name.lower() == from_table_name
         # is_self_join_aggregation = orm_table.name.lower() == query.query.selectable.froms[0].name.lower()
         aliased_orm_table = aliased(orm_table)
 

--- a/specifyweb/stored_queries/format.py
+++ b/specifyweb/stored_queries/format.py
@@ -13,6 +13,7 @@ from sqlalchemy.sql.expression import case, func, cast, literal, Label
 from sqlalchemy.sql.functions import concat
 from sqlalchemy.orm.attributes import InstrumentedAttribute
 from sqlalchemy.sql.elements import Extract
+from sqlalchemy.exc import InvalidRequestError
 from sqlalchemy import types
 
 from typing import Tuple, Optional, Union
@@ -286,6 +287,8 @@ class ObjectFormatter(object):
         try:
             from_table_name = query.query.selectable.froms[0].name.lower()
         except AttributeError:
+            from_table_name = None
+        except InvalidRequestError:
             from_table_name = None
         is_self_join_aggregation = len(query.query.column_descriptions) > 0 and \
             query.query.selectable is not None and \


### PR DESCRIPTION
Fixes #6450

Handle the case of self join aggregation.

Here is the current query generated by the co parent aggregated QB query:

```sql
SELECT
	collectionobject.`CollectionObjectID`,
	collectionobject.`CatalogNumber`,
	(
	SELECT
		IFNULL(GROUP_CONCAT(IFNULL(collectionobject.`CatalogNumber`, '') SEPARATOR ','), '') AS blank_nulls_1
	WHERE
		collectionobject.`ParentCOID` = collectionobject.`CollectionObjectID`) AS aggregator_0
FROM
	collectionobject
WHERE
	collectionobject.`CollectionID` = 4
LIMIT 0, 40;
```

The query should look like this:
```sql
SELECT
	collectionobject.`CollectionObjectID`,
	collectionobject.`CatalogNumber`,
	(
	SELECT
		IFNULL(GROUP_CONCAT(IFNULL(collectionobject_1.`CatalogNumber`, '') SEPARATOR %s), '') AS blank_nulls_1
	FROM
		collectionobject AS collectionobject_1
	WHERE
		collectionobject_1.`ParentCOID` = collectionobject.`CollectionObjectID`) AS aggregator_0
FROM
	collectionobject
WHERE
	collectionobject.`CollectionID` = 4
LIMIT 0, 40;
```

### Checklist

- [x] Self-review the PR after opening it to make sure the changes look good and
      self-explanatory (or properly documented)
- [x] Add relevant issue to release milestone

### Testing instructions

- Choose a database with Collection Objects with child/parent Collection Objects
- Open QB with CO table
- Choose children > aggregated
- Run Query
- [x] No errors and each CO with children has all it's child catalog numbers in the aggregation.

<img width="1151" alt="image" src="https://github.com/user-attachments/assets/190482b9-aefb-4c5c-b05a-433ceec90a1c" />

<img width="1151" alt="image" src="https://github.com/user-attachments/assets/faac327c-9ca2-40e5-9dae-edac13256df8" />

