### PR TITLE
Avoid dockerhub push issues my limiting concurrency

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -22,6 +22,7 @@ jobs:
         platform:
           - linux/amd64
           - linux/arm64
+      max-parallel: 1
     steps:
       - name: Prepare
         id: prep
@@ -87,7 +88,8 @@ jobs:
             GIT_SHA=${{ github.sha }}
           tags: ${{ steps.prep.outputs.tags }}
           push: true
-          retries: 3
+          retries: 6
+          provenance: false
 
       - name: Export digest
         run: |


### PR DESCRIPTION
Fixes #6567

This didn't involve the Dockerfile at all, and is just an issue with the GitHub workflow action for the docker build.  We can avoid DockerHub push issues my limiting concurrency.  By having the arm64 and amd64 builds running in series, rather than in parallel, we can avoid any race condition issues of concurrent pushes to DockerHub.

### Checklist

- [x] Self-review the PR after opening it to make sure the changes look good and
      self-explanatory (or properly documented)
- [x] Add relevant issue to release milestone

### Testing instructions

Dev Testing:
- [x] Re-run the GitHub action workflow for the docker build and push for arm64, like here https://github.com/specify/specify7/actions/runs/15426384439/job/43414227635
