### PR TITLE
Patch migration to match selectseries field to smushed field

### DIFF
--- a/specifyweb/patches/migrations/0004_match_selectseries_to_smushed.py
+++ b/specifyweb/patches/migrations/0004_match_selectseries_to_smushed.py
@@ -1,0 +1,18 @@
+from django.db import migrations
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('patches', '0003_coordinate_fields_fix'),
+    ]
+
+    operations = [
+        migrations.RunSQL(
+            """
+            UPDATE spquery
+            SET SelectSeries = 1
+            WHERE Smushed = 1;
+            """,
+            reverse_sql=''
+        )
+    ]


### PR DESCRIPTION
Fixes #6575

Create a new migration that updates the SelectSeries field and sets it to 1 where Smushed = 1, which will handle existing queries but not new ones.

### Checklist

- [ ] Self-review the PR after opening it to make sure the changes look good and
      self-explanatory (or properly documented)
- [ ] Add relevant issue to release milestone
- [ ] Add relevant documentation (Tester - Dev)
- [ ] Add automated tests
- [ ] Add a reverse migration if a migration is present in the PR

### Testing instructions

TBD
