### PR TITLE
Properly encode special characters for depository URLs

### DIFF
--- a/specifyweb/frontend/js_src/lib/components/Notifications/NotificationRenderers.tsx
+++ b/specifyweb/frontend/js_src/lib/components/Notifications/NotificationRenderers.tsx
@@ -42,7 +42,7 @@ export const notificationRenderers: IR<
           <Link.Success
             className="w-fit normal-case"
             download
-            href={`/static/depository/export_feed/${filename}`}
+            href={`/static/depository/export_feed/${encodeURIComponent(filename)}`}
           >
             {filename}
           </Link.Success>
@@ -71,7 +71,7 @@ export const notificationRenderers: IR<
         <Link.Success
           className="w-fit"
           download
-          href={`/static/depository/${notification.payload.file}`}
+          href={`/static/depository/${encodeURIComponent(filename)}`}
         >
           {notificationsText.download()}
         </Link.Success>
@@ -93,13 +93,17 @@ export const notificationRenderers: IR<
     );
   },
   'query-export-to-csv-complete'(notification) {
+    const filename = notification.payload.file;
+    const displayName = filename.replace(/\.csv$/, '');
     return (
       <>
         {notificationsText.queryExportToCsvCompleted()}
+        <br />
+        <em>{displayName}</em>
         <Link.Success
           className="w-fit"
           download
-          href={`/static/depository/${notification.payload.file}`}
+          href={`/static/depository/${encodeURIComponent(filename)}`}
         >
           {notificationsText.download()}
         </Link.Success>
@@ -107,13 +111,17 @@ export const notificationRenderers: IR<
     );
   },
   'query-export-to-kml-complete'(notification) {
+    const filename = notification.payload.file;
+    const displayName = filename.replace(/\.csv$/, '');
     return (
       <>
         {notificationsText.queryExportToKmlCompleted()}
+        <br />
+        <em>{displayName}</em>
         <Link.Success
           className="w-fit"
           download
-          href={`/static/depository/${notification.payload.file}`}
+          href={`/static/depository/${encodeURIComponent(filename)}`}
         >
           {notificationsText.download()}
         </Link.Success>


### PR DESCRIPTION
Fixes #6537

Solves the issue with special characters in query names:
```
console.log(`?x=${encodeURIComponent("test?")}`);
// Expected output: "?x=test%3F"
```

This _also_ adds the export name to the notifications dialog:

<img width="512" alt="image" src="https://github.com/user-attachments/assets/3c1c50aa-13ab-4094-9ed6-9e7c44fb8ebd" />


### Checklist

- [X] Self-review the PR after opening it to make sure the changes look good and
      self-explanatory (or properly documented)
- [X] Add relevant issue to release milestone
- [X] Add relevant documentation (Tester - Dev)

### Testing instructions

<!-- What are the steps to verify the fixes/changes in this PR? -->
<!-- Can part of that be replaced by automated tests? -->

Test this against `v7.10.2.3` and verify both that it works in this PR and not in production when dealing with special characters in query names.

- [ ] Create a query with special characters in the name (e.g. `?`, `{`, `[`, `@`, or others in the list below)
	```
	        ' ' => '%20',    '!' => '%21',    '"' => '%22',
	        '#' => '%23',    '$' => '%24',    '%' => '%25',
	        '&' => '%26',    '\'' => '%27',   '(' => '%28',
	        ')' => '%29',    '*' => '%2A',    '+' => '%2B',
	        ',' => '%2C',    '-' => '%2D',    '.' => '%2E',
	        '/' => '%2F',    ':' => '%3A',    ';' => '%3B',
	        '<' => '%3C',    '=' => '%3D',    '>' => '%3E',
	        '?' => '%3F',    '@' => '%40',    '[' => '%5B',
	        '\\' => '%5C',   ']' => '%5D',    '^' => '%5E',
	        '_' => '%5F',    '`' => '%60',    '{' => '%7B',
	        '|' => '%7C',    '}' => '%7D',    '~' => '%7E',
	```
- [ ] Export the query to CSV
- [ ] Verify that the exported query can be downloaded from the notifications dialog
- [ ] Verify that opening the download link in a new tab downloads the file
