### PR TITLE
Update logic in base_specify_migration command

### DIFF
--- a/specifyweb/specify/management/commands/base_specify_migration.py
+++ b/specifyweb/specify/management/commands/base_specify_migration.py
@@ -35,14 +35,18 @@ class Command(BaseCommand):
                     );
                 """)
 
-            # Check if the record exists and insert it if it doesn't
+            # Check if the record in the django_migrations table exists with app 'specify' and name '0001_initial'
             cursor.execute("""
-                INSERT INTO django_migrations (app, name, applied)
-                SELECT 'specify', '0001_initial', NOW()
-                FROM dual
-                WHERE NOT EXISTS (
-                    SELECT 1
-                    FROM django_migrations
-                    WHERE app = 'specify' AND name = '0001_initial'
-                );
+                SELECT 1
+                FROM django_migrations
+                WHERE app = 'specify' AND name = '0001_initial'
+                LIMIT 1;
             """)
+            record_exists = cursor.fetchone() is not None
+
+            if not record_exists:
+                # Insert the initial migration record for the specify app
+                cursor.execute("""
+                    INSERT INTO django_migrations (app, name, applied)
+                    VALUES ('specify', '0001_initial', NOW());
+                """)


### PR DESCRIPTION
Fixes #6539

It seems that some databases have got into a state that can cause InconsistentMigrationHistory Django error.

For example, the KU Fish database Django migration state:
```
specify
 [ ] 0001_initial
...
workbench
 [X] 0001_initial
 [X] 0002_spdataset_visualorder
 [X] 0003_auto_20210218_1256
 [X] 0004_auto_20210219_1131
 [X] 0005_auto_20210428_1634
```

In this case, the workbench initial migration has already been made, while the specify initial migration has not.  In the initial workbench migration file, the initial specify migration is listed as a dependency.  This dependency matched with this migration state is what is causing the error.

Not sure how exactly this state was reached.  The two solutions would be for the dependency to be removed from the migration file, or to run some Django migrations commands to fix the state of the database before continuing with the migrations.

When Specify starts up, the `base_specify_migration` command runs before the migrations, so it should ensure that the initial Specify app migration is marked as completed.

Even with all the dependencies removed from all the migration files, the migration will still fail (see https://github.com/specify/specify7/compare/main...issue-6539). We should never run the Specify 0001 migration, it should always be faked.

The solution is just to fake the specify initial migration, so no code change required.  I think this is probably the better solution for fixing databases that get into this situation.  This is something that shouldn't happen to users doing sequential upgrades, and not doing manual merge migration commands.
```bash
docker exec -it specify7-specify7-1 ve/bin/python manage.py migrate specify 0001 --fake;
docker exec -it specify7-specify7-1 ve/bin/python manage.py migrate;
```

In this PR I edited the base_specify_migration logic, to make it more clear as to when the inital specify migration should be faked.

### Checklist

- [x] Self-review the PR after opening it to make sure the changes look good and
      self-explanatory (or properly documented)
- [x] Add relevant issue to release milestone

### Testing instructions

- [x] Using this DB https://drive.google.com/open?id=1KAmlEPnE3uXowe66zUkMoe1PnTCNAnJc&usp=drive_fs, startup the instance, see that the startup migrations run successfully.
