### PR TITLE
Update TreeRankQuery to fix implicit ORs

### DIFF
--- a/specifyweb/stored_queries/queryfieldspec.py
+++ b/specifyweb/stored_queries/queryfieldspec.py
@@ -117,7 +117,16 @@ def make_stringid(fs, table_list):
 class TreeRankQuery(Relationship):
     # FUTURE: used to remember what the previous value was. Useless after 6 retires
     original_field: str
-    pass
+
+    def __hash__(self):
+        return hash((TreeRankQuery, self.relatedModelName, self.name))
+
+    def __eq__(self, value):
+        return (
+            isinstance(value, TreeRankQuery)
+            and value.name == self.name
+            and value.relatedModelName == self.relatedModelName
+        )
 
 
 QueryNode = Union[Field, Relationship, TreeRankQuery]


### PR DESCRIPTION
Fixes #6486 

Cherry picks the commit that fixes this in https://github.com/specify/specify7/pull/6196#issuecomment-2669749739

<!--
> [!WARNING]  
> This PR affects database migrations. See [migration testing instructions](https://specify.github.io/testing/pull_requests.html#prs-tagged-with-label-migration).
-->

### Checklist

- [x] Self-review the PR after opening it to make sure the changes look good and
      self-explanatory (or properly documented)
- [ ] Add relevant issue to release milestone
- [ ] Add relevant documentation (Tester - Dev)
- [ ] Add automated tests
- [ ] Add a reverse migration if a migration is present in the PR

### Testing instructions

<!-- What are the steps to verify the fixes/changes in this PR? -->
<!-- Can part of that be replaced by automated tests? -->
- General test tree queries with OR operations
- [ ] Verify results are same as v7.9
- Use `UW-GeoCollections` db
- Run the query `3 - Create a Species List by Water Body/County/State/Country` (https://uwgeocollections20250210-issue-6486.test.specifysystems.org/specify/query/153/) (use spadmin and Fossil Vertebrates collection)
- [ ] Verify results are same as v7.9 (see issue for reference)