### PR TITLE
Remove field warning on update in prep dialog

### DIFF
--- a/specifyweb/frontend/js_src/lib/components/Interactions/InteractionDialog.tsx
+++ b/specifyweb/frontend/js_src/lib/components/Interactions/InteractionDialog.tsx
@@ -235,6 +235,10 @@ export function InteractionDialog({
       return undefined;
     }
 
+    if (errorMessages.length === 0 && collectionHasSeveralTypes === false) {
+      setValidation([]);
+    }
+
     if (collectionHasSeveralTypes === true) {
       const parsedCatNumber = split(catalogNumbers);
 


### PR DESCRIPTION
Fixes #4915

### Checklist

- [ ] Self-review the PR after opening it to make sure the changes look good and
      self-explanatory (or properly documented)
- [ ] Add relevant issue to release milestone

### Testing instructions

- Go to interactions
- Choose any interaction with the preparations dialog (e.g. loan)
- Click on by entering catalog number
- Add an invalid catalog number
- See the field turns red
- Delete that and enter valid catalog numbers
- [ ] Verify the field does not stay red