### PR TITLE
Change save() to update() in specify migrations

### DIFF
--- a/specifyweb/specify/migrations/0009_tectonic_ranks.py
+++ b/specifyweb/specify/migrations/0009_tectonic_ranks.py
@@ -52,8 +52,7 @@ def create_default_tectonic_ranks(apps):
             treedef=tectonic_tree_def,
         )
 
-        discipline.tectonicunittreedef = tectonic_tree_def
-        discipline.save()
+        Discipline.objects.filter(id=discipline.id).update(tectonicunittreedef=tectonic_tree_def)
 
 def revert_default_tectonic_ranks(apps, schema_editor):
     TectonicUnit = apps.get_model('specify', 'TectonicUnit')
@@ -72,8 +71,7 @@ def revert_default_tectonic_ranks(apps, schema_editor):
 
                 item.delete()
 
-            discipline.tectonicunittreedef = None
-            discipline.save()
+            Discipline.objects.filter(id=discipline.id).update(tectonicunittreedef=None)
             tectonic_tree_def.delete()
 
 def create_root_tectonic_node(apps): 

--- a/specifyweb/specify/migrations/0021_update_hidden_geo_tables.py
+++ b/specifyweb/specify/migrations/0021_update_hidden_geo_tables.py
@@ -27,10 +27,7 @@ def fix_hidden_geo_prop(apps, schema_editor):
                         container=container,
                         name=field_name.lower()
                     )
-
-                    for item in items:
-                        item.ishidden = True
-                        item.save()
+                    items.update(ishidden=True)
 
 def reverse_fix_hidden_geo_prop(apps, schema_editor):
     Splocalecontainer = apps.get_model('specify', 'Splocalecontainer')
@@ -53,10 +50,7 @@ def reverse_fix_hidden_geo_prop(apps, schema_editor):
                         container=container,
                         name=field_name.lower()
                     )
-
-                    for item in items:
-                        item.ishidden = False
-                        item.save()
+                    items.update(ishidden=True)
 
 class Migration(migrations.Migration):
     dependencies = [


### PR DESCRIPTION
Fixes #6511

I was able to recreate the issue on the PR https://github.com/specify/specify7/pull/6499 with the csicollections database.

The error `LookupError: No installed app with label 'businessrules'.` Is caused in the situation where the `businessrules.0006_storage_uniqueIdentifier` migration is already rolled back before `0021_update_hidden_geo_tables, your reverse_fix_hidden_geo_prop` is reverted.  When the signal `businessrules/orm_signal_handler.py` is triggered by the save command in the revert function, the signal handler doesn't exist.

This issue can be solved by changing `save()` to `update()`.

Another issue was this code
https://github.com/specify/specify7/blob/186e47052b6b89726d33efcb69e89b91ab00d28b/specifyweb/specify/migrations/0021_update_hidden_geo_tables.py#L24-L29

The `field_name, _, _ in fields` should just be `for field_name in fields:`, since it is looping on strings, not tuples `MIGRATION_0021_FIELDS = {'CollectionObject': ['relativeAges', 'absoluteAges', 'cojo']}`.  This is already in the main branch, but seemed to be caused by this commit https://github.com/specify/specify7/commit/186e47052b6b89726d33efcb69e89b91ab00d28b in this PR https://github.com/specify/specify7/pull/6499.  I'll add a revert commit to that PR.

### Checklist

- [x] Self-review the PR after opening it to make sure the changes look good and
      self-explanatory (or properly documented)
- [x] Add relevant issue to release milestone

### Testing instructions

- [x] run full migration `ve/bin/python manage.py migrate`, see that no errors appear
- [x] run near full revert migration `ve/bin/python manage.py migrate specify 0001`, see that no errors appear
- [x] re-run full migration `ve/bin/python manage.py migrate`, see that no errors appear
