### PR TITLE
(tests): Add tests for preparations_available_ids

### DIFF
--- a/specifyweb/interactions/tests/test_preps_available_ids.py
+++ b/specifyweb/interactions/tests/test_preps_available_ids.py
@@ -1,0 +1,69 @@
+from specifyweb.interactions.tests.test_preps_available_context import TestPrepsAvailableContext
+
+import json
+
+class TestPrepsAvailableIds(TestPrepsAvailableContext):
+    def test_preps_available_simple(self):
+        
+        expected_response = self._preps_available_simple()
+
+        response = self.client.post(
+            f'/interactions/preparations_available_ids/',
+            data={
+                'id_fld': 'CatalogNumber',
+                'co_ids': json.dumps([co.catalognumber for co in self.collectionobjects])
+            }
+        )
+
+        returned_counts = json.loads(response.content.decode())
+
+        self.assertEqual(response.status_code, 200)
+    
+        self.assertEqual(returned_counts, expected_response)
+
+    def test_preps_available_simple_isloan(self):
+        response = self.client.post(
+            f'/interactions/preparations_available_ids/',
+            data={
+                'id_fld': 'CatalogNumber',
+                'co_ids': json.dumps([co.catalognumber for co in self.collectionobjects]),
+                'isLoan': True
+            }
+        )
+        returned_counts = json.loads(response.content.decode())
+        self.assertEqual(returned_counts, [])
+
+    def test_preps_available_interacted(self):
+
+        expected_response = self._preps_available_interacted()
+
+        response = self.client.post(
+            f'/interactions/preparations_available_ids/',
+            data={
+                'id_fld': 'CatalogNumber',
+                'co_ids': json.dumps([co.catalognumber for co in self.collectionobjects])
+            }
+        )
+
+        returned_counts = json.loads(response.content.decode())
+
+        self.assertEqual(response.status_code, 200)
+    
+        self.assertEqual(returned_counts, expected_response)
+
+    def test_preps_available_interacted_isloan(self):
+        
+        expected_counts = self._preps_available_interacted()
+        response = self.client.post(
+            f'/interactions/preparations_available_ids/',
+            data={
+                'id_fld': 'CatalogNumber',
+                'co_ids': json.dumps([co.catalognumber for co in self.collectionobjects]),
+                'isLoan': True
+            }
+        )
+
+        self.assertEqual(response.status_code, 200)
+
+        returned_counts = json.loads(response.content.decode())
+        self.assertEqual(returned_counts, [expected_counts[i] for i in range(1, 10, 2)])


### PR DESCRIPTION
Fixes #6742 

This was a time sink when adding tests for this view. Should return 500 and an error message, rather than vague 404 (because it is indistinguishable from django not finding the route)

https://github.com/specify/specify7/blob/66693b3ccf46dba679c88607728048640a8e98ab/specifyweb/interactions/views.py#L98-L101
