### PR TITLE
(tests): Add unit tests for useUnloadProtect

### DIFF
--- a/specifyweb/frontend/js_src/lib/hooks/__tests__/useUnloadProtect.test.tsx
+++ b/specifyweb/frontend/js_src/lib/hooks/__tests__/useUnloadProtect.test.tsx
@@ -1,0 +1,82 @@
+import { LocalizedString } from "typesafe-i18n";
+import { localized, RA } from "../../utils/types";
+import { useUnloadProtect } from "../navigation";
+import React from "react";
+import { mount } from "../../tests/reactUtils";
+import { SetUnloadProtectsContext } from "../../components/Router/UnloadProtect";
+import { act } from "react-dom/test-utils";
+
+
+describe("useUnloadProtect", () => {
+
+    function TestUnloadProtect({ isEnabled, message }: { readonly isEnabled: boolean, readonly message: LocalizedString }) {
+        useUnloadProtect(isEnabled, message);
+        return <></>
+    }
+
+    test("unload protect gets set", () => {
+        const message = localized("custom message");
+        let unloadProtects: RA<string> = [];
+
+        const onUnloadProtectSet = (newValue: RA<string> | ((old: RA<string>) => RA<string>)) => {
+            unloadProtects = typeof newValue === 'function' ? newValue(unloadProtects) : newValue;
+        }
+
+        mount(
+            <SetUnloadProtectsContext.Provider value={onUnloadProtectSet}>
+                <TestUnloadProtect isEnabled message={message} />
+            </SetUnloadProtectsContext.Provider>
+        );
+
+        expect(unloadProtects).toEqual([message]);
+
+    });
+
+    test("unload protect gets unset on message change", async () => {
+        const initialMessage = localized("custom message");
+        const newMessage = localized("new custom message");
+        let unloadProtects: RA<string> = [];
+
+        const onUnloadProtectSet = (newValue: RA<string> | ((old: RA<string>) => RA<string>)) => {
+            unloadProtects = typeof newValue === 'function' ? newValue(unloadProtects) : newValue;
+        }
+
+        const { rerender } = mount(<SetUnloadProtectsContext.Provider value={onUnloadProtectSet}>
+            <TestUnloadProtect isEnabled message={initialMessage} />
+        </SetUnloadProtectsContext.Provider>);
+
+        expect(unloadProtects).toEqual([initialMessage]);
+
+        await act(() => rerender(
+            <SetUnloadProtectsContext.Provider value={onUnloadProtectSet}>
+                <TestUnloadProtect isEnabled message={newMessage} />
+            </SetUnloadProtectsContext.Provider>
+        ))
+
+        expect(unloadProtects).toEqual([newMessage]);
+    });
+
+    test("unload protect gets unset on disable change", async () => {
+        const initialMessage = localized("custom message");
+
+        let unloadProtects: RA<string> = [];
+
+        const onUnloadProtectSet = (newValue: RA<string> | ((old: RA<string>) => RA<string>)) => {
+            unloadProtects = typeof newValue === 'function' ? newValue(unloadProtects) : newValue;
+        }
+
+        const { rerender } = mount(<SetUnloadProtectsContext.Provider value={onUnloadProtectSet}>
+            <TestUnloadProtect isEnabled message={initialMessage} />
+        </SetUnloadProtectsContext.Provider>);
+
+        expect(unloadProtects).toEqual([initialMessage]);
+
+        await act(() => rerender(
+            <SetUnloadProtectsContext.Provider value={onUnloadProtectSet}>
+                <TestUnloadProtect isEnabled={false} message={initialMessage} />
+            </SetUnloadProtectsContext.Provider>
+        ))
+
+        expect(unloadProtects).toEqual([]);
+    });
+})

--- a/specifyweb/frontend/js_src/lib/hooks/__tests__/useUnloadProtect.test.tsx
+++ b/specifyweb/frontend/js_src/lib/hooks/__tests__/useUnloadProtect.test.tsx
@@ -1,10 +1,12 @@
-import { LocalizedString } from "typesafe-i18n";
-import { localized, RA } from "../../utils/types";
-import { useUnloadProtect } from "../navigation";
 import React from "react";
-import { mount } from "../../tests/reactUtils";
-import { SetUnloadProtectsContext } from "../../components/Router/UnloadProtect";
 import { act } from "react-dom/test-utils";
+import type { LocalizedString } from "typesafe-i18n";
+
+import { SetUnloadProtectsContext } from "../../components/Router/UnloadProtect";
+import { mount } from "../../tests/reactUtils";
+import type { RA } from "../../utils/types";
+import { localized } from "../../utils/types";
+import { useUnloadProtect } from "../navigation";
 
 
 describe("useUnloadProtect", () => {


### PR DESCRIPTION
Fixes #6669 

`navigation.tsx` also has other functions, so the code coverage is low. However, `useUnloadProtect`'s code coverage is still 100% (since it doesn't appear in uncovered statements)


```
/**
 * Final coverage report:
 *   navigation.tsx              |   61.16 |    88.88 |      50 |   61.16 | 20-49,56-65
 */
```