### PR TITLE
(tests): Add tests for useDistantRelated

### DIFF
--- a/specifyweb/frontend/js_src/lib/hooks/__tests__/useDistantRelated.test.tsx
+++ b/specifyweb/frontend/js_src/lib/hooks/__tests__/useDistantRelated.test.tsx
@@ -1,13 +1,13 @@
 import { act, renderHook, waitFor } from "@testing-library/react";
 
-import { tables } from "../../components/DataModel/tables";
-import { useDistantRelated } from "../resource";
-import { requireContext } from "../../tests/helpers";
-import { overrideAjax } from "../../tests/ajax";
+import type { AnySchema, SerializedResource } from "../../components/DataModel/helperTypes";
 import { getResourceApiUrl } from "../../components/DataModel/resource";
-import { LiteralField, Relationship } from "../../components/DataModel/specifyField";
-import { RA } from "../../utils/types";
-import { AnySchema, SerializedResource } from "../../components/DataModel/helperTypes";
+import type { LiteralField, Relationship } from "../../components/DataModel/specifyField";
+import { tables } from "../../components/DataModel/tables";
+import { overrideAjax } from "../../tests/ajax";
+import { requireContext } from "../../tests/helpers";
+import type { RA } from "../../utils/types";
+import { useDistantRelated } from "../resource";
 
 
 requireContext();
@@ -15,8 +15,10 @@ requireContext();
 describe("useDistantRelated", () => {
 
 
-    // There are tests already for fetchDistantRelated.
-    //Some of the below is taken from tests for fetchDistantRelated.
+    /*
+     *  There are tests already for fetchDistantRelated.
+     * Some of the below is taken from tests for fetchDistantRelated.
+     */
 
     const collectorId = 1;
     const secondCollectorId = 2;
@@ -38,7 +40,7 @@ describe("useDistantRelated", () => {
 
     const validateCollector = (
         result: ReturnType<typeof useDistantRelated>,
-        fields: RA<Relationship | LiteralField> | undefined,
+        fields: RA<LiteralField | Relationship> | undefined,
         agent: Partial<SerializedResource<AnySchema>> | undefined
     ) => {
         expect(result).toBeDefined();
@@ -63,7 +65,7 @@ describe("useDistantRelated", () => {
     test("empty path, that gets set", async () => {
         const resource = new tables.Collector.Resource({ id: collectorId });
 
-        let fields: RA<Relationship | LiteralField> = [];
+        let fields: RA<LiteralField | Relationship> = [];
 
         const { result, rerender } = renderHook(() => useDistantRelated(resource, fields));
 

--- a/specifyweb/frontend/js_src/lib/hooks/__tests__/useDistantRelated.test.tsx
+++ b/specifyweb/frontend/js_src/lib/hooks/__tests__/useDistantRelated.test.tsx
@@ -1,0 +1,141 @@
+import { act, renderHook, waitFor } from "@testing-library/react";
+
+import { tables } from "../../components/DataModel/tables";
+import { useDistantRelated } from "../resource";
+import { requireContext } from "../../tests/helpers";
+import { overrideAjax } from "../../tests/ajax";
+import { getResourceApiUrl } from "../../components/DataModel/resource";
+import { LiteralField, Relationship } from "../../components/DataModel/specifyField";
+import { RA } from "../../utils/types";
+import { AnySchema, SerializedResource } from "../../components/DataModel/helperTypes";
+
+
+requireContext();
+
+describe("useDistantRelated", () => {
+
+
+    // There are tests already for fetchDistantRelated.
+    //Some of the below is taken from tests for fetchDistantRelated.
+
+    const collectorId = 1;
+    const secondCollectorId = 2;
+
+    const firstAgentId = 2;
+    const secondAgentId = 3;
+
+    const firstAgent = {
+        resource_uri: getResourceApiUrl('Agent', firstAgentId),
+        id: firstAgentId,
+        lastname: 'a',
+    };
+
+    const secondAgent = {
+        resource_uri: getResourceApiUrl('Agent', secondAgentId),
+        id: secondAgentId,
+        lastname: 'b',
+    };
+
+    const validateCollector = (
+        result: ReturnType<typeof useDistantRelated>,
+        fields: RA<Relationship | LiteralField> | undefined,
+        agent: Partial<SerializedResource<AnySchema>> | undefined
+    ) => {
+        expect(result).toBeDefined();
+        expect(result?.field).toBe(fields?.at(-1));
+        if (agent !== undefined) expect(result?.resource?.toJSON()).toEqual(agent);
+    }
+
+    overrideAjax(`/api/specify/collector/${collectorId}/`, {
+        resource_uri: getResourceApiUrl('Collector', collectorId),
+        id: collectorId,
+        agent: getResourceApiUrl('Agent', firstAgentId),
+    });
+
+    overrideAjax(`/api/specify/collector/${secondCollectorId}/`, {
+        resource_uri: getResourceApiUrl('Collector', secondCollectorId),
+        id: secondCollectorId,
+    });
+
+    overrideAjax(`/api/specify/agent/${firstAgentId}/`, firstAgent);
+    overrideAjax(`/api/specify/agent/${secondAgentId}/`, secondAgent);
+
+    test("empty path, that gets set", async () => {
+        const resource = new tables.Collector.Resource({ id: collectorId });
+
+        let fields: RA<Relationship | LiteralField> = [];
+
+        const { result, rerender } = renderHook(() => useDistantRelated(resource, fields));
+
+        await waitFor(() => {
+            expect(result.current).toEqual({
+                resource, field: undefined
+            });
+        });
+
+        fields = [
+            tables.Collector.strictGetField('agent'),
+            tables.Agent.strictGetField('lastName'),
+        ];
+
+        await act(rerender);
+
+        await waitFor(() => {
+            validateCollector(result.current, fields, firstAgent);
+        });
+
+    });
+
+
+    test("undefined path, that gets set", async () => {
+        const resource = new tables.Collector.Resource({ id: collectorId });
+
+        let fields: Parameters<typeof useDistantRelated>[1] = undefined;
+
+        const { result, rerender } = renderHook(() => useDistantRelated(resource, fields));
+
+        await waitFor(() => {
+            expect(result.current).toEqual({
+                resource, field: undefined
+            });
+        });
+
+        fields = [
+            tables.Collector.strictGetField('agent'),
+            tables.Agent.strictGetField('lastName'),
+        ];
+
+        await act(rerender);
+
+        await waitFor(() => {
+            validateCollector(result.current, fields, firstAgent);
+        });
+
+    });
+
+    test("multiple field path, and change events", async () => {
+
+        const resource = new tables.Collector.Resource({ id: collectorId });
+        const fields = [
+            tables.Collector.strictGetField('agent'),
+            tables.Agent.strictGetField('lastName'),
+        ];
+
+        const { result } = renderHook(() => useDistantRelated(resource, fields));
+
+        await waitFor(() => {
+            validateCollector(result.current, fields, firstAgent);
+        });
+
+        await act(() => {
+            resource.set("agent", secondAgent.resource_uri as never);
+        });
+
+        await waitFor(() => {
+            validateCollector(result.current, fields, secondAgent);
+        });
+
+    });
+
+
+});


### PR DESCRIPTION
Fixes #6663 

`resource.tsx` also has other hooks, so the code coverage is low. However, `useDistantRelated`'s code coverage is still 100% (since it doesn't appear in uncovered statements)


```
/**
 * Final coverage report:
 *  resource.tsx                |   48.99 |    88.88 |      50 |   48.99 | 32-80,123-149
 */
```