### PR TITLE
Set fullname in TectonUnit Root Initialization migration

### DIFF
--- a/specifyweb/specify/migrations/0009_tectonic_ranks.py
+++ b/specifyweb/specify/migrations/0009_tectonic_ranks.py
@@ -94,6 +94,7 @@ def create_root_tectonic_node(apps):
 
         root, _ = TectonicUnit.objects.get_or_create(
             name="Root",
+            fullname="Root",
             isaccepted=1,
             nodenumber=1,
             rankid=0,


### PR DESCRIPTION
Fixes #6553

Fix searching for and adding child nodes to the Root Tectonic Unit by setting it's fullname to "Root".

### Checklist

- [ ] Self-review the PR after opening it to make sure the changes look good and
      self-explanatory (or properly documented)
- [ ] Add relevant issue to release milestone


### Testing instructions

1. Go to the tectonic unit tree.
2. Select the "Root" Node, and press the "Add Child" Button.
3. See that the name for the parent is "Root".
4. Search for the "Root" node in the parent search, see that Root appears.
5. Create the child node, and click on the "eye" icon next to the parent node, and see that the root node gets selected.
