### PR TITLE
Add a dialog to force saving the query before Batch Edit

### DIFF
--- a/specifyweb/frontend/js_src/lib/components/BatchEdit/index.tsx
+++ b/specifyweb/frontend/js_src/lib/components/BatchEdit/index.tsx
@@ -2,7 +2,10 @@ import React from 'react';
 import { useNavigate } from 'react-router-dom';
 import type { LocalizedString } from 'typesafe-i18n';
 
+import { useBooleanState } from '../../hooks/useBooleanState';
 import { batchEditText } from '../../localization/batchEdit';
+import { commonText } from '../../localization/common';
+import { queryText } from '../../localization/query';
 import { ajax } from '../../utils/ajax';
 import type { RA } from '../../utils/types';
 import { filterArray } from '../../utils/types';
@@ -15,6 +18,7 @@ import { schema } from '../DataModel/schema';
 import { serializeResource } from '../DataModel/serializers';
 import type { SpQuery, Tables } from '../DataModel/types';
 import { isTreeTable, treeRanksPromise } from '../InitialContext/treeRanks';
+import { Dialog } from '../Molecules/Dialog';
 import { userPreferences } from '../Preferences/userPreferences';
 import { QueryFieldSpec } from '../QueryBuilder/fieldSpec';
 import type { QueryField } from '../QueryBuilder/helpers';
@@ -26,10 +30,6 @@ import { MissingRanksDialog } from './MissingRanks';
 import { findAllMissing } from './missingRanksUtils';
 import type { QueryError } from './QueryError';
 import { ErrorsDialog } from './QueryError';
-import { useBooleanState } from '../../hooks/useBooleanState';
-import { Dialog } from '../Molecules/Dialog';
-import { commonText } from '../../localization/common';
-import { queryText } from '../../localization/query';
 
 const queryFieldSpecHeader = (queryFieldSpec: QueryFieldSpec) =>
   generateMappingPathPreview(
@@ -134,8 +134,7 @@ export function BatchEditFromQuery({
     queryFieldSpecs.some(hasHierarchyBaseTable) ||
     containsDisallowedTables(query);
 
-  const handleClickBatchEdit = () => {
-    return loading(
+  const handleClickBatchEdit = () => loading(
       treeRanksPromise.then(async () => {
         const invalidFields = queryFieldSpecs.filter((fieldSpec) =>
           filters.some((filter) => filter(fieldSpec))
@@ -166,7 +165,6 @@ export function BatchEditFromQuery({
         return handleCreateDataset(newName);
       })
     );
-  };
 
   return (
     <>
@@ -194,11 +192,9 @@ export function BatchEditFromQuery({
       {hasUnsavedQuery && (
         <Dialog
           buttons={
-            <>
-              <Button.Danger onClick={closeWarningDialog}>
+            <Button.Danger onClick={closeWarningDialog}>
                 {commonText.close()}
               </Button.Danger>
-            </>
           }
           header={queryText.unsavedChangesInQuery()}
           onClose={closeWarningDialog}

--- a/specifyweb/frontend/js_src/lib/localization/query.ts
+++ b/specifyweb/frontend/js_src/lib/localization/query.ts
@@ -922,4 +922,10 @@ export const queryText = createDictionary({
     `,
     'en-us': 'Format As: {commaSeparatedFormats:string}',
   },
+  unsavedChangesInQuery: {
+    'en-us': 'Query has unsaved changes',
+  },
+  unsavedChangesInQueryDescription: {
+    'en-us': 'Please save the query before running Batch Edit',
+  },
 } as const);


### PR DESCRIPTION
Fixes #6516

- Adds a dialog to force users to save the query before running Batch Edit
- The previous behavior was the standard unload protect used in Specify which is triggered when the application tries to navigate elsewhere while having unsaved changes
- However, unload protect behavior cannot be changed without causing side effects everywhere and so this is a workaround to force users to save their query

<!--
> [!WARNING]  
> This PR affects database migrations. See [migration testing instructions](https://specify.github.io/testing/pull_requests.html#prs-tagged-with-label-migration).
-->

### Checklist

- [x] Self-review the PR after opening it to make sure the changes look good and
      self-explanatory (or properly documented)
- [x] Add relevant issue to release milestone
- [x] Add relevant documentation (Tester - Dev)
- [ ] Add automated tests
- [ ] Add a reverse migration if a migration is present in the PR

### Testing instructions

<!-- What are the steps to verify the fixes/changes in this PR? -->
<!-- Can part of that be replaced by automated tests? -->
- Create a query but do not save it
- Run Batch Edit
- [ ] Verify there is a dialog forcing users to save their query when the query has unsaved changes