### PR TITLE
(tests): Add unit tests for unsetUnloadProtect

### DIFF
--- a/specifyweb/frontend/js_src/lib/hooks/__tests__/unsetUnloadProtect.test.ts
+++ b/specifyweb/frontend/js_src/lib/hooks/__tests__/unsetUnloadProtect.test.ts
@@ -1,0 +1,22 @@
+import { localized, RA } from "../../utils/types"
+import { unsetUnloadProtect } from "../navigation";
+
+describe("unsetUnloadProtect", ()=>{
+    test("removes error message", ()=>{
+        let errorMessages: RA<string> = ["custom error message",  "custom error message 2 (should not be removed)"];
+        const setUnloadProtects = (generator: ((old: RA<string>) => RA<string>) | RA<string>) => {
+            errorMessages = typeof generator === 'function' ? generator(errorMessages) : generator;
+        }
+        unsetUnloadProtect(setUnloadProtects, localized("custom error message"));
+        expect(errorMessages).toEqual(["custom error message 2 (should not be removed)"]);
+    });
+
+    test("returns same unload protects if message not found", ()=>{
+        let errorMessages: RA<string> = ["custom error message",  "custom error message 2 (should not be removed)"];
+        const setUnloadProtects = (generator: ((old: RA<string>) => RA<string>) | RA<string>) => {
+            errorMessages = typeof generator === 'function' ? generator(errorMessages) : generator;
+        }
+        unsetUnloadProtect(setUnloadProtects, localized("custom error message, does not exist"));
+        expect(errorMessages).toEqual(["custom error message",  "custom error message 2 (should not be removed)"]); 
+    });
+})

--- a/specifyweb/frontend/js_src/lib/hooks/__tests__/unsetUnloadProtect.test.ts
+++ b/specifyweb/frontend/js_src/lib/hooks/__tests__/unsetUnloadProtect.test.ts
@@ -1,10 +1,11 @@
-import { localized, RA } from "../../utils/types"
+import type { RA } from "../../utils/types";
+import { localized } from "../../utils/types"
 import { unsetUnloadProtect } from "../navigation";
 
 describe("unsetUnloadProtect", ()=>{
     test("removes error message", ()=>{
         let errorMessages: RA<string> = ["custom error message",  "custom error message 2 (should not be removed)"];
-        const setUnloadProtects = (generator: ((old: RA<string>) => RA<string>) | RA<string>) => {
+        const setUnloadProtects = (generator: RA<string> | ((old: RA<string>) => RA<string>)) => {
             errorMessages = typeof generator === 'function' ? generator(errorMessages) : generator;
         }
         unsetUnloadProtect(setUnloadProtects, localized("custom error message"));
@@ -13,7 +14,7 @@ describe("unsetUnloadProtect", ()=>{
 
     test("returns same unload protects if message not found", ()=>{
         let errorMessages: RA<string> = ["custom error message",  "custom error message 2 (should not be removed)"];
-        const setUnloadProtects = (generator: ((old: RA<string>) => RA<string>) | RA<string>) => {
+        const setUnloadProtects = (generator: RA<string> | ((old: RA<string>) => RA<string>)) => {
             errorMessages = typeof generator === 'function' ? generator(errorMessages) : generator;
         }
         unsetUnloadProtect(setUnloadProtects, localized("custom error message, does not exist"));


### PR DESCRIPTION
Fixes #6675 

`navigation.tsx` also has other functions, so the code coverage is low. However, `unsetUnloadProtect`'s code coverage is still 100% (since it doesn't appear in uncovered statements)


```
/**
 * Final coverage report:
 *    navigation.tsx              |   40.77 |      100 |      25 |   40.77 | 20-49,56-65,68-88
 */
```
