### PR TITLE
Add remarks when saving record set from WB

### DIFF
--- a/specifyweb/frontend/js_src/lib/components/WorkBench/RecordSet.tsx
+++ b/specifyweb/frontend/js_src/lib/components/WorkBench/RecordSet.tsx
@@ -94,7 +94,10 @@ function CreateRecordSetDialog({
             ajax<number>(`/api/workbench/create_recordset/${datasetId}/`, {
               method: 'POST',
               headers: { Accept: 'application/json' },
-              body: formData({ name: recordSet.get('name') }),
+              body: formData({
+                name: recordSet.get('name'),
+                remarks: recordSet.get('remarks') ?? '',
+              }),
               errorMode: 'dismissible',
             }).then(({ data }) =>
               unsafeNavigate(`/specify/record-set/${data}/`)

--- a/specifyweb/workbench/tests.py
+++ b/specifyweb/workbench/tests.py
@@ -111,7 +111,7 @@ class DataSetTests(ApiTests):
 
         response = c.post(
             f"/api/workbench/create_recordset/{datasetid}/",
-            data={"name": "Foobar upload"},
+            data={"name": "Foobar upload", "remarks": ""},
         )
         self.assertEqual(response.status_code, 201)
         recordset_id = json.loads(response.content)

--- a/specifyweb/workbench/upload/upload.py
+++ b/specifyweb/workbench/upload/upload.py
@@ -228,7 +228,7 @@ def clear_disambiguation(ds: Spdataset) -> None:
         ds.save(update_fields=["data"])
 
 
-def create_recordset(ds: Spdataset, name: str):
+def create_recordset(ds: Spdataset, name: str, remarks: str):
     table, upload_plan = get_ds_upload_plan(ds.collection, ds)
     assert ds.rowresults is not None
     results = json.loads(ds.rowresults)
@@ -237,6 +237,7 @@ def create_recordset(ds: Spdataset, name: str):
         collectionmemberid=ds.collection.id,
         dbtableid=table.tableId,
         name=name,
+        remarks=remarks,
         specifyuser=ds.specifyuser,
         type=0,
     )

--- a/specifyweb/workbench/views.py
+++ b/specifyweb/workbench/views.py
@@ -1149,7 +1149,7 @@ def create_recordset(request, ds) -> http.HttpResponse:
         return http.HttpResponseBadRequest("missing parameter: name")
 
     name = request.POST["name"]
-    remarks = request.POST["remarks"] or ""
+    remarks = request.POST["remarks"]
     max_length = Recordset._meta.get_field("name").max_length
     if max_length is not None and len(name) > max_length:
         return http.HttpResponseBadRequest("name too long")

--- a/specifyweb/workbench/views.py
+++ b/specifyweb/workbench/views.py
@@ -1149,6 +1149,7 @@ def create_recordset(request, ds) -> http.HttpResponse:
         return http.HttpResponseBadRequest("missing parameter: name")
 
     name = request.POST["name"]
+    remarks = request.POST["remarks"]
     max_length = Recordset._meta.get_field("name").max_length
     if max_length is not None and len(name) > max_length:
         return http.HttpResponseBadRequest("name too long")
@@ -1162,5 +1163,5 @@ def create_recordset(request, ds) -> http.HttpResponse:
         request.specify_collection, request.specify_user, Recordset, "create"
     )
 
-    rs = uploader.create_recordset(ds, name)
+    rs = uploader.create_recordset(ds, name, remarks)
     return http.JsonResponse(rs.id, status=201, safe=False)

--- a/specifyweb/workbench/views.py
+++ b/specifyweb/workbench/views.py
@@ -1149,7 +1149,7 @@ def create_recordset(request, ds) -> http.HttpResponse:
         return http.HttpResponseBadRequest("missing parameter: name")
 
     name = request.POST["name"]
-    remarks = request.POST["remarks"]
+    remarks = request.POST["remarks"] or ""
     max_length = Recordset._meta.get_field("name").max_length
     if max_length is not None and len(name) > max_length:
         return http.HttpResponseBadRequest("name too long")


### PR DESCRIPTION
Fixes #4913

Previously only the name attribute was being passed to the API for the WB create record set endpoint

<!--
> [!WARNING]  
> This PR affects database migrations. See [migration testing instructions](https://specify.github.io/testing/pull_requests.html#prs-tagged-with-label-migration).
-->

### Checklist

- [x] Self-review the PR after opening it to make sure the changes look good and
      self-explanatory (or properly documented)
- [x] Add relevant issue to release milestone
- [ ] Add relevant documentation (Tester - Dev)
- [ ] Add automated tests
- [ ] Add a reverse migration if a migration is present in the PR

### Testing instructions

<!-- What are the steps to verify the fixes/changes in this PR? -->
<!-- Can part of that be replaced by automated tests? -->
- Upload a WB dataset
- Click Results > Create Record Set
- Add remarks 
- Click save
- Click the pencil icon after being redirected to Record Set
- [ ] Verify remarks were added
