### PR TITLE
Change smushed field name to selectseries in v11 pre-release

### DIFF
--- a/config/specify_datamodel.xml
+++ b/config/specify_datamodel.xml
@@ -4169,6 +4169,7 @@
       <field column="Remarks" name="remarks" type="text" length="4096" updatable="true" required="false" unique="false" indexed="false" partialDate="false"/>
       <field column="SearchSynonymy" name="searchSynonymy" type="java.lang.Boolean" updatable="true" required="false" unique="false" indexed="false" partialDate="false"/>
       <field column="SelectDistinct" name="selectDistinct" type="java.lang.Boolean" updatable="true" required="false" unique="false" indexed="false" partialDate="false"/>
+      <field column="SelectSeries" name="SelectSeries" type="java.lang.Boolean" updatable="true" required="false" unique="false" indexed="false" partialDate="false"/>
       <field column="Smushed" name="smushed" type="java.lang.Boolean" updatable="true" required="false" unique="false" indexed="false" partialDate="false"/>
       <field column="SqlStr" name="sqlStr" type="text" length="4096" updatable="true" required="false" unique="false" indexed="false" partialDate="false"/>
       <field column="TimestampCreated" name="timestampCreated" type="java.sql.Timestamp" updatable="false" required="true" unique="false" indexed="false" partialDate="false"/>

