### PR TITLE
(tests): Add tests for useParser

### DIFF
--- a/specifyweb/frontend/js_src/lib/hooks/__tests__/useMultipleAsyncState.test.tsx
+++ b/specifyweb/frontend/js_src/lib/hooks/__tests__/useMultipleAsyncState.test.tsx
@@ -1,96 +1,96 @@
-import { act, renderHook, waitFor } from "@testing-library/react";
-import React from "react";
+import { act, renderHook, waitFor } from '@testing-library/react';
+import React from 'react';
 
-import { LoadingContext } from "../../components/Core/Contexts";
-import { mount } from "../../tests/reactUtils";
-import type { IR } from "../../utils/types";
-import { useMultipleAsyncState } from "../useAsyncState";
+import { LoadingContext } from '../../components/Core/Contexts';
+import { mount } from '../../tests/reactUtils';
+import type { IR } from '../../utils/types';
+import { useMultipleAsyncState } from '../useAsyncState';
 
-describe("useMultipleAsyncState", () => {
+describe('useMultipleAsyncState', () => {
+  function TestLoading({
+    promises,
+    callback,
+    showLoading,
+  }: {
+    readonly promises: IR<() => Promise<string>>;
+    readonly callback: (state: IR<string | undefined> | undefined) => void;
+    readonly showLoading: boolean;
+  }) {
+    const [state] = useMultipleAsyncState(promises, showLoading);
+    React.useEffect(() => {
+      callback(state);
+    }, [state, callback]);
+    return <></>;
+  }
 
-    function TestLoading(
-        { promises, callback, showLoading }:
-            {
-                readonly promises: IR<() => Promise<string>>,
-                readonly callback: (state: IR<string | undefined> | undefined) => void,
-                readonly showLoading: boolean
-            }
-    ) {
-        const [state] = useMultipleAsyncState(promises, showLoading);
-        React.useEffect(() => {
-            callback(state);
-        }, [state, callback]);
-        return <></>
-    }
+  test('promise gets resolved and state set', async () => {
+    const promises = {
+      firstItem: async () => 'First Promise',
+      secondItem: async () => 'Second Promise',
+    };
 
-    test("promise gets resolved and state set", async () => {
+    const { result } = renderHook(() => useMultipleAsyncState(promises, false));
 
-        const promises = {
-            firstItem: async () => "First Promise",
-            secondItem: async () => "Second Promise"
-        };
+    await waitFor(() => {
+      expect(result.current[0]?.firstItem).toBe('First Promise');
+      expect(result.current[0]?.secondItem).toBe('Second Promise');
+    });
+  });
 
-        const { result } = renderHook(() => useMultipleAsyncState(promises, false));
+  test('Loading screen appears', async () => {
+    const promises = {
+      firstItem: async () => 'First Promise',
+      secondItem: async () => 'Second Promise',
+    };
 
-        await waitFor(() => {
-            expect(result.current[0]?.firstItem).toBe("First Promise");
-            expect(result.current[0]?.secondItem).toBe("Second Promise");
-        });
+    const promiseHandler = jest.fn();
+    const onStateSet = jest.fn();
 
+    mount(
+      <LoadingContext.Provider value={promiseHandler}>
+        <TestLoading callback={onStateSet} promises={promises} showLoading />
+      </LoadingContext.Provider>
+    );
+
+    await waitFor(() => {
+      expect(onStateSet.mock.calls.length).toBeGreaterThanOrEqual(1);
+      const stateSet = onStateSet.mock.calls.at(-1).at(0);
+      expect(stateSet).toEqual({
+        firstItem: 'First Promise',
+        secondItem: 'Second Promise',
+      });
     });
 
-    test("Loading screen appears", async () => {
+    expect(promiseHandler).toHaveBeenCalled();
+  });
 
-        const promises = {
-            firstItem: async () => "First Promise",
-            secondItem: async () => "Second Promise"
-        };
+  test.skip('state changes when promise changes', async () => {
+    const firstPromise = Promise.resolve('First Promise');
+    const secondPromise = Promise.resolve('Second Promise');
+    const thirdPromise = Promise.resolve('Third Promise');
 
-        const promiseHandler = jest.fn();
-        const onStateSet = jest.fn();
+    let promises: IR<() => Promise<string>> = {
+      firstItem: async () => firstPromise,
+      secondItem: async () => secondPromise,
+    };
 
-        mount(<LoadingContext.Provider value={promiseHandler}><TestLoading callback={onStateSet} promises={promises} showLoading /></LoadingContext.Provider>)
+    const { result, rerender } = renderHook(() =>
+      useMultipleAsyncState(promises, false)
+    );
 
-        await waitFor(() => {
-            expect(onStateSet.mock.calls.length).toBeGreaterThanOrEqual(1);
-            const stateSet = onStateSet.mock.calls.at(-1).at(0);
-            expect(stateSet).toEqual({
-                firstItem: "First Promise",
-                secondItem: "Second Promise"
-            });
-        });
-
-        expect(promiseHandler).toHaveBeenCalled();
-
+    await waitFor(() => {
+      expect(result.current[0]?.firstItem).toBe('First Promise');
+      expect(result.current[0]?.secondItem).toBe('Second Promise');
     });
 
-    test.skip("state changes when promise changes", async () => {
+    promises = { ...promises, thirdItem: async () => thirdPromise };
 
-        const firstPromise = Promise.resolve("First Promise");
-        const secondPromise = Promise.resolve("Second Promise");
-        const thirdPromise = Promise.resolve("Third Promise");
+    await act(rerender);
 
-        let promises: IR<() => Promise<string>> = {
-            firstItem: async () => firstPromise,
-            secondItem: async () => secondPromise
-        };
-
-        const { result, rerender } = renderHook(() => useMultipleAsyncState(promises, false));
-
-        await waitFor(() => {
-            expect(result.current[0]?.firstItem).toBe("First Promise");
-            expect(result.current[0]?.secondItem).toBe("Second Promise");
-        });
-
-        promises = { ...promises, thirdItem: async () => thirdPromise };
-
-        await act(rerender);
-
-        await waitFor(() => {
-            expect(result.current[0]?.firstItem).toBe("First Promise");
-            expect(result.current[0]?.secondItem).toBe("Second Promise");
-            expect(result.current[0]?.thirdItem).toBe("Third Promise");
-        });
-
+    await waitFor(() => {
+      expect(result.current[0]?.firstItem).toBe('First Promise');
+      expect(result.current[0]?.secondItem).toBe('Second Promise');
+      expect(result.current[0]?.thirdItem).toBe('Third Promise');
     });
+  });
 });

--- a/specifyweb/frontend/js_src/lib/hooks/__tests__/useParser.test.tsx
+++ b/specifyweb/frontend/js_src/lib/hooks/__tests__/useParser.test.tsx
@@ -1,0 +1,100 @@
+import { act, renderHook } from "@testing-library/react";
+import React from "react";
+
+import { SearchDialogContext } from "../../components/Core/Contexts";
+import { mount } from "../../tests/reactUtils";
+import { tables } from "../../components/DataModel/tables";
+import { useParser } from "../resource";
+import { requireContext } from "../../tests/helpers";
+import { Parser } from "../../utils/parser/definitions";
+
+
+requireContext();
+
+describe("useParser", () => {
+
+    function TestInSearchDialog({ field, resource, defaultParser, callback }: {
+        // Done this way so that, in future, tests don't need to be modified that much.
+        readonly field: Parameters<typeof useParser>[0],
+        readonly resource?: Parameters<typeof useParser>[1],
+        readonly defaultParser?: Parameters<typeof useParser>[2]
+        readonly callback: (parser: Parser) => void
+    }) {
+
+        const parser = useParser(field, resource, defaultParser);
+
+        React.useEffect(() => {
+            callback(parser);
+        }, [parser]);
+
+        return <></>
+    }
+
+    test("simple formatter gets set", async () => {
+        const collectionObject = new tables.CollectionObject.Resource({ id: 1 });
+        const numberField = tables.CollectionObject.strictGetField(
+            "number1"
+        );
+
+        let defaultParser: Parser | undefined = undefined;
+
+        const { result, rerender } = renderHook(() => useParser(numberField, collectionObject, defaultParser));
+
+        expect(result.current.type).toBe("number");
+
+        defaultParser = {
+            type: 'number',
+            step: 3,
+            required: false
+        };
+
+        await act(rerender);
+
+        expect(result.current.type).toBe("number");
+        expect(result.current.step).toBe(3);
+        expect(result.current.required).toBe(false);
+
+    });
+
+    test("formatter in simple search is always text", () => {
+        const numberField = tables.CollectionObject.strictGetField(
+            "number1"
+        );
+
+        const onParserSet = jest.fn();
+
+        mount(
+            <SearchDialogContext.Provider value>
+                <TestInSearchDialog field={numberField} callback={onParserSet} />
+            </SearchDialogContext.Provider>
+        );
+
+        expect(onParserSet).toBeCalled();
+        expect(onParserSet.mock.calls.at(-1).at(0)).toEqual({ type: "text" });
+
+    });
+
+    test("field is relationship", () => {
+        const collectionObject = new tables.CollectionObject.Resource({ id: 1 });
+        const collectingEvent = tables.CollectionObject.strictGetField(
+            "collectingevent"
+        );
+
+        const { result } = renderHook(() => useParser(collectingEvent, collectionObject));
+
+        expect(result.current).toEqual({ type: 'text', required: false });
+
+    });
+
+    test("field is undefined", () => {
+        const collectionObject = new tables.CollectionObject.Resource({ id: 1 });
+
+        const { result } = renderHook(() => useParser(undefined, collectionObject));
+
+        expect(result.current).toEqual({ type: 'text' });
+
+    });
+
+
+
+});

--- a/specifyweb/frontend/js_src/lib/hooks/__tests__/useParser.test.tsx
+++ b/specifyweb/frontend/js_src/lib/hooks/__tests__/useParser.test.tsx
@@ -2,11 +2,11 @@ import { act, renderHook } from "@testing-library/react";
 import React from "react";
 
 import { SearchDialogContext } from "../../components/Core/Contexts";
-import { mount } from "../../tests/reactUtils";
 import { tables } from "../../components/DataModel/tables";
-import { useParser } from "../resource";
 import { requireContext } from "../../tests/helpers";
-import { Parser } from "../../utils/parser/definitions";
+import { mount } from "../../tests/reactUtils";
+import type { Parser } from "../../utils/parser/definitions";
+import { useParser } from "../resource";
 
 
 requireContext();
@@ -65,11 +65,11 @@ describe("useParser", () => {
 
         mount(
             <SearchDialogContext.Provider value>
-                <TestInSearchDialog field={numberField} callback={onParserSet} />
+                <TestInSearchDialog callback={onParserSet} field={numberField} />
             </SearchDialogContext.Provider>
         );
 
-        expect(onParserSet).toBeCalled();
+        expect(onParserSet).toHaveBeenCalled();
         expect(onParserSet.mock.calls.at(-1).at(0)).toEqual({ type: "text" });
 
     });


### PR DESCRIPTION
Fixes #6661 

`resource.tsx` also has other hooks, so the code coverage is low. However, `useParser`'s code coverage is still 100% (since it doesn't appear in uncovered statements)


```
/**
 * Final coverage report:
 *   resource.tsx                |   47.65 |      100 |   33.33 |   47.65 | 32-80,92-120
 */
```
