### PR TITLE
(tests): Begin adding tests for async state family (useAsyncState)

### DIFF
--- a/specifyweb/frontend/js_src/lib/hooks/__tests__/useAsyncState.test.tsx
+++ b/specifyweb/frontend/js_src/lib/hooks/__tests__/useAsyncState.test.tsx
@@ -1,0 +1,82 @@
+import { act, renderHook, waitFor } from "@testing-library/react";
+import React from "react";
+
+import { LoadingContext } from "../../components/Core/Contexts";
+import { mount } from "../../tests/reactUtils";
+import { useAsyncState } from "../useAsyncState";
+
+describe("useAsyncState", () => {
+
+    function TestLoading(
+        { promise, callback, showLoading }:
+            {
+                readonly promise: () => Promise<string>,
+                readonly callback: (state: string | undefined | undefined) => void,
+                readonly showLoading: boolean
+            }
+    ) {
+        const [state] = useAsyncState(promise, showLoading);
+        React.useEffect(() => {
+            callback(state);
+        }, [state, callback]);
+        return <></>
+    }
+
+    test("promise gets resolved and state set", async () => {
+
+        const promise = async () => "First Promise";
+
+        const { result } = renderHook(() => useAsyncState(promise, false));
+
+        await waitFor(() => {
+            expect(result.current[0]).toBe("First Promise");
+        });
+
+    });
+
+    test("Loading screen appears", async () => {
+
+        const promise = async () => "First Promise";
+
+        const promiseHandler = jest.fn();
+        const onStateSet = jest.fn();
+
+        mount(
+            <LoadingContext.Provider value={promiseHandler}>
+                <TestLoading callback={onStateSet} promise={promise} showLoading />
+            </LoadingContext.Provider>
+        )
+
+        await waitFor(() => {
+            expect(onStateSet.mock.calls.length).toBeGreaterThanOrEqual(1);
+            const stateSet = onStateSet.mock.calls.at(-1).at(0);
+            expect(stateSet).toEqual("First Promise");
+        });
+
+        expect(promiseHandler).toHaveBeenCalled();
+
+    });
+
+    test.skip("state changes when promise changes", async () => {
+
+        const firstPromise = Promise.resolve("First Promise");
+        const secondPromise = Promise.resolve("Second Promise");
+
+        let promise: () => Promise<string> = () => firstPromise;
+
+        const { result, rerender } = renderHook(() => useAsyncState(promise, false));
+
+        await waitFor(() => {
+            expect(result.current[0]).toBe("First Promise");
+        });
+
+        promise = () => secondPromise;
+
+        await act(rerender);
+
+        await waitFor(() => {
+            expect(result.current[0]).toBe("Second Promise");
+        });
+
+    });
+});

--- a/specifyweb/frontend/js_src/lib/hooks/__tests__/useAsyncState.test.tsx
+++ b/specifyweb/frontend/js_src/lib/hooks/__tests__/useAsyncState.test.tsx
@@ -50,16 +50,18 @@ describe("useAsyncState", () => {
         await waitFor(() => {
             expect(onStateSet.mock.calls.length).toBeGreaterThanOrEqual(1);
             const stateSet = onStateSet.mock.calls.at(-1).at(0);
-            expect(stateSet).toEqual("First Promise");
+            expect(stateSet).toBe("First Promise");
         });
 
         expect(promiseHandler).toHaveBeenCalled();
 
     });
 
-    // Below tests don't work because of the async nature.
-    // The cleanest way would be a slight refactor and adding callbacks
-    // to the useAsyncState and useMultipleAsyncState.
+    /*
+     * Below tests don't work because of the async nature.
+     * The cleanest way would be a slight refactor and adding callbacks
+     * to the useAsyncState and useMultipleAsyncState.
+     */
     test.skip("destructor call is obeyed", async () => {
 
         const firstPromise = new Promise(() => { });
@@ -68,11 +70,11 @@ describe("useAsyncState", () => {
             "Second Value"
         );
 
-        let promise = () => firstPromise;
+        let promise = async () => firstPromise;
 
         const { result, rerender } = renderHook(() => useAsyncState(promise, false));
 
-        promise = () => secondPromise;
+        promise = async () => secondPromise;
 
         await act(rerender);
 
@@ -91,7 +93,7 @@ describe("useAsyncState", () => {
         const firstPromise = Promise.resolve("First Promise");
         const secondPromise = Promise.resolve("Second Promise");
 
-        let promise: () => Promise<string> = () => firstPromise;
+        let promise: () => Promise<string> = async () => firstPromise;
 
         const { result, rerender } = renderHook(() => useAsyncState(promise, false));
 
@@ -99,7 +101,7 @@ describe("useAsyncState", () => {
             expect(result.current[0]).toBe("First Promise");
         });
 
-        promise = () => secondPromise;
+        promise = async () => secondPromise;
 
         await act(rerender);
 

--- a/specifyweb/frontend/js_src/lib/hooks/__tests__/useAsyncState.test.tsx
+++ b/specifyweb/frontend/js_src/lib/hooks/__tests__/useAsyncState.test.tsx
@@ -62,11 +62,7 @@ describe("useAsyncState", () => {
     // to the useAsyncState and useMultipleAsyncState.
     test.skip("destructor call is obeyed", async () => {
 
-        let resolver: (args: string) => void;
-
-        const firstPromise = new Promise((resolve) => {
-            resolver = resolve;
-        });
+        const firstPromise = new Promise(() => { });
 
         const secondPromise = Promise.resolve(
             "Second Value"

--- a/specifyweb/frontend/js_src/lib/hooks/__tests__/useAsyncState.test.tsx
+++ b/specifyweb/frontend/js_src/lib/hooks/__tests__/useAsyncState.test.tsx
@@ -57,6 +57,39 @@ describe("useAsyncState", () => {
 
     });
 
+    // Below tests don't work because of the async nature.
+    // The cleanest way would be a slight refactor and adding callbacks
+    // to the useAsyncState and useMultipleAsyncState.
+    test.skip("destructor call is obeyed", async () => {
+
+        let resolver: (args: string) => void;
+
+        const firstPromise = new Promise((resolve) => {
+            resolver = resolve;
+        });
+
+        const secondPromise = Promise.resolve(
+            "Second Value"
+        );
+
+        let promise = () => firstPromise;
+
+        const { result, rerender } = renderHook(() => useAsyncState(promise, false));
+
+        promise = () => secondPromise;
+
+        await act(rerender);
+
+        await waitFor(() => {
+            expect(result.current[0]).toBeDefined();
+        })
+
+        expect(result.current[0]).toBe(
+            "Second Value"
+        );
+
+    });
+
     test.skip("state changes when promise changes", async () => {
 
         const firstPromise = Promise.resolve("First Promise");
@@ -79,4 +112,5 @@ describe("useAsyncState", () => {
         });
 
     });
+
 });


### PR DESCRIPTION
Fixes #6659 

Similar to reasoning behind low-test coverage in https://github.com/specify/specify7/pull/6652, the coverage for this function is 100% (no lines of this function appear in "missing statements" column")

```
/**
 * Final coverage report:
 *   useAsyncState.tsx           |   58.67 |    71.42 |   33.33 |   58.67 | 50,71-111,114-121
 */

```