### PR TITLE
Make resource open from formatter and agg readonly

### DIFF
--- a/specifyweb/frontend/js_src/lib/components/Formatters/Preview.tsx
+++ b/specifyweb/frontend/js_src/lib/components/Formatters/Preview.tsx
@@ -9,6 +9,7 @@ import type { GetOrSet, RA } from '../../utils/types';
 import { removeItem } from '../../utils/utils';
 import { Button } from '../Atoms/Button';
 import { Link } from '../Atoms/Link';
+import { ReadOnlyContext } from '../Core/Contexts';
 import { fetchCollection } from '../DataModel/collection';
 import type { AnySchema } from '../DataModel/helperTypes';
 import type { SpecifyResource } from '../DataModel/legacyTypes';
@@ -139,7 +140,16 @@ export function ResourcePreview({
     ),
     false
   );
-  return children((_, index) =>
-    formatted === undefined ? commonText.loading() : formatted[index]
+  /*
+   * Return children((_, index) =>
+   *   formatted === undefined ? commonText.loading() : formatted[index]
+   * );
+   */
+  return (
+    <ReadOnlyContext.Provider value>
+      {children((_, index) =>
+        formatted === undefined ? commonText.loading() : formatted[index]
+      )}
+    </ReadOnlyContext.Provider>
   );
 }


### PR DESCRIPTION
Fixes #4795

### Checklist

- [ ] Self-review the PR after opening it to make sure the changes look good and
      self-explanatory (or properly documented)
- [ ] Add relevant issue to release milestone

### Testing instructions

- Go to record formatters
- Click on any table (e.g. accesssion)
- Scroll down to preview
- Click on one of the view buttons next to a record
- [ ] Verify the form resource in readonly 
