### PR TITLE
Update titles for tree ranks when null

### DIFF
--- a/specifyweb/patches/migrations/0004_add_title_tree_rank_fix.py
+++ b/specifyweb/patches/migrations/0004_add_title_tree_rank_fix.py
@@ -1,0 +1,19 @@
+from django.db import migrations
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('patches', '0003_coordinate_fields_fix'),
+    ]
+
+    operations = [
+        migrations.RunSQL(
+            """
+            UPDATE taxontreedefitem
+            SET Title = Name
+            WHERE Title IS NULL;
+            """,
+            # No reverse SQL because this change is irreversible
+            reverse_sql=''
+        )
+    ]


### PR DESCRIPTION
Fixes #6564

> [!WARNING]  
> This PR affects database migrations. See [migration testing instructions](https://specify.github.io/testing/pull_requests.html#prs-tagged-with-label-migration).

### Checklist

- [ ] Self-review the PR after opening it to make sure the changes look good and
      self-explanatory (or properly documented)
- [ ] Add relevant issue to release milestone

### Testing instructions

- Find a tree that has empty titles rank by creating a branch using Main
- Close that branch 
- Create a new branch with this pr 
- Open the tree 
- [ ] Verify the rank titles are now filled 
