### PR TITLE
Don't trigger unload protect when re-opening to-one resource in dialog

### DIFF
--- a/specifyweb/frontend/js_src/lib/components/DataModel/__tests__/resourceApi.test.ts
+++ b/specifyweb/frontend/js_src/lib/components/DataModel/__tests__/resourceApi.test.ts
@@ -1,6 +1,6 @@
 import { overrideAjax } from '../../../tests/ajax';
 import { requireContext } from '../../../tests/helpers';
-import type { RA, WritableArray } from '../../../utils/types';
+import type { DeepPartial, RA, WritableArray } from '../../../utils/types';
 import { removeKey, replaceItem } from '../../../utils/utils';
 import { formatUrl } from '../../Router/queryString';
 import { addMissingFields } from '../addMissingFields';
@@ -10,7 +10,11 @@ import { getResourceApiUrl } from '../resource';
 import { deserializeResource, serializeResource } from '../serializers';
 import type { Collection } from '../specifyTable';
 import { tables } from '../tables';
-import type { CollectionObjectAttribute, Determination } from '../types';
+import type {
+  CollectionObject,
+  CollectionObjectAttribute,
+  Determination,
+} from '../types';
 
 requireContext();
 
@@ -51,6 +55,8 @@ const collectionObjectResponse = {
   collection: getResourceApiUrl('Collection', 4),
   determinations: determinationsResponse,
 };
+
+overrideAjax(getResourceApiUrl('CollectionObjectType', 1), {});
 
 overrideAjax(collectionObjectUrl, collectionObjectResponse);
 overrideAjax(
@@ -754,6 +760,65 @@ describe('set', () => {
     resource.set('accession', null);
     expect(resource.get('accession')).toBeNull();
     expect(resource.independentResources.accession).toBeNull();
+  });
+  test('bulk setting attributes', () => {
+    const resource = new tables.CollectionObject.Resource({ id: 1 });
+    const collectionObjectId = 1;
+    const catalogNumber = '000000001';
+    const options = undefined;
+    const accessionUrl = getResourceApiUrl('Accession', 1);
+    const attributeText1 = 'example text';
+    const serializedDeterminations: RA<
+      Partial<SerializedRecord<Determination>>
+    > = [
+      {
+        iscurrent: true,
+      },
+      {},
+    ];
+    const serializedAttributes: DeepPartial<
+      SerializedRecord<CollectionObject>
+    > = {
+      id: 1,
+      catalognumber: catalogNumber,
+      accession: accessionUrl,
+      determinations: [...serializedDeterminations],
+      collectionobjectattribute: {
+        text1: attributeText1,
+      } as never,
+    };
+    resource.set(serializedAttributes as never, options as never);
+    expect(resource.id).toStrictEqual(collectionObjectId);
+    expect(resource.get('catalogNumber')).toEqual(catalogNumber);
+    expect(resource.get('accession')).toStrictEqual(accessionUrl);
+    expect(resource.get('determinations')).toBeUndefined();
+    expect(
+      resource.getDependentResource('determinations')?.models.length
+    ).toStrictEqual(serializedDeterminations.length);
+    expect(
+      resource.getDependentResource('collectionObjectAttribute')?.get('text1')
+    ).toStrictEqual(attributeText1);
+  });
+  test('silent respected on bulk set', () => {
+    // See https://github.com/specify/specify7/issues/6488
+    const resource = new tables.CollectionObject.Resource({ id: 1 });
+    const serializedDeterminations: RA<
+      Partial<SerializedRecord<Determination>>
+    > = [
+      {
+        iscurrent: true,
+      },
+      {},
+    ];
+    const serializedAttributes: DeepPartial<
+      SerializedRecord<CollectionObject>
+    > = {
+      determinations: serializedDeterminations,
+    };
+    resource.set(serializedAttributes as never, { silent: true } as never);
+    expect(resource.needsSaved).toStrictEqual(false);
+    resource.set(serializedAttributes as never, { silent: false } as never);
+    expect(resource.needsSaved).toStrictEqual(true);
   });
 });
 

--- a/specifyweb/frontend/js_src/lib/components/DataModel/__tests__/resourceApi.test.ts
+++ b/specifyweb/frontend/js_src/lib/components/DataModel/__tests__/resourceApi.test.ts
@@ -782,7 +782,7 @@ describe('set', () => {
       id: 1,
       catalognumber: catalogNumber,
       accession: accessionUrl,
-      determinations: [...serializedDeterminations],
+      determinations: Array.from(serializedDeterminations),
       collectionobjectattribute: {
         text1: attributeText1,
       } as never,
@@ -816,9 +816,9 @@ describe('set', () => {
       determinations: serializedDeterminations,
     };
     resource.set(serializedAttributes as never, { silent: true } as never);
-    expect(resource.needsSaved).toStrictEqual(false);
+    expect(resource.needsSaved).toBe(false);
     resource.set(serializedAttributes as never, { silent: false } as never);
-    expect(resource.needsSaved).toStrictEqual(true);
+    expect(resource.needsSaved).toBe(true);
   });
 });
 

