### PR TITLE
Ensure all Django migrations run in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,11 +16,7 @@ pip_requirements:
 
 django_migrations:
 	$(PYTHON) manage.py base_specify_migration
-	$(PYTHON) manage.py migrate specify
-	$(PYTHON) manage.py migrate notifications
-	$(PYTHON) manage.py migrate workbench
-	$(PYTHON) manage.py migrate accounts
-	$(PYTHON) manage.py migrate permissions
+	$(PYTHON) manage.py migrate
 
 specifyweb/settings/build_version.py: .FORCE
 	if [ -z "${BUILD_VERSION}" ]; \


### PR DESCRIPTION
Fixes #6719

### Testing Instructions

1. **Prepare your environment**  
   - Ensure you have Python, MariaDB, and any other Specify 7 prerequisites installed locally (this can't be tested using Docker)
   - If you have MariaDB in Docker, adjust the database connection accordingly (hostname `mariadb` for instance)

2. **Install and test with `v711-prerelease`**  
   a. Check out the `v711-prerelease` tag or branch:  
   ```bash
   git checkout v711-prerelease
   ```  
   b. Create and activate a Python virtual environment:  
   ```bash
   python3 -m venv venv
   source venv/bin/activate
   ```  
   c. Install the requirements:  
   ```bash
   pip install -r requirements.txt
   ```  
   d. Configure your database connection in `specify_settings.py`.  
   e. Run Django migrations:  
   ```bash
   python manage.py migrate
   ```  
   f. **Verify failure**  
   You should see the `businessrules` migrations fail at 0003, 0004, and 0005:  
   ```diff
   businessrules
   -  [ ] 0003_catnum_constraint
   -  [ ] 0004_catnum_uniquerule
   -  [ ] 0005_cojo
   ```

3. **Install and test with this branch**  
   a. Check out your feature branch:
   ```bash
   git checkout issue-6719
   ```  
   b. Run the migrations again:  
   ```bash
   python manage.py migrate
   ```  
   e. **Verify success**  
   The `businessrules` migrations should now complete without errors:  
   ```diff
   businessrules
   + [X] 0003_catnum_constraint
   + [X] 0004_catnum_uniquerule
   + [X] 0005_cojo
   ```