### PR TITLE
Update ParetnCOID to ComponentParentID in Component QB

### DIFF
--- a/specifyweb/stored_queries/format.py
+++ b/specifyweb/stored_queries/format.py
@@ -303,7 +303,7 @@ class ObjectFormatter:
                 # Child = aliased(orm_table)
                 subquery_query = Query([]) \
                     .select_from(aliased_orm_table) \
-                    .filter(aliased_orm_table.ParentCOID == getattr(rel_table, rel_table._id)) \
+                    .filter(aliased_orm_table.ComponentParentID == getattr(rel_table, rel_table._id)) \
                     .correlate(rel_table)
             elif field.is_relationship and \
                 field.type == 'one-to-many' and \


### PR DESCRIPTION
Fixes #6551

Fix the error "AttributeError: ParentCOID" is thrown during the components aggregated query

### Checklist

- [ ] Self-review the PR after opening it to make sure the changes look good and
      self-explanatory (or properly documented)
- [ ] Add relevant issue to release milestone

### Testing instructions

TBD
