### PR TITLE
Refine initialization for collections of dependent resources

### DIFF
--- a/specifyweb/frontend/js_src/lib/components/DataModel/__tests__/businessRules.test.ts
+++ b/specifyweb/frontend/js_src/lib/components/DataModel/__tests__/businessRules.test.ts
@@ -458,7 +458,7 @@ describe('Collecting Event', () => {
     );
     expect(collectorToRemove).toBeDefined();
     collectors?.remove(collectorToRemove!);
-    expect(collectors?.length).toBe(1);
+    expect(collectors?.length).toBe(2);
     const firstCollector = collectors?.models.find(
       (collector) => collector.get('agent') === getResourceApiUrl('Agent', 1)
     );

--- a/specifyweb/frontend/js_src/lib/components/DataModel/__tests__/businessRules.test.ts
+++ b/specifyweb/frontend/js_src/lib/components/DataModel/__tests__/businessRules.test.ts
@@ -204,7 +204,42 @@ describe('Collection Object business rules', () => {
     await collectionObject.businessRuleManager?.pendingPromise;
   });
 
-  test('CollectionObject -> determinations: New determinations are current by default', async () => {
+  test('CollectionObject -> determinations: determinations on initializtion is current by default', () => {
+    // We don't directly use the base because the determination is marked as current by default
+    const collectionObject = new tables.CollectionObject.Resource({
+      determinations: [
+        {
+          // We don't directly use IDs because then the determinations will not be 'new' and the
+          // businessrule not executed
+          guid: '1',
+        },
+      ],
+    });
+    const determinations =
+      collectionObject.getDependentResource('determinations');
+    expect(determinations?.length).toBe(1);
+    expect(determinations?.models[0].get('isCurrent')).toBe(true);
+  });
+
+  test('CollectionObject -> determinations: multiple determinations on intialization handled', () => {
+    const collectionObject = new tables.CollectionObject.Resource({
+      determinations: [
+        {
+          guid: '1',
+        },
+        {
+          guid: '2',
+        },
+      ],
+    });
+    const determinations =
+      collectionObject.getDependentResource('determinations');
+    expect(determinations?.length).toBe(2);
+    expect(determinations?.models[0]?.get('isCurrent')).toBe(false);
+    expect(determinations?.models[1]?.get('isCurrent')).toBe(true);
+  });
+
+  test('CollectionObject -> determinations: Newly added determinations are current by default', async () => {
     const collectionObject = getBaseCollectionObject();
     const determinations =
       collectionObject.getDependentResource('determinations');

--- a/specifyweb/frontend/js_src/lib/components/DataModel/__tests__/businessRules.test.ts
+++ b/specifyweb/frontend/js_src/lib/components/DataModel/__tests__/businessRules.test.ts
@@ -3,11 +3,12 @@ import { act, renderHook } from '@testing-library/react';
 import { resourcesText } from '../../../localization/resources';
 import { overrideAjax } from '../../../tests/ajax';
 import { mockTime, requireContext } from '../../../tests/helpers';
-import { overwriteReadOnly, RA } from '../../../utils/types';
+import type { RA } from '../../../utils/types';
+import { overwriteReadOnly } from '../../../utils/types';
 import { getPref } from '../../InitialContext/remotePrefs';
 import { cogTypes } from '../helpers';
 import type { SerializedResource } from '../helperTypes';
-import { SpecifyResource } from '../legacyTypes';
+import type { SpecifyResource } from '../legacyTypes';
 import { getResourceApiUrl } from '../resource';
 import { useSaveBlockers } from '../saveBlockers';
 import { schema } from '../schema';
@@ -215,8 +216,10 @@ describe('Collection Object business rules', () => {
     const collectionObject = new tables.CollectionObject.Resource({
       determinations: [
         {
-          // We don't directly use IDs because then the determinations will not be 'new' and the
-          // businessrule not executed
+          /*
+           * We don't directly use IDs because then the determinations will not be 'new' and the
+           * businessrule not executed
+           */
           guid: '1',
         },
       ],

--- a/specifyweb/frontend/js_src/lib/components/DataModel/__tests__/resourceApi.test.ts
+++ b/specifyweb/frontend/js_src/lib/components/DataModel/__tests__/resourceApi.test.ts
@@ -42,6 +42,7 @@ const determinationsResponse: RA<Partial<SerializedRecord<Determination>>> = [
     resource_uri: determinationUrl,
     id: 123,
     number1: null,
+    iscurrent: true,
   },
 ];
 
@@ -423,6 +424,22 @@ test('save', async () => {
   const newDetermination =
     resource.getDependentResource('determinations')!.models[0];
   expect(newDetermination.get('number1')).toBe(2);
+});
+
+describe('resource initialization', () => {
+  test('Initialization with dependent resources does not trigger saveRequired', () => {
+    const resource = new tables.CollectionObject.Resource({
+      determinations: [
+        {
+          id: 1,
+        },
+        {
+          id: 2,
+        },
+      ],
+    });
+    expect(resource.needsSaved).toBe(false);
+  });
 });
 
 describe('set', () => {

--- a/specifyweb/frontend/js_src/lib/components/DataModel/businessRuleDefs.ts
+++ b/specifyweb/frontend/js_src/lib/components/DataModel/businessRuleDefs.ts
@@ -406,6 +406,23 @@ export const businessRuleDefs: MappedBusinessRuleDefs = {
   },
 
   Determination: {
+    customInit: (determinaton: SpecifyResource<Determination>): void => {
+      if (determinaton.isNew()) {
+        const setCurrent = () => {
+          determinaton.set('isCurrent', true);
+          if (determinaton.collection !== undefined) {
+            determinaton.collection.models.forEach(
+              (other: SpecifyResource<Determination>) => {
+                if (other.cid !== determinaton.cid)
+                  other.set('isCurrent', false);
+              }
+            );
+          }
+        };
+        if (determinaton.collection !== null) setCurrent();
+        determinaton.on('add', setCurrent);
+      }
+    },
     fieldChecks: {
       taxon: async (
         determination: SpecifyResource<Determination>

--- a/specifyweb/frontend/js_src/lib/components/DataModel/businessRuleDefs.ts
+++ b/specifyweb/frontend/js_src/lib/components/DataModel/businessRuleDefs.ts
@@ -407,10 +407,21 @@ export const businessRuleDefs: MappedBusinessRuleDefs = {
 
   Determination: {
     customInit: (determinaton: SpecifyResource<Determination>): void => {
+      /**
+       * Theoretically if the user could add an existing Determination to a
+       * (Backbone) Collection in the UI we still want to set it as current in
+       * the Collection and uncheck any existing current, though we would also
+       * want to make sure the existing Collection the Determination is leaving
+       * contains a current Determination and prevent the operation
+       * (via saveblocker?) if so.
+       */
       if (determinaton.isNew()) {
         const setCurrent = () => {
           determinaton.set('isCurrent', true);
-          if (determinaton.collection !== undefined) {
+          if (
+            determinaton.collection !== undefined &&
+            determinaton.collection !== null
+          ) {
             determinaton.collection.models.forEach(
               (other: SpecifyResource<Determination>) => {
                 if (other.cid !== determinaton.cid)
@@ -419,7 +430,17 @@ export const businessRuleDefs: MappedBusinessRuleDefs = {
             );
           }
         };
-        if (determinaton.collection !== null) setCurrent();
+        if (
+          determinaton.collection !== null &&
+          determinaton.collection !== undefined
+        ) {
+          determinaton.collection.models.at(-1)?.set('isCurrent', true);
+          determinaton.collection.models
+            .slice(0, -1)
+            .forEach((determination) => {
+              determination.set('isCurrent', false);
+            });
+        }
         determinaton.on('add', setCurrent);
       }
     },

--- a/specifyweb/frontend/js_src/lib/components/DataModel/collectionApi.ts
+++ b/specifyweb/frontend/js_src/lib/components/DataModel/collectionApi.ts
@@ -91,7 +91,11 @@ export const DependentCollection = Base.extend({
         ),
         { table: this.table.name, records }
       );
-    Base.call(this, records, options);
+    Base.call(this, null, options);
+    // If models are passed during collection initializtion, manually add them
+    // to the collection after initialization.
+    // This ensures proper onAdd functionality is triggered on initialization
+    records.forEach((record) => this.add(record));
   },
   initialize(_tables, options) {
     setupToOne(this, options);

--- a/specifyweb/frontend/js_src/lib/components/PickLists/__tests__/fetch.test.ts
+++ b/specifyweb/frontend/js_src/lib/components/PickLists/__tests__/fetch.test.ts
@@ -96,7 +96,7 @@ describe('unsafeFetchPickList', () => {
 describe('fetchPickListItems', () => {
   test('pick list from items', async () => {
     const pickListItems = [
-      addMissingFields('PickListItem', { title: 'a', value: 'b' }),
+      addMissingFields('PickListItem', { title: 'a', value: 'b', ordinal: 0 }),
     ];
     const pickList = deserializeResource(
       addMissingFields('PickList', {


### PR DESCRIPTION
Fixes #6578
The Issue was ultimately caused in f8c02e5 when the `customInit` behavior for `Determination -> isPrimary` was removed. 
That code was responsible for making sure any new Determination on a CollectionObject would be marked as primary, and uncheck other Determinations as primary. 

I assume that the customInit was removed in the first place under the assumption that the `onAdd` business rule logic would cover the removed customInit logic. However, `customInit` and `onAdd` were two distinct operations regarding Collections of dependent resources. A CollectionObject could be initialized with any number of Determinations and since the Determinations were never actually "added" to the Collection, the isPrimary business rule was never being run. 

@specify/dev-testing 
I have modified the frontend Collection API such that if a dependent collection is initialized with resources, it makes sure to first create the empty collection and then explicitly add the resources to the collection (triggering any onAdd events). 
Essentially, in terms of frontend business rules all `customInit` behavior specific for dependent collections can be moved/merged to `onAdd` : which is hopefully more intuitive. What do you all think? 

The case was not caught by our automated tests because we were using a single "base" Collection Object in our Collection Object business rule tests which was being [initialized with a current Determination](https://github.com/specify/specify7/blob/7566d40097a9ba1dd7faad9178e82894807cfb30/specifyweb/frontend/js_src/lib/components/DataModel/__tests__/businessRules.test.ts#L89). In other words, we were testing the onAdd and onRemove functionality, but not the initialization functionality. 

I would like to go through the rest of the similar business rules to modify/simplify them and write automated tests. 


### Checklist

- [ ] Self-review the PR after opening it to make sure the changes look good and
      self-explanatory (or properly documented)
- [ ] Add relevant issue to release milestone
- [ ] Add relevant documentation (Tester - Dev)
- [x] Add automated tests

### Testing instructions

<!-- What are the steps to verify the fixes/changes in this PR? -->
<!-- Can part of that be replaced by automated tests? -->