--- a/specifyweb/frontend/js_src/lib/components/DataModel/resourceApi.ts
+++ b/specifyweb/frontend/js_src/lib/components/DataModel/resourceApi.ts
@@ -443,7 +443,8 @@ export const ResourceBase = Backbone.Model.extend({
            * on their models holding the resource are not incidently notified
            * of a change event
            * See https://github.com/specify/specify7/issues/6488
-           * */
+           * 
+           */
           {
             silent: typeof key === 'object' && options?.silent === true,
           }

--- a/specifyweb/frontend/js_src/lib/components/DataModel/resourceApi.ts
+++ b/specifyweb/frontend/js_src/lib/components/DataModel/resourceApi.ts
@@ -402,6 +402,11 @@ export const ResourceBase = Backbone.Model.extend({
     const attributes = {};
     if (_.isObject(key) || key == null) {
       /*
+       * The two argument case. This is almost exclusively called by BackBone
+       * when syncing the resource attributes with the server
+       */
+
+      /*
        * In the two argument case, so
        * "key" is actually an object mapping keys to values
        */
@@ -427,7 +432,22 @@ export const ResourceBase = Backbone.Model.extend({
     const adjustedAttributes = _.reduce(
       attributes,
       (accumulator, value, fieldName) => {
-        const [newFieldName, newValue] = this._handleField(value, fieldName);
+        const [newFieldName, newValue] = this._handleField(
+          value,
+          fieldName,
+          /**
+           * Only silence (change) events in the two argument case and when
+           * options indicate.
+           *
+           * This is primarily so any Collections listening to change events
+           * on their models holding the resource are not incidently notified
+           * of a change event
+           * See https://github.com/specify/specify7/issues/6488
+           * */
+          {
+            silent: typeof key === 'object' && options?.silent === true,
+          }
+        );
         return _.isUndefined(newValue)
           ? accumulator
           : Object.assign(accumulator, { [newFieldName]: newValue });
@@ -447,7 +467,11 @@ export const ResourceBase = Backbone.Model.extend({
     this.trigger('changed');
     return result;
   },
-  _handleField(value, fieldName) {
+  _handleField<OPTIONS extends { readonly silent?: boolean }>(
+    value,
+    fieldName,
+    options?: OPTIONS
+  ) {
     if (fieldName === '_tablename') return ['_tablename', undefined];
     if (_(['id', 'resource_uri', 'recordset_info']).contains(fieldName))
       return [fieldName, value]; // Special fields
@@ -473,11 +497,15 @@ export const ResourceBase = Backbone.Model.extend({
               getResourceApiUrl(field.table.name, value),
               fieldName
             )
-          : this._handleInlineDataOrResource(value, fieldName);
+          : this._handleInlineDataOrResource(value, fieldName, options);
     }
     return [fieldName, value];
   },
-  _handleInlineDataOrResource(value, fieldName) {
+  _handleInlineDataOrResource<OPTIONS extends { readonly silent?: boolean }>(
+    value,
+    fieldName,
+    options?: OPTIONS
+  ) {
     // BUG: check type of value
     const field: Relationship = this.specifyTable.strictGetField(fieldName);
     const relatedTable = field.relatedTable;
@@ -530,8 +558,10 @@ export const ResourceBase = Backbone.Model.extend({
         }
 
         // Because the foreign key is on the other side
-        this.trigger(`change:${fieldName}`, this);
-        this.trigger('change', this);
+        if (!(options?.silent ?? false)) {
+          this.trigger(`change:${fieldName}`, this);
+          this.trigger('change', this);
+        }
 
         /**
          * These are serialized and added to the JSON before being sent to the
@@ -556,8 +586,10 @@ export const ResourceBase = Backbone.Model.extend({
         const toOne = maybeMakeResource(value, relatedTable);
         if (field.isDependent()) this.storeDependent(field, toOne);
         else this.storeIndependent(field, toOne);
-        this.trigger(`change:${fieldName}`, this);
-        this.trigger('change', this);
+        if (!(options?.silent ?? false)) {
+          this.trigger(`change:${fieldName}`, this);
+          this.trigger('change', this);
+        }
         return toOne.url();
       } // The FK as a URI
       case 'zero-to-one': {
@@ -575,8 +607,10 @@ export const ResourceBase = Backbone.Model.extend({
 
         field.isDependent() && this.storeDependent(field, oneTo);
         // Because the FK is on the other side
-        this.trigger(`change:${fieldName}`, this);
-        this.trigger('change', this);
+        if (!(options?.silent ?? false)) {
+          this.trigger(`change:${fieldName}`, this);
+          this.trigger('change', this);
+        }
         return undefined;
       }
     }


### PR DESCRIPTION
See #6488

### The Issue

When rendering an independent `to-one` relationship (`CollectionObject -> accession`, `CollectionObject -> collectingEvent`  if shared, etc.) via Query Combo Box where the reverse relationship (`Accession -> collectionObjects`, `CollectingEvent -> collectionObjects`, etc.) was rendered as a Subview, opening the related record's form _after_ the first time would cause Specify to internally think the related record's version of the "main" record had changed. 
If the related record is saved, Specify _also_ modifies each of the `to-many` side of the relationship: which triggers their version and timestamp modified to be updated. The main form version of the record is not updated, which led to the (appropriate) out-of-date error. 

https://github.com/user-attachments/assets/b675f5ed-ca9c-445e-8126-62258a640ea4


https://github.com/user-attachments/assets/e2c8192e-0425-4707-ae00-9bfe4245a0a1


This PR addresses the first solution (provided below) mentioned in https://github.com/specify/specify7/issues/6488#issuecomment-2867865536

> Re-fetching a resource or collection of resources should not be triggering a change unless changes have actually been made to the models

### Checklist

- [x] Self-review the PR after opening it to make sure the changes look good and
      self-explanatory (or properly documented)
- [x] Add relevant issue to release milestone
- [ ] Add relevant documentation (Tester - Dev)
- [x] Add automated tests

### Testing instructions
- Find a Independent to-many relationship (such as `Accession -> collectionObjects`). For the to-one side of the relationship (e.g., `CollectionObject -> accession`), make sure it is on the form either as a QueryComboBox or as a button and that the other table's form (e.g., `Accession`) has the `to-many` relationship back to the base table as a Subview (Accession -> collectionObjects) 
  - Below is a table which contains all relationships which could cause this error to make identifying relationships easier
-  Locate or create a record of the to-one side which contains information on both sides of the relationship. For example, find a CollectionObject which is already associated with an Accession. 
- Open the related record (e.g., Accession) by using the Query Combo Box edit button or by clicking on the Subview Button (whichever the relationship is rendered as)
- Close the related record form
- Re-open the related record's form 
- [ ] Ensure that the save button (unload protect) is not enabled on either the related record or base record 
- Make an edit to the related record and save the related record 
- Save the base record
- Re-open the related record's form 
- Make another edit to the related record and save the related record
- [ ] Save the base record and ensure no out-of-date errors occur

<details><summary>All relationships for which the Issue can occur</summary>

_To use this table, make sure the `To-One Field` is rendered on the Base Table form as a Query Combo Box or (Subview) Button and the form of the `To-One Field` has the `Independent Back to Base` as a Subview_

| Base Table | To-One Field | Independent Back to Base |
|--------------|--------------|--------------|
| AccessionCitation | accession | accessionCitations |
| Appraisal | accession | appraisals |
| CollectionObject | accession | collectionObjects |
| TreatmentEvent | accession | treatmentEvents |
| Division | address | divisions |
| Institution | address | insitutions |
| Accession | addressOfRecord | accessions |
| Borrow | addressOfRecord | borrow |
| ExchangeIn | addressOfRecord | exchangeIns |
| ExchangeOut | addressOfRecord | exchangeOuts |
| Loan | addressOfRecord | loans |
| RepositoryAgreement | addressOfRecord | repositoryAgreements |
| CollectionObject | cataloger | catalogerOf |
| Collector | agent | collectors |
| GroupPerson | member | members |
| Agent | organization | orgMembers |
| CollectionObject | appraisal | collectionObjects |
| AccessionAttachment | attachment | accessionAttachments |
| AgentAttachment | attachment | agentAttachments |
| BorrowAttachment | attachment | borrowAttachments |
| CollectingEventAttachment | attachment | collectingEventAttachments |
| CollectingTripAttachment | attachment | collectingTripAttachments |
| CollectionObjectAttachment | attachment | collectionObjectAttachments |
| ConservDescriptionAttachment | attachment | conservDescriptionAttachments |
| ConservEventAttachment | attachment | conservEventAttachments |
| DeaccessionAttachment | attachment | deaccessionAttachments |
| DisposalAttachment | attachment | disposalAttachments |
| DNASequenceAttachment | attachment | dnaSequenceAttachments |
| DNASequencingRunAttachment | attachment | dnaSequencingRunAttachments |
| ExchangeInAttachment | attachment | exchangeInAttachments |
| ExchangeOutAttachment | attachment | exchangeOutAttachments |
| FieldNotebookAttachment | attachment | fieldNotebookAttachments |
| FieldNotebookPageAttachment | attachment | fieldNotebookPageAttachments |
| FieldNotebookPageSetAttachment | attachment | fieldNotebookPageSetAttachments |
| GiftAttachment | attachment | giftAttachments |
| LoanAttachment | attachment | loanAttachments |
| LocalityAttachment | attachment | localityAttachments |
| AttachmentMetadata | attachment | metadata |
| PermitAttachment | attachment | permitAttachments |
| PreparationAttachment | attachment | preparationAttachments |
| ReferenceWorkAttachment | attachment | referenceWorkAttachments |
| RepositoryAgreementAttachment | attachment | repositoryAgreementAttachments |
| SpDataSetAttachment | attachment | spDataSetAttachments |
| StorageAttachment | attachment | storageAttachments |
| AttachmentTag | attachment | tags |
| TaxonAttachment | attachment | taxonAttachments |
| TreatmentEventAttachment | attachment | treatmentEventAttachments |
| CollectingEventAttr | definition | collectingEventAttrs |
| CollectionObjectAttr | definition | collectionObjectAttrs |
| PreparationAttr | definition | preparationAttrs |
| CollectionObject | collectingEvent | collectionObjects |
| CollectingEvent | collectingEventAttribute | collectingEvents |
| CollectingEvent | collectingTrip | collectingEvents |
| CollectingTrip | collectingTripAttribute | collectingTrips |
| CollectionObject | collection | collectionObjects |
| Agent | collContentContact | contentContacts |
| CollectionRelType | leftSideCollection | leftSideRelTypes |
| PickList | collection | pickLists |
| PrepType | collection | prepTypes |
| CollectionRelType | rightSideCollection | rightSideRelTypes |
| Agent | collTechContact | technicalContacts |
| SpPrincipal | scope | userGroups |
| CollectionObject | collectionObjectAttribute | collectionObjects |
| Container | parent | children |
| CollectionObject | containerOwner | collectionObjectKids |
| CollectionObject | container | collectionObjects |
| DNASequencingRun | dnaPrimer | dnaSequencingRuns |
| Extractor | dnaSequence | extractors |
| PcrPerson | dnaSequence | pcrPersons |
| Disposal | deaccession | disposals |
| ExchangeOut | deaccession | exchangeOuts |
| Gift | deaccession | gifts |
| AttributeDef | discipline | attributeDefs |
| Collection | discipline | collections |
| SpExportSchema | discipline | spExportSchemas |
| SpLocaleContainer | discipline | spLocaleContainers |
| SpPrincipal | scope | userGroups |
| Accession | division | accessions |
| Discipline | division | disciplines |
| Agent | division | members |
| SpPrincipal | scope | userGroups |
| Shipment | exchangeOut | shipments |
| CollectionObject | fieldNotebookPage | collectionObjects |
| Geography | acceptedGeography | acceptedChildren |
| Geography | parent | children |
| Locality | geography | localities |
| Geography | definition | treeEntries |
| GeographyTreeDefItem | parent | children |
| Geography | definitionItem | treeEntries |
| GeologicTimePeriod | acceptedGeologicTimePeriod | acceptedChildren |
| PaleoContext | bioStrat | bioStratsPaleoContext |
| GeologicTimePeriod | parent | children |
| PaleoContext | chronosStrat | chronosStratsPaleoContext |
| GeologicTimePeriod | definition | treeEntries |
| GeologicTimePeriodTreeDefItem | parent | children |
| GeologicTimePeriod | definitionItem | treeEntries |
| RecordSet | infoRequest | recordSets |
| Agent | instContentContact | contentContacts |
| Division | institution | divisions |
| Agent | instTechContact | technicalContacts |
| SpPrincipal | scope | userGroups |
| Collection | institutionNetwork | collections |
| Agent | instTechContact | contacts |
| ReferenceWork | journal | referenceWorks |
| LithoStrat | acceptedLithoStrat | acceptedChildren |
| LithoStrat | parent | children |
| PaleoContext | lithoStrat | paleoContexts |
| LithoStrat | definition | treeEntries |
| LithoStratTreeDefItem | parent | children |
| LithoStrat | definitionItem | treeEntries |
| DisposalPreparation | loanReturnPreparation | disposalPreparations |
| CollectingEvent | locality | collectingEvents |
| AttachmentImageAttribute | morphBankView | attachmentImageAttributes |
| CollectingEvent | paleoContext | collectingEvents |
| CollectionObject | paleoContext | collectionObjects |
| Locality | paleoContext | localities |
| AccessionAuthorization | permit | accessionAuthorizations |
| CollectingEventAuthorization | permit | collectingEventAuthorizations |
| CollectingTripAuthorization | permit | collectingTripAuthorizations |
| Preparation | prepType | preparations |
| ConservDescription | preparation | conservDescriptions |
| DisposalPreparation | preparation | disposalPreparations |
| ExchangeInPrep | preparation | exchangeInPreps |
| ExchangeOutPrep | preparation | exchangeOutPreps |
| GiftPreparation | preparation | giftPreparations |
| LoanPreparation | preparation | loanPreparations |
| Preparation | preparationAttribute | preparations |
| RecordSetItem | recordSet | recordSetItems |
| CollectionObjectCitation | referenceWork | collectionObjectCitations |
| ReferenceWork | containedRFParent | containedReferenceWorks |
| DeterminationCitation | referenceWork | determinationCitations |
| Exsiccata | referenceWork | exsiccatae |
| LocalityCitation | referenceWork | localityCitations |
| TaxonCitation | referenceWork | taxonCitations |
| Accession | repositoryAgreement | accessions |
| SpAppResourceData | spAppResource | spAppResourceDatas |
| SpReport | appResource | spReports |
| SpAppResource | spAppResourceDir | spPersistedAppResources |
| SpViewSetObj | spAppResourceDir | spPersistedViewSets |
| SpAuditLogField | spAuditLog | fields |
| SpExportSchemaItem | spExportSchema | spExportSchemaItems |
| SpExportSchemaItemMapping | exportSchemaMapping | mappings |
| SpSymbiotaInstance | schemaMapping | symbiotaInstances |
| SpLocaleItemStr | containerDesc | descs |
| SpLocaleContainerItem | container | items |
| SpLocaleItemStr | containerName | names |
| SpLocaleItemStr | itemDesc | descs |
| SpLocaleItemStr | itemName | names |
| SpExportSchemaItem | spLocaleContainerItem | spExportSchemaItems |
| SpReport | query | reports |
| SpExportSchemaItemMapping | queryField | mappings |
| SpAppResourceData | spViewSetObj | spAppResourceDatas |
| LatLonPolygon | visualQuery | polygons |
| Agent | specifyUser | agents |
| SpAppResourceDir | specifyUser | spAppResourceDirs |
| SpAppResource | specifyUser | spAppResources |
| SpQuery | specifyUser | spQuerys |
| SpTaskSemaphore | owner | taskSemaphores |
| Workbench | specifyUser | workbenches |
| WorkbenchTemplate | specifyUser | workbenchTemplates |
| Storage | acceptedStorage | acceptedChildren |
| Storage | parent | children |
| Container | storage | containers |
| Preparation | storage | preparations |
| Storage | definition | treeEntries |
| StorageTreeDefItem | parent | children |
| Storage | definitionItem | treeEntries |
| Taxon | acceptedTaxon | acceptedChildren |
| Taxon | parent | children |
| CollectingEventAttribute | hostTaxon | collectingEventAttributes |
| Determination | taxon | determinations |
| Taxon | hybridParent1 | hybridChildren1 |
| Taxon | hybridParent2 | hybridChildren2 |
| Determination | preferredTaxon | preferredTaxonOf |
| Taxon | taxonAttribute | taxons |
| Taxon | definition | treeEntries |
| TaxonTreeDefItem | parent | children |
| Taxon | definitionItem | treeEntries |
| WorkbenchRow | workbench | workbenchRows |
| WorkbenchDataItem | workbenchRow | workbenchDataItems |
| WorkbenchRowExportedRelationship | workbenchRow | workbenchRowExportedRelationships |
| WorkbenchRowImage | workbenchRow | workbenchRowImages |
| Workbench | workbenchTemplate | workbenches |
| WorkbenchDataItem | workbenchTemplateMappingItem | workbenchDataItems |
| TectonicUnit | definition | treeEntries |
| TectonicUnitTreeDefItem | parent | children |
| TectonicUnit | definitionItem | treeEntries |
| TectonicUnit | acceptedTectonicUnit | acceptedChildren |
| PaleoContext | tectonicUnit | paleoContexts |

</details>