### PR TITLE
Add `TIME_ZONE` as env variable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -168,6 +168,7 @@ RUN echo \
         "\nCELERY_TASK_DEFAULT_QUEUE = os.getenv('CELERY_TASK_QUEUE', DATABASE_NAME)" \
         "\nANONYMOUS_USER = os.getenv('ANONYMOUS_USER', None)" \
         "\nSPECIFY_CONFIG_DIR = os.environ.get('SPECIFY_CONFIG_DIR', '/opt/Specify/config')" \
+        "\nTIME_ZONE = os.getenv('TIME_ZONE', 'America/Chicago')" \
         "\nhost = os.getenv('CSRF_TRUSTED_ORIGINS', None)" \
         "\nCSRF_TRUSTED_ORIGINS = [origin.strip() for origin in host.split(',')] if host else []" \
         > settings/local_specify_settings.py

--- a/specifyweb/settings/__init__.py
+++ b/specifyweb/settings/__init__.py
@@ -84,7 +84,7 @@ RO_MODE = False
 # timezone as the operating system.
 # If running in a Windows environment this must be set to the same as your
 # system time zone.
-TIME_ZONE = 'America/Chicago'
+TIME_ZONE = os.environ.get('TIME_ZONE', 'America/Chicago')
 
 # Language code for this installation. All choices can be found here:
 # http://www.i18nguy.com/unicode/language-identifiers.html


### PR DESCRIPTION
Fixes #641

### Testing instructions


- [ ] Modify the `TIME_ZONE` variable in the `.env` file to one from this list: https://en.wikipedia.org/wiki/List_of_tz_zones_by_name
- [ ] Verify that the time zone selected is used for system timestamps
	- [ ] `TimestampCreated` and `TimestampModified` for various records, such as
		- [ ] WorkBench/Batch Edit data set timestamps
				<img width="971" alt="image" src="https://github.com/user-attachments/assets/eb2799c0-4ed8-45de-baa2-141ff2376c51" />
        - [ ] Notifications
				<img width="505" alt="image" src="https://github.com/user-attachments/assets/a02b46e6-adef-4e17-8f3d-b8d649d573ee" />
        -  [ ] Records entered via data entry (easiest to check via API)
         ```json
		"timestampcreated": "2025-06-28T12:15:34",
		"timestampmodified": "2025-06-28T12:15:34",
		```
- [ ] Verify the time zone is set in Django via command line
	```bash
	❯ docker exec -it specify7-specify7-1 /bin/bash
		specify@32b007f73376:/opt/specify7$ ve/bin/python manage.py shell -c "from django.conf import settings; print(settings.TIME_ZONE)"
		America/New_York
	```

