### PR TITLE
Fix ID queries with spaces in rank name

### DIFF
--- a/specifyweb/stored_queries/queryfieldspec.py
+++ b/specifyweb/stored_queries/queryfieldspec.py
@@ -87,15 +87,15 @@ def find_tree_and_field(table: Table, fieldname: str):
         return tree_rank_and_field[0], mapping[""]
     
     # Handles case where rank name contains spaces
-    if len(tree_rank_and_field) >= 2:
-        if table.get_field(tree_rank_and_field[-1]) is not None:
-            tree_rank_and_field = [" ".join(tree_rank_and_field[:-1]), tree_rank_and_field[-1]]
-        else:
-            # Edge case: when rank name has spaces and there is no field in stringid (ie. fullname query)
-            tree_rank_and_field = [" ".join(tree_rank_and_field), ""]
+    field = tree_rank_and_field[-1]
+    if table.get_field(field) or field in mapping:
+        tree_rank = " ".join(tree_rank_and_field[:-1])
+    else:
+        # Edge case: rank name contains spaces, and no field exists (ie: fullname query)
+        tree_rank = " ".join(tree_rank_and_field)
+        field = ""
     
-    tree_rank, tree_field = tree_rank_and_field
-    return tree_rank, mapping.get(tree_field, tree_field)
+    return tree_rank, mapping.get(field, field)
 
 
 def make_stringid(fs, table_list):

--- a/specifyweb/stored_queries/tests/tests_legacy.py
+++ b/specifyweb/stored_queries/tests/tests_legacy.py
@@ -51,6 +51,16 @@ class QueryFieldTests(TestCase):
         self.assertEqual(rank_name, "Country / Region")
         self.assertEqual(field_name, "geographyCode")
 
+        # Test ID mapping
+        rank_name, field_name = find_tree_and_field(geography, "Country ID")
+        self.assertEqual(rank_name, "Country")
+        self.assertEqual(field_name, "geographyid")
+
+        # Test ID mapping with spaces
+        rank_name, field_name = find_tree_and_field(geography, "Country / Region ID")
+        self.assertEqual(rank_name, "Country / Region")
+        self.assertEqual(field_name, "geographyid")
+
 @skip("These tests are out of date.")
 class StoredQueriesTests(ApiTests):
     # def setUp(self):


### PR DESCRIPTION
The hotfix in #6465 broke querying on the ID field. Added a unit test to make sure it doesn't break again

<!--
> [!WARNING]  
> This PR affects database migrations. See [migration testing instructions](https://specify.github.io/testing/pull_requests.html#prs-tagged-with-label-migration).
-->

### Checklist

- [x] Self-review the PR after opening it to make sure the changes look good and
      self-explanatory (or properly documented)
- [ ] Add relevant issue to release milestone
- [ ] Add relevant documentation (Tester - Dev)
- [x] Add automated tests
- [ ] Add a reverse migration if a migration is present in the PR

### Testing instructions

<!-- What are the steps to verify the fixes/changes in this PR? -->
<!-- Can part of that be replaced by automated tests? -->

- [ ] General test queries with rank names (ie: do not use `(any rank)`)
- [ ] General test queries with rank names that have spaces
- Use the db `os_2025_04_30_09_33_44`
  - Go to Trees > Geography
  - Select a node in a rank that has spaces
  - Query from tree
  - [ ] Verify results are same as in version `7.10.0`
  - Select a node in a rank that DOES NOT have spaces
  - Query from tree
  - [ ] Verify results are same as in version `7.10.0`