--- a/specifyweb/frontend/js_src/lib/components/DataModel/__tests__/helpers.test.ts
+++ b/specifyweb/frontend/js_src/lib/components/DataModel/__tests__/helpers.test.ts
@@ -123,6 +123,7 @@ describe('serializeResource', () => {
       remarks: null,
       searchSynonymy: null,
       selectDistinct: null,
+      selectSeries: null,
       smushed: null,
       specifyUser: null,
       sqlStr: null,

--- a/specifyweb/frontend/js_src/lib/components/DataModel/__tests__/helpers.test.ts
+++ b/specifyweb/frontend/js_src/lib/components/DataModel/__tests__/helpers.test.ts
@@ -124,7 +124,6 @@ describe('serializeResource', () => {
       searchSynonymy: null,
       selectDistinct: null,
       selectSeries: null,
-      smushed: null,
       specifyUser: null,
       sqlStr: null,
       timestampCreated: '2022-08-31',

--- a/specifyweb/frontend/js_src/lib/components/DataModel/types.ts
+++ b/specifyweb/frontend/js_src/lib/components/DataModel/types.ts
@@ -5299,6 +5299,7 @@ export type SpQuery = {
     readonly remarks: string | null;
     readonly searchSynonymy: boolean | null;
     readonly selectDistinct: boolean | null;
+    readonly selectSeries: boolean | null;
     readonly smushed: boolean | null;
     readonly sqlStr: string | null;
     readonly timestampCreated: string;

--- a/specifyweb/frontend/js_src/lib/components/DataModel/types.ts
+++ b/specifyweb/frontend/js_src/lib/components/DataModel/types.ts
@@ -5300,7 +5300,6 @@ export type SpQuery = {
     readonly searchSynonymy: boolean | null;
     readonly selectDistinct: boolean | null;
     readonly selectSeries: boolean | null;
-    readonly smushed: boolean | null;
     readonly sqlStr: string | null;
     readonly timestampCreated: string;
     readonly timestampModified: string | null;

--- a/specifyweb/frontend/js_src/lib/components/Forms/__tests__/DeleteButton.test.tsx
+++ b/specifyweb/frontend/js_src/lib/components/Forms/__tests__/DeleteButton.test.tsx
@@ -105,6 +105,7 @@ overrideAjax(
       resource_uri: undefined,
       searchsynonymy: null,
       selectdistinct: false,
+      selectseries: false,
       smushed: null,
       specifyuser: '/api/specify/specifyuser/2/',
       sqlstr: null,

--- a/specifyweb/frontend/js_src/lib/components/Forms/__tests__/DeleteButton.test.tsx
+++ b/specifyweb/frontend/js_src/lib/components/Forms/__tests__/DeleteButton.test.tsx
@@ -106,7 +106,6 @@ overrideAjax(
       searchsynonymy: null,
       selectdistinct: false,
       selectseries: false,
-      smushed: null,
       specifyuser: '/api/specify/specifyuser/2/',
       sqlstr: null,
       timestampcreated: '2022-08-31',

--- a/specifyweb/frontend/js_src/lib/components/QueryBuilder/Wrapped.tsx
+++ b/specifyweb/frontend/js_src/lib/components/QueryBuilder/Wrapped.tsx
@@ -161,9 +161,9 @@ function Wrapped({
     handleChange?.({
       fields: unParseQueryFields(state.baseTableName, state.fields),
       isDistinct: query.selectDistinct,
-      isSeries: query.smushed,
+      isSeries: query.selectSeries,
     });
-  }, [state, query.selectDistinct, query.smushed]);
+  }, [state, query.selectDistinct, query.selectSeries]);
 
   /**
    * If tried to save a query, enforce the field length limit for the
@@ -314,7 +314,7 @@ function Wrapped({
     if (!showSeries)
       setQuery({
         ...query,
-        smushed: false,
+        selectSeries: false,
       });
   }, [showSeries]);
 
@@ -578,7 +578,7 @@ function Wrapped({
               />
               <QueryToolbar
                 isDistinct={query.selectDistinct ?? false}
-                isSeries={query.smushed ?? false}
+                isSeries={query.selectSeries ?? false}
                 showHiddenFields={showHiddenFields}
                 showSeries={showSeries}
                 tableName={table.name}
@@ -598,7 +598,7 @@ function Wrapped({
                 onToggleSeries={(): void =>
                   setQuery({
                     ...query,
-                    smushed: !(query.smushed ?? false),
+                    selectSeries: !(query.selectSeries ?? false),
                   })
                 }
               />

--- a/specifyweb/frontend/js_src/lib/components/QueryBuilder/__tests__/__snapshots__/fromTree.test.ts.snap
+++ b/specifyweb/frontend/js_src/lib/components/QueryBuilder/__tests__/__snapshots__/fromTree.test.ts.snap
@@ -86,7 +86,7 @@ exports[`queryFromTree 1`] = `
     "name": "Collection Object using \\"Los Angeles County\\"",
     "ordinal": 32767,
     "selectdistinct": false,
-    "smushed": false,
+    "selectseries": false,
     "specifyuser": "/api/specify/specifyuser/2/",
   },
   {
@@ -161,7 +161,7 @@ exports[`queryFromTree 1`] = `
     "name": "Collection Object using \\"Cabinet 1\\"",
     "ordinal": 32767,
     "selectdistinct": false,
-    "smushed": false,
+    "selectseries": false,
     "specifyuser": "/api/specify/specifyuser/2/",
   },
   {
@@ -236,7 +236,7 @@ exports[`queryFromTree 1`] = `
     "name": "Collection Object using \\"Carpiodes velifer\\"",
     "ordinal": 32767,
     "selectdistinct": false,
-    "smushed": false,
+    "selectseries": false,
     "specifyuser": "/api/specify/specifyuser/2/",
   },
   {
@@ -311,7 +311,7 @@ exports[`queryFromTree 1`] = `
     "name": "Collection Object using \\"Paleocene\\"",
     "ordinal": 32767,
     "selectdistinct": false,
-    "smushed": false,
+    "selectseries": false,
     "specifyuser": "/api/specify/specifyuser/2/",
   },
   {
@@ -386,7 +386,7 @@ exports[`queryFromTree 1`] = `
     "name": "Collection Object using \\"Cretaceous\\"",
     "ordinal": 32767,
     "selectdistinct": false,
-    "smushed": false,
+    "selectseries": false,
     "specifyuser": "/api/specify/specifyuser/2/",
   },
   {
@@ -461,7 +461,7 @@ exports[`queryFromTree 1`] = `
     "name": "Collection Object using \\"Plate\\"",
     "ordinal": 32767,
     "selectdistinct": false,
-    "smushed": false,
+    "selectseries": false,
     "specifyuser": "/api/specify/specifyuser/2/",
   },
 ]

--- a/specifyweb/frontend/js_src/lib/components/QueryBuilder/index.tsx
+++ b/specifyweb/frontend/js_src/lib/components/QueryBuilder/index.tsx
@@ -97,7 +97,7 @@ export function createQuery(
   query.set('contextName', table.name);
   query.set('contextTableId', table.tableId);
   query.set('selectDistinct', false);
-  query.set('smushed', false);
+  query.set('selectSeries', false);
   query.set('countOnly', false);
   query.set('formatAuditRecIds', false);
   query.set('specifyUser', userInformation.resource_uri);

--- a/specifyweb/frontend/js_src/lib/components/QueryComboBox/helpers.ts
+++ b/specifyweb/frontend/js_src/lib/components/QueryComboBox/helpers.ts
@@ -35,7 +35,7 @@ export function makeComboBoxQuery({
   query.set('contextName', table.name);
   query.set('contextTableId', table.tableId);
   query.set('selectDistinct', false);
-  query.set('smushed', false);
+  query.set('selectSeries', false);
   query.set('countOnly', false);
   query.set('specifyUser', userInformation.resource_uri);
   query.set('isFavorite', false);

--- a/specifyweb/frontend/js_src/lib/tests/ajax/static/context/datamodel.json
+++ b/specifyweb/frontend/js_src/lib/tests/ajax/static/context/datamodel.json
@@ -31079,6 +31079,14 @@
         "type": "java.lang.Boolean"
       },
       {
+        "name": "selectSeries",
+        "column": "SelectSeries",
+        "indexed": false,
+        "unique": false,
+        "required": false,
+        "type": "java.lang.Boolean"
+      },
+      {
         "name": "smushed",
         "column": "Smushed",
         "indexed": false,

--- a/specifyweb/frontend/js_src/lib/tests/ajax/static/context/datamodel.json
+++ b/specifyweb/frontend/js_src/lib/tests/ajax/static/context/datamodel.json
@@ -31087,14 +31087,6 @@
         "type": "java.lang.Boolean"
       },
       {
-        "name": "smushed",
-        "column": "Smushed",
-        "indexed": false,
-        "unique": false,
-        "required": false,
-        "type": "java.lang.Boolean"
-      },
-      {
         "name": "sqlStr",
         "column": "SqlStr",
         "indexed": false,

--- a/specifyweb/frontend/js_src/lib/tests/ajax/static/context/schema_localization.json/lang=en.json
+++ b/specifyweb/frontend/js_src/lib/tests/ajax/static/context/schema_localization.json/lang=en.json
@@ -38532,6 +38532,17 @@
         "name": "Select Distinct",
         "desc": "Select Distinct"
       },
+      "selectseries": {
+        "format": null,
+        "ishidden": false,
+        "isuiformatter": false,
+        "picklistname": null,
+        "type": null,
+        "isrequired": false,
+        "weblinkname": null,
+        "name": "Select Series",
+        "desc": "Select Series"
+      },
       "smushed": {
         "format": null,
         "ishidden": false,

--- a/specifyweb/frontend/js_src/lib/tests/ajax/static/context/schema_localization.json/lang=en.json
+++ b/specifyweb/frontend/js_src/lib/tests/ajax/static/context/schema_localization.json/lang=en.json
@@ -38543,17 +38543,6 @@
         "name": "Select Series",
         "desc": "Select Series"
       },
-      "smushed": {
-        "format": null,
-        "ishidden": false,
-        "isuiformatter": false,
-        "picklistname": null,
-        "type": null,
-        "isrequired": false,
-        "weblinkname": null,
-        "name": "Smushed",
-        "desc": "Smushed"
-      },
       "specifyuser": {
         "format": null,
         "ishidden": true,

--- a/specifyweb/specify/datamodel.py
+++ b/specifyweb/specify/datamodel.py
@@ -6595,6 +6595,7 @@ datamodel = Datamodel(tables=[
             Field(name='remarks', column='Remarks', indexed=False, unique=False, required=False, type='text', length=4096),
             Field(name='searchSynonymy', column='SearchSynonymy', indexed=False, unique=False, required=False, type='java.lang.Boolean'),
             Field(name='selectDistinct', column='SelectDistinct', indexed=False, unique=False, required=False, type='java.lang.Boolean'),
+            Field(name='selectSeries', column='SelectSeries', indexed=False, unique=False, required=False, type='java.lang.Boolean'),
             Field(name='smushed', column='Smushed', indexed=False, unique=False, required=False, type='java.lang.Boolean'),
             Field(name='sqlStr', column='SqlStr', indexed=False, unique=False, required=False, type='text', length=4096),
             Field(name='timestampCreated', column='TimestampCreated', indexed=False, unique=False, required=True, type='java.sql.Timestamp'),

--- a/specifyweb/specify/datamodel.py
+++ b/specifyweb/specify/datamodel.py
@@ -6596,7 +6596,6 @@ datamodel = Datamodel(tables=[
             Field(name='searchSynonymy', column='SearchSynonymy', indexed=False, unique=False, required=False, type='java.lang.Boolean'),
             Field(name='selectDistinct', column='SelectDistinct', indexed=False, unique=False, required=False, type='java.lang.Boolean'),
             Field(name='selectSeries', column='SelectSeries', indexed=False, unique=False, required=False, type='java.lang.Boolean'),
-            Field(name='smushed', column='Smushed', indexed=False, unique=False, required=False, type='java.lang.Boolean'),
             Field(name='sqlStr', column='SqlStr', indexed=False, unique=False, required=False, type='text', length=4096),
             Field(name='timestampCreated', column='TimestampCreated', indexed=False, unique=False, required=True, type='java.sql.Timestamp'),
             Field(name='timestampModified', column='TimestampModified', indexed=False, unique=False, required=False, type='java.sql.Timestamp'),

--- a/specifyweb/specify/migrations/0001_initial.py
+++ b/specifyweb/specify/migrations/0001_initial.py
@@ -1979,7 +1979,7 @@ class Migration(migrations.Migration):
                 ('remarks', models.TextField(blank=True, db_column='Remarks', null=True)),
                 ('searchsynonymy', models.BooleanField(blank=True, db_column='SearchSynonymy', null=True)),
                 ('selectdistinct', models.BooleanField(blank=True, db_column='SelectDistinct', null=True)),
-                ('selectseries', models.BooleanField(blank=True, db_column='selectseries', null=True)),
+                ('smushed', models.BooleanField(blank=True, db_column='Smushed', null=True)),
                 ('sqlstr', models.TextField(blank=True, db_column='SqlStr', null=True)),
                 ('timestampcreated', models.DateTimeField(db_column='TimestampCreated', default=django.utils.timezone.now)),
                 ('timestampmodified', models.DateTimeField(blank=True, db_column='TimestampModified', default=django.utils.timezone.now, null=True)),

--- a/specifyweb/specify/migrations/0001_initial.py
+++ b/specifyweb/specify/migrations/0001_initial.py
@@ -1979,7 +1979,7 @@ class Migration(migrations.Migration):
                 ('remarks', models.TextField(blank=True, db_column='Remarks', null=True)),
                 ('searchsynonymy', models.BooleanField(blank=True, db_column='SearchSynonymy', null=True)),
                 ('selectdistinct', models.BooleanField(blank=True, db_column='SelectDistinct', null=True)),
-                ('smushed', models.BooleanField(blank=True, db_column='Smushed', null=True)),
+                ('selectseries', models.BooleanField(blank=True, db_column='selectseries', null=True)),
                 ('sqlstr', models.TextField(blank=True, db_column='SqlStr', null=True)),
                 ('timestampcreated', models.DateTimeField(db_column='TimestampCreated', default=django.utils.timezone.now)),
                 ('timestampmodified', models.DateTimeField(blank=True, db_column='TimestampModified', default=django.utils.timezone.now, null=True)),

--- a/specifyweb/specify/migrations/0033_change_smushed_to_selectseries.py
+++ b/specifyweb/specify/migrations/0033_change_smushed_to_selectseries.py
@@ -1,0 +1,18 @@
+from django.db import migrations
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('specify', '0032_remove_spquery_selectseries'),
+    ]
+
+    operations = [
+        migrations.RunSQL(
+            sql="""
+                ALTER TABLE spquery CHANGE COLUMN Smushed SelectSeries BIT(1);
+            """,
+            reverse_sql="""
+                ALTER TABLE spquery CHANGE COLUMN SelectSeries Smushed BIT(1);
+            """
+        ),
+    ]

--- a/specifyweb/specify/models.py
+++ b/specifyweb/specify/models.py
@@ -6261,6 +6261,7 @@ class Spquery(models.Model):
     remarks = models.TextField(blank=True, null=True, unique=False, db_column='Remarks', db_index=False)
     searchsynonymy = models.BooleanField(blank=True, null=True, unique=False, db_column='SearchSynonymy', db_index=False)
     selectdistinct = models.BooleanField(blank=True, null=True, unique=False, db_column='SelectDistinct', db_index=False)
+    selectseries = models.BooleanField(blank=True, null=True, unique=False, db_column='SelectSeries', db_index=False, default=False)
     smushed = models.BooleanField(blank=True, null=True, unique=False, db_column='Smushed', db_index=False)
     sqlstr = models.TextField(blank=True, null=True, unique=False, db_column='SqlStr', db_index=False)
     timestampcreated = models.DateTimeField(blank=False, null=False, unique=False, db_column='TimestampCreated', db_index=False, default=timezone.now)

--- a/specifyweb/specify/models.py
+++ b/specifyweb/specify/models.py
@@ -6262,7 +6262,6 @@ class Spquery(models.Model):
     searchsynonymy = models.BooleanField(blank=True, null=True, unique=False, db_column='SearchSynonymy', db_index=False)
     selectdistinct = models.BooleanField(blank=True, null=True, unique=False, db_column='SelectDistinct', db_index=False)
     selectseries = models.BooleanField(blank=True, null=True, unique=False, db_column='SelectSeries', db_index=False, default=False)
-    smushed = models.BooleanField(blank=True, null=True, unique=False, db_column='Smushed', db_index=False)
     sqlstr = models.TextField(blank=True, null=True, unique=False, db_column='SqlStr', db_index=False)
     timestampcreated = models.DateTimeField(blank=False, null=False, unique=False, db_column='TimestampCreated', db_index=False, default=timezone.now)
     timestampmodified = models.DateTimeField(blank=True, null=True, unique=False, db_column='TimestampModified', db_index=False, default=timezone.now) # auto_now=True

--- a/specifyweb/specify/temp_models.py
+++ b/specifyweb/specify/temp_models.py
@@ -5016,7 +5016,6 @@ class Spquery(models.Model):
     modifiedbyagentid = models.ForeignKey(Agent, models.DO_NOTHING, db_column='ModifiedByAgentID', blank=True, null=True)  # Field name made lowercase.
     specifyuserid = models.ForeignKey(Specifyuser, models.DO_NOTHING, db_column='SpecifyUserID')  # Field name made lowercase.
     createdbyagentid = models.ForeignKey(Agent, models.DO_NOTHING, db_column='CreatedByAgentID', blank=True, null=True)  # Field name made lowercase.
-    smushed = models.BooleanField(db_column='Smushed', blank=True, null=True)  # Field name made lowercase.
     formatauditrecids = models.BooleanField(db_column='FormatAuditRecIds', blank=True, null=True)  # Field name made lowercase.
 
     class Meta:

--- a/specifyweb/specify/tests/test_geotime.py
+++ b/specifyweb/specify/tests/test_geotime.py
@@ -496,7 +496,7 @@ class GeoTimeTests(ApiTests):
                 "_tablename": "SpQuery",
                 "remarks": None,
                 "searchsynonymy": None,
-                "smushed": None,
+                "selectseries": None,
                 "sqlstr": None,
                 "timestampcreated": "2024-11-06",
                 "timestampmodified": None,

--- a/specifyweb/stored_queries/execution.py
+++ b/specifyweb/stored_queries/execution.py
@@ -575,7 +575,7 @@ def run_ephemeral_query(collection, user, spquery):
     offset = spquery.get("offset", 0)
     recordsetid = spquery.get("recordsetid", None)
     distinct = spquery["selectdistinct"]
-    series = spquery.get('smushed', None)
+    series = spquery.get('selectseries', None)
     tableid = spquery["contexttableid"]
     count_only = spquery["countonly"]
     format_audits = spquery.get("formatauditrecids", False)

--- a/specifyweb/stored_queries/tests/static/co_query.json
+++ b/specifyweb/stored_queries/tests/static/co_query.json
@@ -410,7 +410,6 @@
   "_tablename": "SpQuery",
   "remarks": null,
   "searchsynonymy": null,
-  "smushed": null,
   "sqlstr": null,
   "timestampcreated": "2024-08-20",
   "timestampmodified": null,

--- a/specifyweb/stored_queries/tests/static/co_query.json
+++ b/specifyweb/stored_queries/tests/static/co_query.json
@@ -3,6 +3,7 @@
   "contextname": "CollectionObject",
   "contexttableid": 1,
   "selectdistinct": false,
+  "selectseries": false,
   "countonly": true,
   "formatauditrecids": false,
   "specifyuser": "/api/specify/specifyuser/1/",

--- a/specifyweb/stored_queries/views.py
+++ b/specifyweb/stored_queries/views.py
@@ -83,7 +83,7 @@ def query(request, id):
     with models.session_context() as session:
         sp_query = session.query(models.SpQuery).get(int(id))
         distinct = sp_query.selectDistinct
-        series = sp_query.smushed
+        series = sp_query.selectSeries
         tableid = sp_query.contextTableId
         count_only = sp_query.countOnly
 


### PR DESCRIPTION
Fixes #6579

Change 'smushed' field name to 'selectseries'.

### Checklist

- [ ] Self-review the PR after opening it to make sure the changes look good and
      self-explanatory (or properly documented)
- [x] Add relevant issue to release milestone

### Testing instructions

- [ ] Run series queries and see that they runs successfully. See original series QB PR for more testing instructions https://github.com/specify/specify7/pull/4952
