### PR TITLE
Increase default form width

### DIFF
--- a/specifyweb/frontend/js_src/lib/components/Preferences/UserDefinitions.tsx
+++ b/specifyweb/frontend/js_src/lib/components/Preferences/UserDefinitions.tsx
@@ -850,7 +850,7 @@ export const userPreferenceDefinitions = {
             requiresReload: false,
             setOnBlurOnly: true,
             visible: true,
-            defaultValue: 1200,
+            defaultValue: 1600,
             type: 'java.lang.Float',
             parser: {
               min: 100,


### PR DESCRIPTION
Fixes #6379

This really needs almost 0 testing, it is a super simple change.

### Testing instructions

1. Verify the default form width is `1600` in preferences
2. Verify the form is wider than before
