### PR TITLE
Workbench/Batch Edit: Avoid overriding CollectionObject in to-one fields to prevent matching CollectionObjectAttribute/CollectingEvent

### DIFF
--- a/specifyweb/workbench/upload/scoping.py
+++ b/specifyweb/workbench/upload/scoping.py
@@ -315,7 +315,7 @@ def apply_scoping_to_uploadtable(
 
 
 def get_to_one_fields(collection) -> dict[str, list["str"]]:
-    return {
+    fields_collection = {
         "collectionobject": [
             *(["collectingevent"] if collection.isembeddedcollectingevent else []),
             "collectionobjectattribute",
@@ -324,12 +324,14 @@ def get_to_one_fields(collection) -> dict[str, list["str"]]:
         "attachment": ["attachmentimageattribute"],
         "collectingtrip": ["collectingtripattribute"],
         "preparation": ["preparationattribute"],
-        **(
-            {collection.discipline.paleocontextchildtable.lower(): ["paleocontext"]}
-            if collection.discipline.ispaleocontextembedded
-            else {}
-        ),
     }
+   
+    if collection.discipline.ispaleocontextembedded:
+        child = collection.discipline.paleocontextchildtable.lower()
+        # Done this way because child could be collectionobject and end up overriding the key in the dict above
+        fields_collection[child] = [*fields_collection.get(child, []), "paleocontext"]
+ 
+    return fields_collection
 
 
 def set_order_number(


### PR DESCRIPTION
Fixes #6519

COA gets matched in collections whose discipline has PaleoContextChildTable as collectionobject. 

This happens because when `collection.discipline.paleocontextchildtable.lower()` is `collectionobject`, it overrides the `collectionobject` key of the dictionary that is returned. This removes CollectionObjectAttribute from the CollectionObject key due to which COA is no longer considered a to-one relationship
https://github.com/specify/specify7/blob/61d6cc69d45743b5f3d2904e0428af76d437a0da/specifyweb/workbench/upload/scoping.py#L317-L332

This will also cause matching for CollectingEvent in case the collection has embedded collecting event and the paleo context child table is CO at the same time.


<!--
> [!WARNING]  
> This PR affects database migrations. See [migration testing instructions](https://specify.github.io/testing/pull_requests.html#prs-tagged-with-label-migration).
-->

### Checklist

- [x] Self-review the PR after opening it to make sure the changes look good and
      self-explanatory (or properly documented)
- [x] Add relevant issue to release milestone
- [x] Add relevant documentation (Tester - Dev)
- [ ] Add automated tests
- [ ] Add a reverse migration if a migration is present in the PR

### Testing instructions

<!-- What are the steps to verify the fixes/changes in this PR? -->
<!-- Can part of that be replaced by automated tests? -->
- Use a db with embedded paleo context whose PaleoContextChildTable is CollectionObject (See: https://docs.google.com/document/d/1O7GTCYVinv3gV5nuY5TtdyFB5PjElKOS/edit#heading=h.aq0uujqxzup7)
- Create a query with CO as Base Table and include CollectionObjectAttribute (COA) fields
- Enter the same data for COA in multiple rows
- Validate
- [ ] Verify COA does not get matched (i.e: no matched and changed cells)

- Create a WB Dataset with CO as base table and include COA fields
- Enter the same data for COA in multiple rows
- Validate
- [ ] Verify COA does not get matched (i.e: all COA rows are new cells)