### PR TITLE
(tests): Begin adding unit tests for useLiveState and useReadyEffect

### DIFF
--- a/specifyweb/frontend/js_src/lib/hooks/__tests__/useLiveState.test.ts
+++ b/specifyweb/frontend/js_src/lib/hooks/__tests__/useLiveState.test.ts
@@ -1,26 +1,27 @@
 import { renderHook } from "@testing-library/react";
-import { useLiveState } from "../useLiveState";
 import { act } from "react-dom/test-utils";
+
+import { useLiveState } from "../useLiveState";
 
 describe("useLiveState", ()=>{
 
-    it("does not recalculate state when function does not change", async ()=>{
+    test("does not recalculate state when function does not change", async ()=>{
 
         const stateCreator = jest.fn().mockReturnValueOnce(50);
 
         const { result, rerender } = renderHook(()=>useLiveState(stateCreator));
 
         expect(result.current[0]).toBe(50);
-        expect(stateCreator).toBeCalledTimes(1);
+        expect(stateCreator).toHaveBeenCalledTimes(1);
 
         await act(rerender);
 
         expect(result.current[0]).toBe(50);
-        expect(stateCreator).toBeCalledTimes(1);
+        expect(stateCreator).toHaveBeenCalledTimes(1);
 
     });
 
-    it("recalculates state when function changes", async ()=>{
+    test("recalculates state when function changes", async ()=>{
 
         // Here, the function gets changed later.
         let volatileStateCreator = jest.fn().mockReturnValue(10);
@@ -28,7 +29,7 @@ describe("useLiveState", ()=>{
         const { result, rerender } = renderHook(()=>useLiveState(volatileStateCreator));
 
         expect(result.current[0]).toBe(10);
-        expect(volatileStateCreator).toBeCalledTimes(1);
+        expect(volatileStateCreator).toHaveBeenCalledTimes(1);
 
         const originalCreator = volatileStateCreator;
 
@@ -37,8 +38,8 @@ describe("useLiveState", ()=>{
         await act(rerender);
 
         expect(result.current[0]).toBe(50);
-        expect(volatileStateCreator).toBeCalledTimes(1);
-        expect(originalCreator).toBeCalledTimes(1);
+        expect(volatileStateCreator).toHaveBeenCalledTimes(1);
+        expect(originalCreator).toHaveBeenCalledTimes(1);
 
     })
 });

--- a/specifyweb/frontend/js_src/lib/hooks/__tests__/useLiveState.test.ts
+++ b/specifyweb/frontend/js_src/lib/hooks/__tests__/useLiveState.test.ts
@@ -1,0 +1,44 @@
+import { renderHook } from "@testing-library/react";
+import { useLiveState } from "../useLiveState";
+import { act } from "react-dom/test-utils";
+
+describe("useLiveState", ()=>{
+
+    it("does not recalculate state when function does not change", async ()=>{
+
+        const stateCreator = jest.fn().mockReturnValueOnce(50);
+
+        const { result, rerender } = renderHook(()=>useLiveState(stateCreator));
+
+        expect(result.current[0]).toBe(50);
+        expect(stateCreator).toBeCalledTimes(1);
+
+        await act(rerender);
+
+        expect(result.current[0]).toBe(50);
+        expect(stateCreator).toBeCalledTimes(1);
+
+    });
+
+    it("recalculates state when function changes", async ()=>{
+
+        // Here, the function gets changed later.
+        let volatileStateCreator = jest.fn().mockReturnValue(10);
+
+        const { result, rerender } = renderHook(()=>useLiveState(volatileStateCreator));
+
+        expect(result.current[0]).toBe(10);
+        expect(volatileStateCreator).toBeCalledTimes(1);
+
+        const originalCreator = volatileStateCreator;
+
+        volatileStateCreator = jest.fn().mockReturnValue(50);
+
+        await act(rerender);
+
+        expect(result.current[0]).toBe(50);
+        expect(volatileStateCreator).toBeCalledTimes(1);
+        expect(originalCreator).toBeCalledTimes(1);
+
+    })
+});


### PR DESCRIPTION
Fixes #6627 and #6628

**Test coverage before (0, but below is the first test)** 

Not Applicable

**Test coverage after** 
```
/**
 * Final coverage report:
 * useLiveState.tsx   |     100 |      100 |     100 |     100 |                
 * useReadyEffect.tsx |     100 |      100 |     100 |     100 |   
 */
```

`useReadyEffect` code paths are also completely exercised, so this single PR is considered for both of them.
