### PR TITLE
Remove required for version in datamodel

### DIFF
--- a/specifyweb/specify/datamodel.py
+++ b/specifyweb/specify/datamodel.py
@@ -8741,7 +8741,7 @@ datamodel = Datamodel(tables=[
             Field(name='remarks', column='Remarks', indexed=False, unique=False, required=False, type='text'),
             Field(name='timestampCreated', column='TimestampCreated', indexed=False, unique=False, required=True, type='java.sql.Timestamp'),
             Field(name='timestampModified', column='TimestampModified', indexed=False, unique=False, required=False, type='java.sql.Timestamp'),
-            Field(name='version', column='Version', indexed=False, unique=False, required=Falsee, type='java.lang.Integer')
+            Field(name='version', column='Version', indexed=False, unique=False, required=False, type='java.lang.Integer')
         ],
         indexes=[
             Index(name='SpDataSetAttColMemIDX', column_names=['CollectionMemberID'])

--- a/specifyweb/specify/datamodel.py
+++ b/specifyweb/specify/datamodel.py
@@ -46,7 +46,7 @@ datamodel = Datamodel(tables=[
             Field(name='totalValue', column='TotalValue', indexed=False, unique=False, required=False, type='java.math.BigDecimal'),
             Field(name='type', column='Type', indexed=False, unique=False, required=False, type='java.lang.String', length=32),
             Field(name='verbatimDate', column='VerbatimDate', indexed=False, unique=False, required=False, type='java.lang.String', length=50),
-            Field(name='version', column='Version', indexed=False, unique=False, required=True, type='java.lang.Integer'),
+            Field(name='version', column='Version', indexed=False, unique=False, required=False, type='java.lang.Integer'),
             Field(name='yesNo1', column='YesNo1', indexed=False, unique=False, required=False, type='java.lang.Boolean'),
             Field(name='yesNo2', column='YesNo2', indexed=False, unique=False, required=False, type='java.lang.Boolean')
         ],
@@ -86,7 +86,7 @@ datamodel = Datamodel(tables=[
             Field(name='role', column='Role', indexed=False, unique=False, required=True, type='java.lang.String', length=50),
             Field(name='timestampCreated', column='TimestampCreated', indexed=False, unique=False, required=True, type='java.sql.Timestamp'),
             Field(name='timestampModified', column='TimestampModified', indexed=False, unique=False, required=False, type='java.sql.Timestamp'),
-            Field(name='version', column='Version', indexed=False, unique=False, required=True, type='java.lang.Integer')
+            Field(name='version', column='Version', indexed=False, unique=False, required=False, type='java.lang.Integer')
         ],
         indexes=[
 
@@ -117,7 +117,7 @@ datamodel = Datamodel(tables=[
             Field(name='remarks', column='Remarks', indexed=False, unique=False, required=False, type='text', length=4096),
             Field(name='timestampCreated', column='TimestampCreated', indexed=False, unique=False, required=True, type='java.sql.Timestamp'),
             Field(name='timestampModified', column='TimestampModified', indexed=False, unique=False, required=False, type='java.sql.Timestamp'),
-            Field(name='version', column='Version', indexed=False, unique=False, required=True, type='java.lang.Integer')
+            Field(name='version', column='Version', indexed=False, unique=False, required=False, type='java.lang.Integer')
         ],
         indexes=[
 
@@ -145,7 +145,7 @@ datamodel = Datamodel(tables=[
             Field(name='remarks', column='Remarks', indexed=False, unique=False, required=False, type='text', length=4096),
             Field(name='timestampCreated', column='TimestampCreated', indexed=False, unique=False, required=True, type='java.sql.Timestamp'),
             Field(name='timestampModified', column='TimestampModified', indexed=False, unique=False, required=False, type='java.sql.Timestamp'),
-            Field(name='version', column='Version', indexed=False, unique=False, required=True, type='java.lang.Integer')
+            Field(name='version', column='Version', indexed=False, unique=False, required=False, type='java.lang.Integer')
         ],
         indexes=[
 
@@ -178,7 +178,7 @@ datamodel = Datamodel(tables=[
             Field(name='remarks', column='Remarks', indexed=False, unique=False, required=False, type='text', length=4096),
             Field(name='timestampCreated', column='TimestampCreated', indexed=False, unique=False, required=True, type='java.sql.Timestamp'),
             Field(name='timestampModified', column='TimestampModified', indexed=False, unique=False, required=False, type='java.sql.Timestamp'),
-            Field(name='version', column='Version', indexed=False, unique=False, required=True, type='java.lang.Integer')
+            Field(name='version', column='Version', indexed=False, unique=False, required=False, type='java.lang.Integer')
         ],
         indexes=[
 
@@ -225,7 +225,7 @@ datamodel = Datamodel(tables=[
             Field(name='timestampCreated', column='TimestampCreated', indexed=False, unique=False, required=True, type='java.sql.Timestamp'),
             Field(name='timestampModified', column='TimestampModified', indexed=False, unique=False, required=False, type='java.sql.Timestamp'),
             Field(name='typeOfAddr', column='TypeOfAddr', indexed=False, unique=False, required=False, type='java.lang.String', length=32),
-            Field(name='version', column='Version', indexed=False, unique=False, required=True, type='java.lang.Integer')
+            Field(name='version', column='Version', indexed=False, unique=False, required=False, type='java.lang.Integer')
         ],
         indexes=[
 
@@ -260,7 +260,7 @@ datamodel = Datamodel(tables=[
             Field(name='state', column='State', indexed=False, unique=False, required=False, type='java.lang.String', length=64),
             Field(name='timestampCreated', column='TimestampCreated', indexed=False, unique=False, required=True, type='java.sql.Timestamp'),
             Field(name='timestampModified', column='TimestampModified', indexed=False, unique=False, required=False, type='java.sql.Timestamp'),
-            Field(name='version', column='Version', indexed=False, unique=False, required=True, type='java.lang.Integer')
+            Field(name='version', column='Version', indexed=False, unique=False, required=False, type='java.lang.Integer')
         ],
         indexes=[
 
@@ -321,7 +321,7 @@ datamodel = Datamodel(tables=[
             Field(name='url', column='URL', indexed=False, unique=False, required=False, type='java.lang.String', length=1024),
             Field(name='verbatimDate1', column='VerbatimDate1', indexed=False, unique=False, required=False, type='java.lang.String', length=128),
             Field(name='verbatimDate2', column='VerbatimDate2', indexed=False, unique=False, required=False, type='java.lang.String', length=128),
-            Field(name='version', column='Version', indexed=False, unique=False, required=True, type='java.lang.Integer')
+            Field(name='version', column='Version', indexed=False, unique=False, required=False, type='java.lang.Integer')
         ],
         indexes=[
             Index(name='AgentLastNameIDX', column_names=['LastName']),
@@ -370,7 +370,7 @@ datamodel = Datamodel(tables=[
             Field(name='remarks', column='Remarks', indexed=False, unique=False, required=False, type='text', length=4096),
             Field(name='timestampCreated', column='TimestampCreated', indexed=False, unique=False, required=True, type='java.sql.Timestamp'),
             Field(name='timestampModified', column='TimestampModified', indexed=False, unique=False, required=False, type='java.sql.Timestamp'),
-            Field(name='version', column='Version', indexed=False, unique=False, required=True, type='java.lang.Integer')
+            Field(name='version', column='Version', indexed=False, unique=False, required=False, type='java.lang.Integer')
         ],
         indexes=[
 
@@ -399,7 +399,7 @@ datamodel = Datamodel(tables=[
             Field(name='role', column='Role', indexed=False, unique=False, required=False, type='java.lang.String', length=64),
             Field(name='timestampCreated', column='TimestampCreated', indexed=False, unique=False, required=True, type='java.sql.Timestamp'),
             Field(name='timestampModified', column='TimestampModified', indexed=False, unique=False, required=False, type='java.sql.Timestamp'),
-            Field(name='version', column='Version', indexed=False, unique=False, required=True, type='java.lang.Integer')
+            Field(name='version', column='Version', indexed=False, unique=False, required=False, type='java.lang.Integer')
         ],
         indexes=[
 
@@ -436,7 +436,7 @@ datamodel = Datamodel(tables=[
             Field(name='text5', column='Text5', indexed=False, unique=False, required=False, type='text', length=65535),
             Field(name='timestampCreated', column='TimestampCreated', indexed=False, unique=False, required=True, type='java.sql.Timestamp'),
             Field(name='timestampModified', column='TimestampModified', indexed=False, unique=False, required=False, type='java.sql.Timestamp'),
-            Field(name='version', column='Version', indexed=False, unique=False, required=True, type='java.lang.Integer'),
+            Field(name='version', column='Version', indexed=False, unique=False, required=False, type='java.lang.Integer'),
             Field(name='yesNo1', column='YesNo1', indexed=False, unique=False, required=False, type='java.lang.Boolean'),
             Field(name='yesNo2', column='YesNo2', indexed=False, unique=False, required=False, type='java.lang.Boolean'),
             Field(name='yesNo3', column='YesNo3', indexed=False, unique=False, required=False, type='java.lang.Boolean'),
@@ -469,7 +469,7 @@ datamodel = Datamodel(tables=[
             Field(name='specialtyName', column='SpecialtyName', indexed=False, unique=False, required=True, type='java.lang.String', length=64),
             Field(name='timestampCreated', column='TimestampCreated', indexed=False, unique=False, required=True, type='java.sql.Timestamp'),
             Field(name='timestampModified', column='TimestampModified', indexed=False, unique=False, required=False, type='java.sql.Timestamp'),
-            Field(name='version', column='Version', indexed=False, unique=False, required=True, type='java.lang.Integer')
+            Field(name='version', column='Version', indexed=False, unique=False, required=False, type='java.lang.Integer')
         ],
         indexes=[
 
@@ -498,7 +498,7 @@ datamodel = Datamodel(tables=[
             Field(name='timestampModified', column='TimestampModified', indexed=False, unique=False, required=False, type='java.sql.Timestamp'),
             Field(name='varType', column='VarType', indexed=False, unique=False, required=True, type='java.lang.Byte'),
             Field(name='variant', column='Variant', indexed=False, unique=False, required=False, type='java.lang.String', length=2),
-            Field(name='version', column='Version', indexed=False, unique=False, required=True, type='java.lang.Integer')
+            Field(name='version', column='Version', indexed=False, unique=False, required=False, type='java.lang.Integer')
         ],
         indexes=[
 
@@ -529,7 +529,7 @@ datamodel = Datamodel(tables=[
             Field(name='notes', column='Notes', indexed=False, unique=False, required=False, type='text', length=2048),
             Field(name='timestampCreated', column='TimestampCreated', indexed=False, unique=False, required=True, type='java.sql.Timestamp'),
             Field(name='timestampModified', column='TimestampModified', indexed=False, unique=False, required=False, type='java.sql.Timestamp'),
-            Field(name='version', column='Version', indexed=False, unique=False, required=True, type='java.lang.Integer')
+            Field(name='version', column='Version', indexed=False, unique=False, required=False, type='java.lang.Integer')
         ],
         indexes=[
             Index(name='AppraisalNumberIDX', column_names=['AppraisalNumber']),
@@ -582,7 +582,7 @@ datamodel = Datamodel(tables=[
             Field(name='timestampModified', column='TimestampModified', indexed=False, unique=False, required=False, type='java.sql.Timestamp'),
             Field(name='title', column='Title', indexed=True, unique=False, required=False, type='java.lang.String', length=255),
             Field(name='type', column='Type', indexed=False, unique=False, required=False, type='java.lang.String', length=64),
-            Field(name='version', column='Version', indexed=False, unique=False, required=True, type='java.lang.Integer'),
+            Field(name='version', column='Version', indexed=False, unique=False, required=False, type='java.lang.Integer'),
             Field(name='visibility', column='Visibility', indexed=False, unique=False, required=False, type='java.lang.Byte')
         ],
         indexes=[
@@ -659,7 +659,7 @@ datamodel = Datamodel(tables=[
             Field(name='timestampLastSend', column='TimestampLastSend', indexed=False, unique=False, required=False, type='java.sql.Timestamp'),
             Field(name='timestampLastUpdateCheck', column='TimestampLastUpdateCheck', indexed=False, unique=False, required=False, type='java.sql.Timestamp'),
             Field(name='timestampModified', column='TimestampModified', indexed=False, unique=False, required=False, type='java.sql.Timestamp'),
-            Field(name='version', column='Version', indexed=False, unique=False, required=True, type='java.lang.Integer'),
+            Field(name='version', column='Version', indexed=False, unique=False, required=False, type='java.lang.Integer'),
             Field(name='viewDescription', column='ViewDescription', indexed=False, unique=False, required=False, type='java.lang.String', length=80),
             Field(name='width', column='Width', indexed=False, unique=False, required=False, type='java.lang.Integer', length=24),
             Field(name='yesNo1', column='YesNo1', indexed=False, unique=False, required=False, type='java.lang.Boolean'),
@@ -691,7 +691,7 @@ datamodel = Datamodel(tables=[
             Field(name='timestampCreated', column='TimestampCreated', indexed=False, unique=False, required=True, type='java.sql.Timestamp'),
             Field(name='timestampModified', column='TimestampModified', indexed=False, unique=False, required=False, type='java.sql.Timestamp'),
             Field(name='value', column='Value', indexed=False, unique=False, required=True, type='java.lang.String', length=128),
-            Field(name='version', column='Version', indexed=False, unique=False, required=True, type='java.lang.Integer')
+            Field(name='version', column='Version', indexed=False, unique=False, required=False, type='java.lang.Integer')
         ],
         indexes=[
 
@@ -717,7 +717,7 @@ datamodel = Datamodel(tables=[
             Field(name='tag', column='Tag', indexed=False, unique=False, required=True, type='java.lang.String', length=64),
             Field(name='timestampCreated', column='TimestampCreated', indexed=False, unique=False, required=True, type='java.sql.Timestamp'),
             Field(name='timestampModified', column='TimestampModified', indexed=False, unique=False, required=False, type='java.sql.Timestamp'),
-            Field(name='version', column='Version', indexed=False, unique=False, required=True, type='java.lang.Integer')
+            Field(name='version', column='Version', indexed=False, unique=False, required=False, type='java.lang.Integer')
         ],
         indexes=[
 
@@ -745,7 +745,7 @@ datamodel = Datamodel(tables=[
             Field(name='tableType', column='TableType', indexed=False, unique=False, required=False, type='java.lang.Short'),
             Field(name='timestampCreated', column='TimestampCreated', indexed=False, unique=False, required=True, type='java.sql.Timestamp'),
             Field(name='timestampModified', column='TimestampModified', indexed=False, unique=False, required=False, type='java.sql.Timestamp'),
-            Field(name='version', column='Version', indexed=False, unique=False, required=True, type='java.lang.Integer')
+            Field(name='version', column='Version', indexed=False, unique=False, required=False, type='java.lang.Integer')
         ],
         indexes=[
 
@@ -775,7 +775,7 @@ datamodel = Datamodel(tables=[
             Field(name='remarks', column='Remarks', indexed=False, unique=False, required=False, type='text', length=4096),
             Field(name='timestampCreated', column='TimestampCreated', indexed=False, unique=False, required=True, type='java.sql.Timestamp'),
             Field(name='timestampModified', column='TimestampModified', indexed=False, unique=False, required=False, type='java.sql.Timestamp'),
-            Field(name='version', column='Version', indexed=False, unique=False, required=True, type='java.lang.Integer')
+            Field(name='version', column='Version', indexed=False, unique=False, required=False, type='java.lang.Integer')
         ],
         indexes=[
 
@@ -808,7 +808,7 @@ datamodel = Datamodel(tables=[
             Field(name='tableNumber', column='TableNumber', indexed=False, unique=False, required=True, type='java.lang.Integer'),
             Field(name='timestampCreated', column='TimestampCreated', indexed=False, unique=False, required=True, type='java.sql.Timestamp'),
             Field(name='timestampModified', column='TimestampModified', indexed=False, unique=False, required=False, type='java.sql.Timestamp'),
-            Field(name='version', column='Version', indexed=False, unique=False, required=True, type='java.lang.Integer')
+            Field(name='version', column='Version', indexed=False, unique=False, required=False, type='java.lang.Integer')
         ],
         indexes=[
             Index(name='SchemeNameIDX', column_names=['SchemeName'])
@@ -853,7 +853,7 @@ datamodel = Datamodel(tables=[
             Field(name='text2', column='Text2', indexed=False, unique=False, required=False, type='text', length=65535),
             Field(name='timestampCreated', column='TimestampCreated', indexed=False, unique=False, required=True, type='java.sql.Timestamp'),
             Field(name='timestampModified', column='TimestampModified', indexed=False, unique=False, required=False, type='java.sql.Timestamp'),
-            Field(name='version', column='Version', indexed=False, unique=False, required=True, type='java.lang.Integer'),
+            Field(name='version', column='Version', indexed=False, unique=False, required=False, type='java.lang.Integer'),
             Field(name='yesNo1', column='YesNo1', indexed=False, unique=False, required=False, type='java.lang.Boolean'),
             Field(name='yesNo2', column='YesNo2', indexed=False, unique=False, required=False, type='java.lang.Boolean')
         ],
@@ -890,7 +890,7 @@ datamodel = Datamodel(tables=[
             Field(name='role', column='Role', indexed=False, unique=False, required=True, type='java.lang.String', length=32),
             Field(name='timestampCreated', column='TimestampCreated', indexed=False, unique=False, required=True, type='java.sql.Timestamp'),
             Field(name='timestampModified', column='TimestampModified', indexed=False, unique=False, required=False, type='java.sql.Timestamp'),
-            Field(name='version', column='Version', indexed=False, unique=False, required=True, type='java.lang.Integer')
+            Field(name='version', column='Version', indexed=False, unique=False, required=False, type='java.lang.Integer')
         ],
         indexes=[
             Index(name='BorColMemIDX2', column_names=['CollectionMemberID'])
@@ -920,7 +920,7 @@ datamodel = Datamodel(tables=[
             Field(name='remarks', column='Remarks', indexed=False, unique=False, required=False, type='text', length=4096),
             Field(name='timestampCreated', column='TimestampCreated', indexed=False, unique=False, required=True, type='java.sql.Timestamp'),
             Field(name='timestampModified', column='TimestampModified', indexed=False, unique=False, required=False, type='java.sql.Timestamp'),
-            Field(name='version', column='Version', indexed=False, unique=False, required=True, type='java.lang.Integer')
+            Field(name='version', column='Version', indexed=False, unique=False, required=False, type='java.lang.Integer')
         ],
         indexes=[
 
@@ -957,7 +957,7 @@ datamodel = Datamodel(tables=[
             Field(name='text2', column='Text2', indexed=False, unique=False, required=False, type='text', length=6667),
             Field(name='timestampCreated', column='TimestampCreated', indexed=False, unique=False, required=True, type='java.sql.Timestamp'),
             Field(name='timestampModified', column='TimestampModified', indexed=False, unique=False, required=False, type='java.sql.Timestamp'),
-            Field(name='version', column='Version', indexed=False, unique=False, required=True, type='java.lang.Integer')
+            Field(name='version', column='Version', indexed=False, unique=False, required=False, type='java.lang.Integer')
         ],
         indexes=[
             Index(name='BorMaterialNumberIDX', column_names=['MaterialNumber']),
@@ -990,7 +990,7 @@ datamodel = Datamodel(tables=[
             Field(name='returnedDate', column='ReturnedDate', indexed=True, unique=False, required=False, type='java.util.Calendar'),
             Field(name='timestampCreated', column='TimestampCreated', indexed=False, unique=False, required=True, type='java.sql.Timestamp'),
             Field(name='timestampModified', column='TimestampModified', indexed=False, unique=False, required=False, type='java.sql.Timestamp'),
-            Field(name='version', column='Version', indexed=False, unique=False, required=True, type='java.lang.Integer')
+            Field(name='version', column='Version', indexed=False, unique=False, required=False, type='java.lang.Integer')
         ],
         indexes=[
             Index(name='BorrowReturnedDateIDX', column_names=['ReturnedDate']),
@@ -1051,7 +1051,7 @@ datamodel = Datamodel(tables=[
             Field(name='uniqueIdentifier', column='UniqueIdentifier', indexed=True, unique=False, required=False, type='java.lang.String', length=128),
             Field(name='verbatimDate', column='VerbatimDate', indexed=False, unique=False, required=False, type='java.lang.String', length=50),
             Field(name='verbatimLocality', column='VerbatimLocality', indexed=False, unique=False, required=False, type='text', length=2048),
-            Field(name='version', column='Version', indexed=False, unique=False, required=True, type='java.lang.Integer'),
+            Field(name='version', column='Version', indexed=False, unique=False, required=False, type='java.lang.Integer'),
             Field(name='visibility', column='Visibility', indexed=False, unique=False, required=False, type='java.lang.Byte')
         ],
         indexes=[
@@ -1096,7 +1096,7 @@ datamodel = Datamodel(tables=[
             Field(name='remarks', column='Remarks', indexed=False, unique=False, required=False, type='text', length=4096),
             Field(name='timestampCreated', column='TimestampCreated', indexed=False, unique=False, required=True, type='java.sql.Timestamp'),
             Field(name='timestampModified', column='TimestampModified', indexed=False, unique=False, required=False, type='java.sql.Timestamp'),
-            Field(name='version', column='Version', indexed=False, unique=False, required=True, type='java.lang.Integer')
+            Field(name='version', column='Version', indexed=False, unique=False, required=False, type='java.lang.Integer')
         ],
         indexes=[
             Index(name='CEAColMemIDX', column_names=['CollectionMemberID'])
@@ -1126,7 +1126,7 @@ datamodel = Datamodel(tables=[
             Field(name='strValue', column='StrValue', indexed=False, unique=False, required=False, type='java.lang.String', length=255),
             Field(name='timestampCreated', column='TimestampCreated', indexed=False, unique=False, required=True, type='java.sql.Timestamp'),
             Field(name='timestampModified', column='TimestampModified', indexed=False, unique=False, required=False, type='java.sql.Timestamp'),
-            Field(name='version', column='Version', indexed=False, unique=False, required=True, type='java.lang.Integer')
+            Field(name='version', column='Version', indexed=False, unique=False, required=False, type='java.lang.Integer')
         ],
         indexes=[
             Index(name='COLEVATColMemIDX', column_names=['CollectionMemberID'])
@@ -1192,7 +1192,7 @@ datamodel = Datamodel(tables=[
             Field(name='text9', column='Text9', indexed=False, unique=False, required=False, type='text', length=65535),
             Field(name='timestampCreated', column='TimestampCreated', indexed=False, unique=False, required=True, type='java.sql.Timestamp'),
             Field(name='timestampModified', column='TimestampModified', indexed=False, unique=False, required=False, type='java.sql.Timestamp'),
-            Field(name='version', column='Version', indexed=False, unique=False, required=True, type='java.lang.Integer'),
+            Field(name='version', column='Version', indexed=False, unique=False, required=False, type='java.lang.Integer'),
             Field(name='yesNo1', column='YesNo1', indexed=False, unique=False, required=False, type='java.lang.Boolean'),
             Field(name='yesNo2', column='YesNo2', indexed=False, unique=False, required=False, type='java.lang.Boolean'),
             Field(name='yesNo3', column='YesNo3', indexed=False, unique=False, required=False, type='java.lang.Boolean'),
@@ -1224,7 +1224,7 @@ datamodel = Datamodel(tables=[
             Field(name='remarks', column='Remarks', indexed=False, unique=False, required=False, type='text', length=4096),
             Field(name='timestampCreated', column='TimestampCreated', indexed=False, unique=False, required=True, type='java.sql.Timestamp'),
             Field(name='timestampModified', column='TimestampModified', indexed=False, unique=False, required=False, type='java.sql.Timestamp'),
-            Field(name='version', column='Version', indexed=False, unique=False, required=True, type='java.lang.Integer')
+            Field(name='version', column='Version', indexed=False, unique=False, required=False, type='java.lang.Integer')
         ],
         indexes=[
 
@@ -1279,7 +1279,7 @@ datamodel = Datamodel(tables=[
             Field(name='text9', column='Text9', indexed=False, unique=False, required=False, type='text', length=65535),
             Field(name='timestampCreated', column='TimestampCreated', indexed=False, unique=False, required=True, type='java.sql.Timestamp'),
             Field(name='timestampModified', column='TimestampModified', indexed=False, unique=False, required=False, type='java.sql.Timestamp'),
-            Field(name='version', column='Version', indexed=False, unique=False, required=True, type='java.lang.Integer'),
+            Field(name='version', column='Version', indexed=False, unique=False, required=False, type='java.lang.Integer'),
             Field(name='vessel', column='Vessel', indexed=False, unique=False, required=False, type='java.lang.String', length=250),
             Field(name='yesNo1', column='YesNo1', indexed=False, unique=False, required=False, type='java.lang.Boolean'),
             Field(name='yesNo2', column='YesNo2', indexed=False, unique=False, required=False, type='java.lang.Boolean')
@@ -1320,7 +1320,7 @@ datamodel = Datamodel(tables=[
             Field(name='remarks', column='Remarks', indexed=False, unique=False, required=False, type='text', length=4096),
             Field(name='timestampCreated', column='TimestampCreated', indexed=False, unique=False, required=True, type='java.sql.Timestamp'),
             Field(name='timestampModified', column='TimestampModified', indexed=False, unique=False, required=False, type='java.sql.Timestamp'),
-            Field(name='version', column='Version', indexed=False, unique=False, required=True, type='java.lang.Integer')
+            Field(name='version', column='Version', indexed=False, unique=False, required=False, type='java.lang.Integer')
         ],
         indexes=[
             Index(name='CTAColMemIDX', column_names=['CollectionMemberID'])
@@ -1388,7 +1388,7 @@ datamodel = Datamodel(tables=[
             Field(name='text9', column='Text9', indexed=False, unique=False, required=False, type='java.lang.String', length=50),
             Field(name='timestampCreated', column='TimestampCreated', indexed=False, unique=False, required=True, type='java.sql.Timestamp'),
             Field(name='timestampModified', column='TimestampModified', indexed=False, unique=False, required=False, type='java.sql.Timestamp'),
-            Field(name='version', column='Version', indexed=False, unique=False, required=True, type='java.lang.Integer'),
+            Field(name='version', column='Version', indexed=False, unique=False, required=False, type='java.lang.Integer'),
             Field(name='yesNo1', column='YesNo1', indexed=False, unique=False, required=False, type='java.lang.Boolean'),
             Field(name='yesNo2', column='YesNo2', indexed=False, unique=False, required=False, type='java.lang.Boolean'),
             Field(name='yesNo3', column='YesNo3', indexed=False, unique=False, required=False, type='java.lang.Boolean'),
@@ -1419,7 +1419,7 @@ datamodel = Datamodel(tables=[
             Field(name='remarks', column='Remarks', indexed=False, unique=False, required=False, type='text', length=4096),
             Field(name='timestampCreated', column='TimestampCreated', indexed=False, unique=False, required=True, type='java.sql.Timestamp'),
             Field(name='timestampModified', column='TimestampModified', indexed=False, unique=False, required=False, type='java.sql.Timestamp'),
-            Field(name='version', column='Version', indexed=False, unique=False, required=True, type='java.lang.Integer')
+            Field(name='version', column='Version', indexed=False, unique=False, required=False, type='java.lang.Integer')
         ],
         indexes=[
 
@@ -1465,7 +1465,7 @@ datamodel = Datamodel(tables=[
             Field(name='scope', column='Scope', indexed=False, unique=False, required=False, type='text', length=2048),
             Field(name='timestampCreated', column='TimestampCreated', indexed=False, unique=False, required=True, type='java.sql.Timestamp'),
             Field(name='timestampModified', column='TimestampModified', indexed=False, unique=False, required=False, type='java.sql.Timestamp'),
-            Field(name='version', column='Version', indexed=False, unique=False, required=True, type='java.lang.Integer'),
+            Field(name='version', column='Version', indexed=False, unique=False, required=False, type='java.lang.Integer'),
             Field(name='webPortalURI', column='WebPortalURI', indexed=False, unique=False, required=False, type='java.lang.String', length=255),
             Field(name='webSiteURI', column='WebSiteURI', indexed=False, unique=False, required=False, type='java.lang.String', length=255)
         ],
@@ -1555,7 +1555,7 @@ datamodel = Datamodel(tables=[
             Field(name='timestampModified', column='TimestampModified', indexed=False, unique=False, required=False, type='java.sql.Timestamp'),
             Field(name='totalValue', column='TotalValue', indexed=False, unique=False, required=False, type='java.math.BigDecimal'),
             Field(name='uniqueIdentifier', column='UniqueIdentifier', indexed=True, unique=False, required=False, type='java.lang.String', length=128),
-            Field(name='version', column='Version', indexed=False, unique=False, required=True, type='java.lang.Integer'),
+            Field(name='version', column='Version', indexed=False, unique=False, required=False, type='java.lang.Integer'),
             Field(name='visibility', column='Visibility', indexed=False, unique=False, required=False, type='java.lang.Byte', length=10),
             Field(name='yesNo1', column='YesNo1', indexed=False, unique=False, required=False, type='java.lang.Boolean'),
             Field(name='yesNo2', column='YesNo2', indexed=False, unique=False, required=False, type='java.lang.Boolean'),
@@ -1635,7 +1635,7 @@ datamodel = Datamodel(tables=[
             Field(name='remarks', column='Remarks', indexed=False, unique=False, required=False, type='text', length=4096),
             Field(name='timestampCreated', column='TimestampCreated', indexed=False, unique=False, required=True, type='java.sql.Timestamp'),
             Field(name='timestampModified', column='TimestampModified', indexed=False, unique=False, required=False, type='java.sql.Timestamp'),
-            Field(name='version', column='Version', indexed=False, unique=False, required=True, type='java.lang.Integer')
+            Field(name='version', column='Version', indexed=False, unique=False, required=False, type='java.lang.Integer')
         ],
         indexes=[
             Index(name='COLOBJATTColMemIDX', column_names=['CollectionMemberID'])
@@ -1665,7 +1665,7 @@ datamodel = Datamodel(tables=[
             Field(name='strValue', column='StrValue', indexed=False, unique=False, required=False, type='java.lang.String', length=255),
             Field(name='timestampCreated', column='TimestampCreated', indexed=False, unique=False, required=True, type='java.sql.Timestamp'),
             Field(name='timestampModified', column='TimestampModified', indexed=False, unique=False, required=False, type='java.sql.Timestamp'),
-            Field(name='version', column='Version', indexed=False, unique=False, required=True, type='java.lang.Integer')
+            Field(name='version', column='Version', indexed=False, unique=False, required=False, type='java.lang.Integer')
         ],
         indexes=[
             Index(name='COLOBJATRSColMemIDX', column_names=['CollectionMemberID'])
@@ -1791,7 +1791,7 @@ datamodel = Datamodel(tables=[
             Field(name='timestampCreated', column='TimestampCreated', indexed=False, unique=False, required=True, type='java.sql.Timestamp'),
             Field(name='timestampModified', column='TimestampModified', indexed=False, unique=False, required=False, type='java.sql.Timestamp'),
             Field(name='topDistance', column='TopDistance', indexed=False, unique=False, required=False, type='java.math.BigDecimal'),
-            Field(name='version', column='Version', indexed=False, unique=False, required=True, type='java.lang.Integer'),
+            Field(name='version', column='Version', indexed=False, unique=False, required=False, type='java.lang.Integer'),
             Field(name='yesNo1', column='YesNo1', indexed=False, unique=False, required=False, type='java.lang.Boolean'),
             Field(name='yesNo10', column='YesNo10', indexed=False, unique=False, required=False, type='java.lang.Boolean'),
             Field(name='yesNo11', column='YesNo11', indexed=False, unique=False, required=False, type='java.lang.Boolean'),
@@ -1842,7 +1842,7 @@ datamodel = Datamodel(tables=[
             Field(name='remarks', column='Remarks', indexed=False, unique=False, required=False, type='text', length=4096),
             Field(name='timestampCreated', column='TimestampCreated', indexed=False, unique=False, required=True, type='java.sql.Timestamp'),
             Field(name='timestampModified', column='TimestampModified', indexed=False, unique=False, required=False, type='java.sql.Timestamp'),
-            Field(name='version', column='Version', indexed=False, unique=False, required=True, type='java.lang.Integer')
+            Field(name='version', column='Version', indexed=False, unique=False, required=False, type='java.lang.Integer')
         ],
         indexes=[
             Index(name='COCITColMemIDX', column_names=['CollectionMemberID'])
@@ -1990,7 +1990,7 @@ datamodel = Datamodel(tables=[
             Field(name='text9', column='Text9', indexed=False, unique=False, required=False, type='java.lang.String', length=50),
             Field(name='timestampCreated', column='TimestampCreated', indexed=False, unique=False, required=True, type='java.sql.Timestamp'),
             Field(name='timestampModified', column='TimestampModified', indexed=False, unique=False, required=False, type='java.sql.Timestamp'),
-            Field(name='version', column='Version', indexed=False, unique=False, required=True, type='java.lang.Integer'),
+            Field(name='version', column='Version', indexed=False, unique=False, required=False, type='java.lang.Integer'),
             Field(name='yesNo1', column='YesNo1', indexed=False, unique=False, required=False, type='java.lang.Boolean'),
             Field(name='yesNo10', column='YesNo10', indexed=False, unique=False, required=False, type='java.lang.Boolean'),
             Field(name='yesNo11', column='YesNo11', indexed=False, unique=False, required=False, type='java.lang.Boolean'),
@@ -2058,7 +2058,7 @@ datamodel = Datamodel(tables=[
             Field(name='remarks', column='Remarks', indexed=False, unique=False, required=False, type='java.lang.String', length=4096),
             Field(name='timestampCreated', column='TimestampCreated', indexed=False, unique=False, required=True, type='java.sql.Timestamp'),
             Field(name='timestampModified', column='TimestampModified', indexed=False, unique=False, required=False, type='java.sql.Timestamp'),
-            Field(name='version', column='Version', indexed=False, unique=False, required=True, type='java.lang.Integer')
+            Field(name='version', column='Version', indexed=False, unique=False, required=False, type='java.lang.Integer')
         ],
         indexes=[
 
@@ -2087,7 +2087,7 @@ datamodel = Datamodel(tables=[
             Field(name='text2', column='Text2', indexed=False, unique=False, required=False, type='java.lang.String', length=32),
             Field(name='timestampCreated', column='TimestampCreated', indexed=False, unique=False, required=True, type='java.sql.Timestamp'),
             Field(name='timestampModified', column='TimestampModified', indexed=False, unique=False, required=False, type='java.sql.Timestamp'),
-            Field(name='version', column='Version', indexed=False, unique=False, required=True, type='java.lang.Integer')
+            Field(name='version', column='Version', indexed=False, unique=False, required=False, type='java.lang.Integer')
         ],
         indexes=[
 
@@ -2120,7 +2120,7 @@ datamodel = Datamodel(tables=[
             Field(name='text2', column='Text2', indexed=False, unique=False, required=False, type='text', length=65535),
             Field(name='timestampCreated', column='TimestampCreated', indexed=False, unique=False, required=True, type='java.sql.Timestamp'),
             Field(name='timestampModified', column='TimestampModified', indexed=False, unique=False, required=False, type='java.sql.Timestamp'),
-            Field(name='version', column='Version', indexed=False, unique=False, required=True, type='java.lang.Integer'),
+            Field(name='version', column='Version', indexed=False, unique=False, required=False, type='java.lang.Integer'),
             Field(name='yesNo1', column='YesNo1', indexed=False, unique=False, required=False, type='java.lang.Boolean'),
             Field(name='yesNo2', column='YesNo2', indexed=False, unique=False, required=False, type='java.lang.Boolean')
         ],
@@ -2155,7 +2155,7 @@ datamodel = Datamodel(tables=[
             Field(name='timestampCreated', column='TimestampCreated', indexed=False, unique=False, required=True, type='java.sql.Timestamp'),
             Field(name='timestampModified', column='TimestampModified', indexed=False, unique=False, required=False, type='java.sql.Timestamp'),
             Field(name='variant', column='Variant', indexed=False, unique=False, required=False, type='java.lang.String', length=2),
-            Field(name='version', column='Version', indexed=False, unique=False, required=True, type='java.lang.Integer')
+            Field(name='version', column='Version', indexed=False, unique=False, required=False, type='java.lang.Integer')
         ],
         indexes=[
             Index(name='CommonNameTxNameIDX', column_names=['Name']),
@@ -2190,7 +2190,7 @@ datamodel = Datamodel(tables=[
             Field(name='text2', column='Text2', indexed=False, unique=False, required=False, type='text', length=65535),
             Field(name='timestampCreated', column='TimestampCreated', indexed=False, unique=False, required=True, type='java.sql.Timestamp'),
             Field(name='timestampModified', column='TimestampModified', indexed=False, unique=False, required=False, type='java.sql.Timestamp'),
-            Field(name='version', column='Version', indexed=False, unique=False, required=True, type='java.lang.Integer'),
+            Field(name='version', column='Version', indexed=False, unique=False, required=False, type='java.lang.Integer'),
             Field(name='yesNo1', column='YesNo1', indexed=False, unique=False, required=False, type='java.lang.Boolean'),
             Field(name='yesNo2', column='YesNo2', indexed=False, unique=False, required=False, type='java.lang.Boolean')
         ],
@@ -2255,7 +2255,7 @@ datamodel = Datamodel(tables=[
             Field(name='timestampCreated', column='TimestampCreated', indexed=False, unique=False, required=True, type='java.sql.Timestamp'),
             Field(name='timestampModified', column='TimestampModified', indexed=False, unique=False, required=False, type='java.sql.Timestamp'),
             Field(name='units', column='Units', indexed=False, unique=False, required=False, type='java.lang.String', length=16),
-            Field(name='version', column='Version', indexed=False, unique=False, required=True, type='java.lang.Integer'),
+            Field(name='version', column='Version', indexed=False, unique=False, required=False, type='java.lang.Integer'),
             Field(name='width', column='Width', indexed=False, unique=False, required=False, type='java.math.BigDecimal'),
             Field(name='yesNo1', column='YesNo1', indexed=False, unique=False, required=False, type='java.lang.Boolean'),
             Field(name='yesNo2', column='YesNo2', indexed=False, unique=False, required=False, type='java.lang.Boolean'),
@@ -2292,7 +2292,7 @@ datamodel = Datamodel(tables=[
             Field(name='remarks', column='Remarks', indexed=False, unique=False, required=False, type='text', length=4096),
             Field(name='timestampCreated', column='TimestampCreated', indexed=False, unique=False, required=True, type='java.sql.Timestamp'),
             Field(name='timestampModified', column='TimestampModified', indexed=False, unique=False, required=False, type='java.sql.Timestamp'),
-            Field(name='version', column='Version', indexed=False, unique=False, required=True, type='java.lang.Integer')
+            Field(name='version', column='Version', indexed=False, unique=False, required=False, type='java.lang.Integer')
         ],
         indexes=[
 
@@ -2338,7 +2338,7 @@ datamodel = Datamodel(tables=[
             Field(name='treatmentCompDate', column='TreatmentCompDate', indexed=False, unique=False, required=False, type='java.util.Calendar'),
             Field(name='treatmentCompDatePrecision', column='TreatmentCompDatePrecision', indexed=False, unique=False, required=False, type='java.lang.Byte'),
             Field(name='treatmentReport', column='TreatmentReport', indexed=False, unique=False, required=False, type='text', length=8192),
-            Field(name='version', column='Version', indexed=False, unique=False, required=True, type='java.lang.Integer'),
+            Field(name='version', column='Version', indexed=False, unique=False, required=False, type='java.lang.Integer'),
             Field(name='yesNo1', column='YesNo1', indexed=False, unique=False, required=False, type='java.lang.Boolean'),
             Field(name='yesNo2', column='YesNo2', indexed=False, unique=False, required=False, type='java.lang.Boolean')
         ],
@@ -2372,7 +2372,7 @@ datamodel = Datamodel(tables=[
             Field(name='remarks', column='Remarks', indexed=False, unique=False, required=False, type='text', length=4096),
             Field(name='timestampCreated', column='TimestampCreated', indexed=False, unique=False, required=True, type='java.sql.Timestamp'),
             Field(name='timestampModified', column='TimestampModified', indexed=False, unique=False, required=False, type='java.sql.Timestamp'),
-            Field(name='version', column='Version', indexed=False, unique=False, required=True, type='java.lang.Integer')
+            Field(name='version', column='Version', indexed=False, unique=False, required=False, type='java.lang.Integer')
         ],
         indexes=[
 
@@ -2404,7 +2404,7 @@ datamodel = Datamodel(tables=[
             Field(name='timestampCreated', column='TimestampCreated', indexed=False, unique=False, required=True, type='java.sql.Timestamp'),
             Field(name='timestampModified', column='TimestampModified', indexed=False, unique=False, required=False, type='java.sql.Timestamp'),
             Field(name='type', column='Type', indexed=False, unique=False, required=False, type='java.lang.Short'),
-            Field(name='version', column='Version', indexed=False, unique=False, required=True, type='java.lang.Integer')
+            Field(name='version', column='Version', indexed=False, unique=False, required=False, type='java.lang.Integer')
         ],
         indexes=[
             Index(name='ContainerNameIDX', column_names=['Name']),
@@ -2458,7 +2458,7 @@ datamodel = Datamodel(tables=[
             Field(name='text2', column='Text2', indexed=False, unique=False, required=False, type='text', length=4096),
             Field(name='timestampCreated', column='TimestampCreated', indexed=False, unique=False, required=True, type='java.sql.Timestamp'),
             Field(name='timestampModified', column='TimestampModified', indexed=False, unique=False, required=False, type='java.sql.Timestamp'),
-            Field(name='version', column='Version', indexed=False, unique=False, required=True, type='java.lang.Integer'),
+            Field(name='version', column='Version', indexed=False, unique=False, required=False, type='java.lang.Integer'),
             Field(name='yesNo1', column='YesNo1', indexed=False, unique=False, required=False, type='java.lang.Boolean'),
             Field(name='yesNo2', column='YesNo2', indexed=False, unique=False, required=False, type='java.lang.Boolean')
         ],
@@ -2512,7 +2512,7 @@ datamodel = Datamodel(tables=[
             Field(name='timestampCreated', column='TimestampCreated', indexed=False, unique=False, required=True, type='java.sql.Timestamp'),
             Field(name='timestampModified', column='TimestampModified', indexed=False, unique=False, required=False, type='java.sql.Timestamp'),
             Field(name='totalResidues', column='TotalResidues', indexed=False, unique=False, required=False, type='java.lang.Integer'),
-            Field(name='version', column='Version', indexed=False, unique=False, required=True, type='java.lang.Integer'),
+            Field(name='version', column='Version', indexed=False, unique=False, required=False, type='java.lang.Integer'),
             Field(name='yesNo1', column='YesNo1', indexed=False, unique=False, required=False, type='java.lang.Boolean'),
             Field(name='yesNo2', column='YesNo2', indexed=False, unique=False, required=False, type='java.lang.Boolean'),
             Field(name='yesNo3', column='YesNo3', indexed=False, unique=False, required=False, type='java.lang.Boolean')
@@ -2551,7 +2551,7 @@ datamodel = Datamodel(tables=[
             Field(name='remarks', column='Remarks', indexed=False, unique=False, required=False, type='text', length=4096),
             Field(name='timestampCreated', column='TimestampCreated', indexed=False, unique=False, required=True, type='java.sql.Timestamp'),
             Field(name='timestampModified', column='TimestampModified', indexed=False, unique=False, required=False, type='java.sql.Timestamp'),
-            Field(name='version', column='Version', indexed=False, unique=False, required=True, type='java.lang.Integer')
+            Field(name='version', column='Version', indexed=False, unique=False, required=False, type='java.lang.Integer')
         ],
         indexes=[
 
@@ -2605,7 +2605,7 @@ datamodel = Datamodel(tables=[
             Field(name='timestampCreated', column='TimestampCreated', indexed=False, unique=False, required=True, type='java.sql.Timestamp'),
             Field(name='timestampModified', column='TimestampModified', indexed=False, unique=False, required=False, type='java.sql.Timestamp'),
             Field(name='traceFileName', column='TraceFileName', indexed=False, unique=False, required=False, type='java.lang.String', length=32),
-            Field(name='version', column='Version', indexed=False, unique=False, required=True, type='java.lang.Integer'),
+            Field(name='version', column='Version', indexed=False, unique=False, required=False, type='java.lang.Integer'),
             Field(name='yesNo1', column='YesNo1', indexed=False, unique=False, required=False, type='java.lang.Boolean'),
             Field(name='yesNo2', column='YesNo2', indexed=False, unique=False, required=False, type='java.lang.Boolean'),
             Field(name='yesNo3', column='YesNo3', indexed=False, unique=False, required=False, type='java.lang.Boolean')
@@ -2640,7 +2640,7 @@ datamodel = Datamodel(tables=[
             Field(name='remarks', column='Remarks', indexed=False, unique=False, required=False, type='text', length=4096),
             Field(name='timestampCreated', column='TimestampCreated', indexed=False, unique=False, required=True, type='java.sql.Timestamp'),
             Field(name='timestampModified', column='TimestampModified', indexed=False, unique=False, required=False, type='java.sql.Timestamp'),
-            Field(name='version', column='Version', indexed=False, unique=False, required=True, type='java.lang.Integer')
+            Field(name='version', column='Version', indexed=False, unique=False, required=False, type='java.lang.Integer')
         ],
         indexes=[
 
@@ -2676,7 +2676,7 @@ datamodel = Datamodel(tables=[
             Field(name='text2', column='Text2', indexed=False, unique=False, required=False, type='text', length=65535),
             Field(name='timestampCreated', column='TimestampCreated', indexed=False, unique=False, required=True, type='java.sql.Timestamp'),
             Field(name='timestampModified', column='TimestampModified', indexed=False, unique=False, required=False, type='java.sql.Timestamp'),
-            Field(name='version', column='Version', indexed=False, unique=False, required=True, type='java.lang.Integer'),
+            Field(name='version', column='Version', indexed=False, unique=False, required=False, type='java.lang.Integer'),
             Field(name='yesNo1', column='YesNo1', indexed=False, unique=False, required=False, type='java.lang.Boolean'),
             Field(name='yesNo2', column='YesNo2', indexed=False, unique=False, required=False, type='java.lang.Boolean')
         ],
@@ -2705,7 +2705,7 @@ datamodel = Datamodel(tables=[
             Field(name='name', column='Name', indexed=False, unique=False, required=False, type='java.lang.String', length=50),
             Field(name='timestampCreated', column='TimestampCreated', indexed=False, unique=False, required=True, type='java.sql.Timestamp'),
             Field(name='timestampModified', column='TimestampModified', indexed=False, unique=False, required=False, type='java.sql.Timestamp'),
-            Field(name='version', column='Version', indexed=False, unique=False, required=True, type='java.lang.Integer')
+            Field(name='version', column='Version', indexed=False, unique=False, required=False, type='java.lang.Integer')
         ],
         indexes=[
 
@@ -2750,7 +2750,7 @@ datamodel = Datamodel(tables=[
             Field(name='timestampCreated', column='TimestampCreated', indexed=False, unique=False, required=True, type='java.sql.Timestamp'),
             Field(name='timestampModified', column='TimestampModified', indexed=False, unique=False, required=False, type='java.sql.Timestamp'),
             Field(name='type', column='Type', indexed=False, unique=False, required=False, type='java.lang.String', length=64),
-            Field(name='version', column='Version', indexed=False, unique=False, required=True, type='java.lang.Integer'),
+            Field(name='version', column='Version', indexed=False, unique=False, required=False, type='java.lang.Integer'),
             Field(name='yesNo1', column='YesNo1', indexed=False, unique=False, required=False, type='java.lang.Boolean'),
             Field(name='yesNo2', column='YesNo2', indexed=False, unique=False, required=False, type='java.lang.Boolean'),
             Field(name='yesNo3', column='YesNo3', indexed=False, unique=False, required=False, type='java.lang.Boolean'),
@@ -2790,7 +2790,7 @@ datamodel = Datamodel(tables=[
             Field(name='role', column='Role', indexed=False, unique=False, required=True, type='java.lang.String', length=50),
             Field(name='timestampCreated', column='TimestampCreated', indexed=False, unique=False, required=True, type='java.sql.Timestamp'),
             Field(name='timestampModified', column='TimestampModified', indexed=False, unique=False, required=False, type='java.sql.Timestamp'),
-            Field(name='version', column='Version', indexed=False, unique=False, required=True, type='java.lang.Integer')
+            Field(name='version', column='Version', indexed=False, unique=False, required=False, type='java.lang.Integer')
         ],
         indexes=[
 
@@ -2820,7 +2820,7 @@ datamodel = Datamodel(tables=[
             Field(name='remarks', column='Remarks', indexed=False, unique=False, required=False, type='text', length=4096),
             Field(name='timestampCreated', column='TimestampCreated', indexed=False, unique=False, required=True, type='java.sql.Timestamp'),
             Field(name='timestampModified', column='TimestampModified', indexed=False, unique=False, required=False, type='java.sql.Timestamp'),
-            Field(name='version', column='Version', indexed=False, unique=False, required=True, type='java.lang.Integer')
+            Field(name='version', column='Version', indexed=False, unique=False, required=False, type='java.lang.Integer')
         ],
         indexes=[
 
@@ -2881,7 +2881,7 @@ datamodel = Datamodel(tables=[
             Field(name='timestampModified', column='TimestampModified', indexed=False, unique=False, required=False, type='java.sql.Timestamp'),
             Field(name='typeStatusName', column='TypeStatusName', indexed=True, unique=False, required=False, type='java.lang.String', length=50),
             Field(name='varQualifier', column='VarQualifier', indexed=False, unique=False, required=False, type='java.lang.String', length=16),
-            Field(name='version', column='Version', indexed=False, unique=False, required=True, type='java.lang.Integer'),
+            Field(name='version', column='Version', indexed=False, unique=False, required=False, type='java.lang.Integer'),
             Field(name='yesNo1', column='YesNo1', indexed=False, unique=False, required=False, type='java.lang.Boolean'),
             Field(name='yesNo2', column='YesNo2', indexed=False, unique=False, required=False, type='java.lang.Boolean'),
             Field(name='yesNo3', column='YesNo3', indexed=False, unique=False, required=False, type='java.lang.Boolean'),
@@ -2927,7 +2927,7 @@ datamodel = Datamodel(tables=[
             Field(name='remarks', column='Remarks', indexed=False, unique=False, required=False, type='text', length=4096),
             Field(name='timestampCreated', column='TimestampCreated', indexed=False, unique=False, required=True, type='java.sql.Timestamp'),
             Field(name='timestampModified', column='TimestampModified', indexed=False, unique=False, required=False, type='java.sql.Timestamp'),
-            Field(name='version', column='Version', indexed=False, unique=False, required=True, type='java.lang.Integer')
+            Field(name='version', column='Version', indexed=False, unique=False, required=False, type='java.lang.Integer')
         ],
         indexes=[
             Index(name='DetCitColMemIDX', column_names=['CollectionMemberID'])
@@ -2957,7 +2957,7 @@ datamodel = Datamodel(tables=[
             Field(name='text2', column='Text2', indexed=False, unique=False, required=False, type='text', length=65535),
             Field(name='timestampCreated', column='TimestampCreated', indexed=False, unique=False, required=True, type='java.sql.Timestamp'),
             Field(name='timestampModified', column='TimestampModified', indexed=False, unique=False, required=False, type='java.sql.Timestamp'),
-            Field(name='version', column='Version', indexed=False, unique=False, required=True, type='java.lang.Integer'),
+            Field(name='version', column='Version', indexed=False, unique=False, required=False, type='java.lang.Integer'),
             Field(name='yesNo1', column='YesNo1', indexed=False, unique=False, required=False, type='java.lang.Boolean'),
             Field(name='yesNo2', column='YesNo2', indexed=False, unique=False, required=False, type='java.lang.Boolean')
         ],
@@ -2991,7 +2991,7 @@ datamodel = Datamodel(tables=[
             Field(name='timestampCreated', column='TimestampCreated', indexed=False, unique=False, required=True, type='java.sql.Timestamp'),
             Field(name='timestampModified', column='TimestampModified', indexed=False, unique=False, required=False, type='java.sql.Timestamp'),
             Field(name='type', column='Type', indexed=False, unique=False, required=False, type='java.lang.String', length=64),
-            Field(name='version', column='Version', indexed=False, unique=False, required=True, type='java.lang.Integer')
+            Field(name='version', column='Version', indexed=False, unique=False, required=False, type='java.lang.Integer')
         ],
         indexes=[
             Index(name='DisciplineNameIDX', column_names=['Name'])
@@ -3038,7 +3038,7 @@ datamodel = Datamodel(tables=[
             Field(name='timestampCreated', column='TimestampCreated', indexed=False, unique=False, required=True, type='java.sql.Timestamp'),
             Field(name='timestampModified', column='TimestampModified', indexed=False, unique=False, required=False, type='java.sql.Timestamp'),
             Field(name='type', column='Type', indexed=False, unique=False, required=False, type='java.lang.String', length=64),
-            Field(name='version', column='Version', indexed=False, unique=False, required=True, type='java.lang.Integer'),
+            Field(name='version', column='Version', indexed=False, unique=False, required=False, type='java.lang.Integer'),
             Field(name='yesNo1', column='YesNo1', indexed=False, unique=False, required=False, type='java.lang.Boolean'),
             Field(name='yesNo2', column='YesNo2', indexed=False, unique=False, required=False, type='java.lang.Boolean')
         ],
@@ -3072,7 +3072,7 @@ datamodel = Datamodel(tables=[
             Field(name='role', column='Role', indexed=False, unique=False, required=True, type='java.lang.String', length=50),
             Field(name='timestampCreated', column='TimestampCreated', indexed=False, unique=False, required=True, type='java.sql.Timestamp'),
             Field(name='timestampModified', column='TimestampModified', indexed=False, unique=False, required=False, type='java.sql.Timestamp'),
-            Field(name='version', column='Version', indexed=False, unique=False, required=True, type='java.lang.Integer')
+            Field(name='version', column='Version', indexed=False, unique=False, required=False, type='java.lang.Integer')
         ],
         indexes=[
 
@@ -3102,7 +3102,7 @@ datamodel = Datamodel(tables=[
             Field(name='remarks', column='Remarks', indexed=False, unique=False, required=False, type='text', length=4096),
             Field(name='timestampCreated', column='TimestampCreated', indexed=False, unique=False, required=True, type='java.sql.Timestamp'),
             Field(name='timestampModified', column='TimestampModified', indexed=False, unique=False, required=False, type='java.sql.Timestamp'),
-            Field(name='version', column='Version', indexed=False, unique=False, required=True, type='java.lang.Integer')
+            Field(name='version', column='Version', indexed=False, unique=False, required=False, type='java.lang.Integer')
         ],
         indexes=[
 
@@ -3131,7 +3131,7 @@ datamodel = Datamodel(tables=[
             Field(name='remarks', column='Remarks', indexed=False, unique=False, required=False, type='text', length=4096),
             Field(name='timestampCreated', column='TimestampCreated', indexed=False, unique=False, required=True, type='java.sql.Timestamp'),
             Field(name='timestampModified', column='TimestampModified', indexed=False, unique=False, required=False, type='java.sql.Timestamp'),
-            Field(name='version', column='Version', indexed=False, unique=False, required=True, type='java.lang.Integer')
+            Field(name='version', column='Version', indexed=False, unique=False, required=False, type='java.lang.Integer')
         ],
         indexes=[
 
@@ -3168,7 +3168,7 @@ datamodel = Datamodel(tables=[
             Field(name='timestampCreated', column='TimestampCreated', indexed=False, unique=False, required=True, type='java.sql.Timestamp'),
             Field(name='timestampModified', column='TimestampModified', indexed=False, unique=False, required=False, type='java.sql.Timestamp'),
             Field(name='uri', column='Uri', indexed=False, unique=False, required=False, type='java.lang.String', length=255),
-            Field(name='version', column='Version', indexed=False, unique=False, required=True, type='java.lang.Integer')
+            Field(name='version', column='Version', indexed=False, unique=False, required=False, type='java.lang.Integer')
         ],
         indexes=[
             Index(name='DivisionNameIDX', column_names=['Name'])
@@ -3211,7 +3211,7 @@ datamodel = Datamodel(tables=[
             Field(name='text2', column='Text2', indexed=False, unique=False, required=False, type='text', length=65535),
             Field(name='timestampCreated', column='TimestampCreated', indexed=False, unique=False, required=True, type='java.sql.Timestamp'),
             Field(name='timestampModified', column='TimestampModified', indexed=False, unique=False, required=False, type='java.sql.Timestamp'),
-            Field(name='version', column='Version', indexed=False, unique=False, required=True, type='java.lang.Integer'),
+            Field(name='version', column='Version', indexed=False, unique=False, required=False, type='java.lang.Integer'),
             Field(name='yesNo1', column='YesNo1', indexed=False, unique=False, required=False, type='java.lang.Boolean'),
             Field(name='yesNo2', column='YesNo2', indexed=False, unique=False, required=False, type='java.lang.Boolean')
         ],
@@ -3248,7 +3248,7 @@ datamodel = Datamodel(tables=[
             Field(name='remarks', column='Remarks', indexed=False, unique=False, required=False, type='text', length=4096),
             Field(name='timestampCreated', column='TimestampCreated', indexed=False, unique=False, required=True, type='java.sql.Timestamp'),
             Field(name='timestampModified', column='TimestampModified', indexed=False, unique=False, required=False, type='java.sql.Timestamp'),
-            Field(name='version', column='Version', indexed=False, unique=False, required=True, type='java.lang.Integer')
+            Field(name='version', column='Version', indexed=False, unique=False, required=False, type='java.lang.Integer')
         ],
         indexes=[
 
@@ -3281,7 +3281,7 @@ datamodel = Datamodel(tables=[
             Field(name='text2', column='Text2', indexed=False, unique=False, required=False, type='text'),
             Field(name='timestampCreated', column='TimestampCreated', indexed=False, unique=False, required=True, type='java.sql.Timestamp'),
             Field(name='timestampModified', column='TimestampModified', indexed=False, unique=False, required=False, type='java.sql.Timestamp'),
-            Field(name='version', column='Version', indexed=False, unique=False, required=True, type='java.lang.Integer')
+            Field(name='version', column='Version', indexed=False, unique=False, required=False, type='java.lang.Integer')
         ],
         indexes=[
             Index(name='ExchgInPrepDspMemIDX', column_names=['DisciplineID'])
@@ -3321,7 +3321,7 @@ datamodel = Datamodel(tables=[
             Field(name='text2', column='Text2', indexed=False, unique=False, required=False, type='text', length=65535),
             Field(name='timestampCreated', column='TimestampCreated', indexed=False, unique=False, required=True, type='java.sql.Timestamp'),
             Field(name='timestampModified', column='TimestampModified', indexed=False, unique=False, required=False, type='java.sql.Timestamp'),
-            Field(name='version', column='Version', indexed=False, unique=False, required=True, type='java.lang.Integer'),
+            Field(name='version', column='Version', indexed=False, unique=False, required=False, type='java.lang.Integer'),
             Field(name='yesNo1', column='YesNo1', indexed=False, unique=False, required=False, type='java.lang.Boolean'),
             Field(name='yesNo2', column='YesNo2', indexed=False, unique=False, required=False, type='java.lang.Boolean')
         ],
@@ -3361,7 +3361,7 @@ datamodel = Datamodel(tables=[
             Field(name='remarks', column='Remarks', indexed=False, unique=False, required=False, type='text', length=4096),
             Field(name='timestampCreated', column='TimestampCreated', indexed=False, unique=False, required=True, type='java.sql.Timestamp'),
             Field(name='timestampModified', column='TimestampModified', indexed=False, unique=False, required=False, type='java.sql.Timestamp'),
-            Field(name='version', column='Version', indexed=False, unique=False, required=True, type='java.lang.Integer')
+            Field(name='version', column='Version', indexed=False, unique=False, required=False, type='java.lang.Integer')
         ],
         indexes=[
 
@@ -3394,7 +3394,7 @@ datamodel = Datamodel(tables=[
             Field(name='text2', column='Text2', indexed=False, unique=False, required=False, type='text'),
             Field(name='timestampCreated', column='TimestampCreated', indexed=False, unique=False, required=True, type='java.sql.Timestamp'),
             Field(name='timestampModified', column='TimestampModified', indexed=False, unique=False, required=False, type='java.sql.Timestamp'),
-            Field(name='version', column='Version', indexed=False, unique=False, required=True, type='java.lang.Integer')
+            Field(name='version', column='Version', indexed=False, unique=False, required=False, type='java.lang.Integer')
         ],
         indexes=[
             Index(name='ExchgOutPrepDspMemIDX', column_names=['DisciplineID'])
@@ -3425,7 +3425,7 @@ datamodel = Datamodel(tables=[
             Field(name='timestampCreated', column='TimestampCreated', indexed=False, unique=False, required=True, type='java.sql.Timestamp'),
             Field(name='timestampModified', column='TimestampModified', indexed=False, unique=False, required=False, type='java.sql.Timestamp'),
             Field(name='title', column='Title', indexed=False, unique=False, required=True, type='java.lang.String', length=255),
-            Field(name='version', column='Version', indexed=False, unique=False, required=True, type='java.lang.Integer')
+            Field(name='version', column='Version', indexed=False, unique=False, required=False, type='java.lang.Integer')
         ],
         indexes=[
 
@@ -3454,7 +3454,7 @@ datamodel = Datamodel(tables=[
             Field(name='number', column='Number', indexed=False, unique=False, required=False, type='java.lang.String', length=16),
             Field(name='timestampCreated', column='TimestampCreated', indexed=False, unique=False, required=True, type='java.sql.Timestamp'),
             Field(name='timestampModified', column='TimestampModified', indexed=False, unique=False, required=False, type='java.sql.Timestamp'),
-            Field(name='version', column='Version', indexed=False, unique=False, required=True, type='java.lang.Integer')
+            Field(name='version', column='Version', indexed=False, unique=False, required=False, type='java.lang.Integer')
         ],
         indexes=[
 
@@ -3483,7 +3483,7 @@ datamodel = Datamodel(tables=[
             Field(name='text2', column='Text2', indexed=False, unique=False, required=False, type='text', length=4096),
             Field(name='timestampCreated', column='TimestampCreated', indexed=False, unique=False, required=True, type='java.sql.Timestamp'),
             Field(name='timestampModified', column='TimestampModified', indexed=False, unique=False, required=False, type='java.sql.Timestamp'),
-            Field(name='version', column='Version', indexed=False, unique=False, required=True, type='java.lang.Integer'),
+            Field(name='version', column='Version', indexed=False, unique=False, required=False, type='java.lang.Integer'),
             Field(name='yesNo1', column='YesNo1', indexed=False, unique=False, required=False, type='java.lang.Boolean'),
             Field(name='yesNo2', column='YesNo2', indexed=False, unique=False, required=False, type='java.lang.Boolean')
         ],
@@ -3517,7 +3517,7 @@ datamodel = Datamodel(tables=[
             Field(name='startDate', column='StartDate', indexed=True, unique=False, required=False, type='java.util.Calendar'),
             Field(name='timestampCreated', column='TimestampCreated', indexed=False, unique=False, required=True, type='java.sql.Timestamp'),
             Field(name='timestampModified', column='TimestampModified', indexed=False, unique=False, required=False, type='java.sql.Timestamp'),
-            Field(name='version', column='Version', indexed=False, unique=False, required=True, type='java.lang.Integer')
+            Field(name='version', column='Version', indexed=False, unique=False, required=False, type='java.lang.Integer')
         ],
         indexes=[
             Index(name='FNBNameIDX', column_names=['Name']),
@@ -3550,7 +3550,7 @@ datamodel = Datamodel(tables=[
             Field(name='remarks', column='Remarks', indexed=False, unique=False, required=False, type='text', length=8192),
             Field(name='timestampCreated', column='TimestampCreated', indexed=False, unique=False, required=True, type='java.sql.Timestamp'),
             Field(name='timestampModified', column='TimestampModified', indexed=False, unique=False, required=False, type='java.sql.Timestamp'),
-            Field(name='version', column='Version', indexed=False, unique=False, required=True, type='java.lang.Integer')
+            Field(name='version', column='Version', indexed=False, unique=False, required=False, type='java.lang.Integer')
         ],
         indexes=[
 
@@ -3580,7 +3580,7 @@ datamodel = Datamodel(tables=[
             Field(name='scanDate', column='ScanDate', indexed=True, unique=False, required=False, type='java.util.Calendar'),
             Field(name='timestampCreated', column='TimestampCreated', indexed=False, unique=False, required=True, type='java.sql.Timestamp'),
             Field(name='timestampModified', column='TimestampModified', indexed=False, unique=False, required=False, type='java.sql.Timestamp'),
-            Field(name='version', column='Version', indexed=False, unique=False, required=True, type='java.lang.Integer')
+            Field(name='version', column='Version', indexed=False, unique=False, required=False, type='java.lang.Integer')
         ],
         indexes=[
             Index(name='FNBPPageNumberIDX', column_names=['PageNumber']),
@@ -3613,7 +3613,7 @@ datamodel = Datamodel(tables=[
             Field(name='remarks', column='Remarks', indexed=False, unique=False, required=False, type='text', length=8192),
             Field(name='timestampCreated', column='TimestampCreated', indexed=False, unique=False, required=True, type='java.sql.Timestamp'),
             Field(name='timestampModified', column='TimestampModified', indexed=False, unique=False, required=False, type='java.sql.Timestamp'),
-            Field(name='version', column='Version', indexed=False, unique=False, required=True, type='java.lang.Integer')
+            Field(name='version', column='Version', indexed=False, unique=False, required=False, type='java.lang.Integer')
         ],
         indexes=[
 
@@ -3645,7 +3645,7 @@ datamodel = Datamodel(tables=[
             Field(name='startDate', column='StartDate', indexed=True, unique=False, required=False, type='java.util.Calendar'),
             Field(name='timestampCreated', column='TimestampCreated', indexed=False, unique=False, required=True, type='java.sql.Timestamp'),
             Field(name='timestampModified', column='TimestampModified', indexed=False, unique=False, required=False, type='java.sql.Timestamp'),
-            Field(name='version', column='Version', indexed=False, unique=False, required=True, type='java.lang.Integer')
+            Field(name='version', column='Version', indexed=False, unique=False, required=False, type='java.lang.Integer')
         ],
         indexes=[
             Index(name='FNBPSStartDateIDX', column_names=['StartDate']),
@@ -3677,7 +3677,7 @@ datamodel = Datamodel(tables=[
             Field(name='remarks', column='Remarks', indexed=False, unique=False, required=False, type='text', length=8192),
             Field(name='timestampCreated', column='TimestampCreated', indexed=False, unique=False, required=True, type='java.sql.Timestamp'),
             Field(name='timestampModified', column='TimestampModified', indexed=False, unique=False, required=False, type='java.sql.Timestamp'),
-            Field(name='version', column='Version', indexed=False, unique=False, required=True, type='java.lang.Integer')
+            Field(name='version', column='Version', indexed=False, unique=False, required=False, type='java.lang.Integer')
         ],
         indexes=[
 
@@ -3708,7 +3708,7 @@ datamodel = Datamodel(tables=[
             Field(name='timestampCreated', column='TimestampCreated', indexed=False, unique=False, required=True, type='java.sql.Timestamp'),
             Field(name='timestampModified', column='TimestampModified', indexed=False, unique=False, required=False, type='java.sql.Timestamp'),
             Field(name='type', column='Type', indexed=False, unique=False, required=False, type='java.lang.String', length=32),
-            Field(name='version', column='Version', indexed=False, unique=False, required=True, type='java.lang.Integer')
+            Field(name='version', column='Version', indexed=False, unique=False, required=False, type='java.lang.Integer')
         ],
         indexes=[
             Index(name='COLTRIPDivIDX', column_names=['DivisionID'])
@@ -3768,7 +3768,7 @@ datamodel = Datamodel(tables=[
             Field(name='timestampModified', column='TimestampModified', indexed=False, unique=False, required=False, type='java.sql.Timestamp'),
             Field(name='uncertaintyPolygon', column='UncertaintyPolygon', indexed=False, unique=False, required=False, type='text'),
             Field(name='validation', column='Validation', indexed=False, unique=False, required=False, type='java.lang.String', length=64),
-            Field(name='version', column='Version', indexed=False, unique=False, required=True, type='java.lang.Integer'),
+            Field(name='version', column='Version', indexed=False, unique=False, required=False, type='java.lang.Integer'),
             Field(name='yesNo1', column='YesNo1', indexed=False, unique=False, required=False, type='java.lang.Boolean'),
             Field(name='yesNo2', column='YesNo2', indexed=False, unique=False, required=False, type='java.lang.Boolean'),
             Field(name='yesNo3', column='YesNo3', indexed=False, unique=False, required=False, type='java.lang.Boolean'),
@@ -3819,7 +3819,7 @@ datamodel = Datamodel(tables=[
             Field(name='timestampCreated', column='TimestampCreated', indexed=False, unique=False, required=True, type='java.sql.Timestamp'),
             Field(name='timestampModified', column='TimestampModified', indexed=False, unique=False, required=False, type='java.sql.Timestamp'),
             Field(name='timestampVersion', column='TimestampVersion', indexed=False, unique=False, required=False, type='java.util.Date'),
-            Field(name='version', column='Version', indexed=False, unique=False, required=True, type='java.lang.Integer')
+            Field(name='version', column='Version', indexed=False, unique=False, required=False, type='java.lang.Integer')
         ],
         indexes=[
             Index(name='GeoNameIDX', column_names=['Name']),
@@ -3855,7 +3855,7 @@ datamodel = Datamodel(tables=[
             Field(name='remarks', column='Remarks', indexed=False, unique=False, required=False, type='text', length=4096),
             Field(name='timestampCreated', column='TimestampCreated', indexed=False, unique=False, required=True, type='java.sql.Timestamp'),
             Field(name='timestampModified', column='TimestampModified', indexed=False, unique=False, required=False, type='java.sql.Timestamp'),
-            Field(name='version', column='Version', indexed=False, unique=False, required=True, type='java.lang.Integer')
+            Field(name='version', column='Version', indexed=False, unique=False, required=False, type='java.lang.Integer')
         ],
         indexes=[
 
@@ -3890,7 +3890,7 @@ datamodel = Datamodel(tables=[
             Field(name='timestampCreated', column='TimestampCreated', indexed=False, unique=False, required=True, type='java.sql.Timestamp'),
             Field(name='timestampModified', column='TimestampModified', indexed=False, unique=False, required=False, type='java.sql.Timestamp'),
             Field(name='title', column='Title', indexed=False, unique=False, required=False, type='java.lang.String', length=64),
-            Field(name='version', column='Version', indexed=False, unique=False, required=True, type='java.lang.Integer')
+            Field(name='version', column='Version', indexed=False, unique=False, required=False, type='java.lang.Integer')
         ],
         indexes=[
 
@@ -3933,7 +3933,7 @@ datamodel = Datamodel(tables=[
             Field(name='text2', column='Text2', indexed=False, unique=False, required=False, type='java.lang.String', length=128),
             Field(name='timestampCreated', column='TimestampCreated', indexed=False, unique=False, required=True, type='java.sql.Timestamp'),
             Field(name='timestampModified', column='TimestampModified', indexed=False, unique=False, required=False, type='java.sql.Timestamp'),
-            Field(name='version', column='Version', indexed=False, unique=False, required=True, type='java.lang.Integer')
+            Field(name='version', column='Version', indexed=False, unique=False, required=False, type='java.lang.Integer')
         ],
         indexes=[
             Index(name='GTPNameIDX', column_names=['Name']),
@@ -3971,7 +3971,7 @@ datamodel = Datamodel(tables=[
             Field(name='remarks', column='Remarks', indexed=False, unique=False, required=False, type='text', length=4096),
             Field(name='timestampCreated', column='TimestampCreated', indexed=False, unique=False, required=True, type='java.sql.Timestamp'),
             Field(name='timestampModified', column='TimestampModified', indexed=False, unique=False, required=False, type='java.sql.Timestamp'),
-            Field(name='version', column='Version', indexed=False, unique=False, required=True, type='java.lang.Integer')
+            Field(name='version', column='Version', indexed=False, unique=False, required=False, type='java.lang.Integer')
         ],
         indexes=[
 
@@ -4006,7 +4006,7 @@ datamodel = Datamodel(tables=[
             Field(name='timestampCreated', column='TimestampCreated', indexed=False, unique=False, required=True, type='java.sql.Timestamp'),
             Field(name='timestampModified', column='TimestampModified', indexed=False, unique=False, required=False, type='java.sql.Timestamp'),
             Field(name='title', column='Title', indexed=False, unique=False, required=False, type='java.lang.String', length=64),
-            Field(name='version', column='Version', indexed=False, unique=False, required=True, type='java.lang.Integer')
+            Field(name='version', column='Version', indexed=False, unique=False, required=False, type='java.lang.Integer')
         ],
         indexes=[
 
@@ -4057,7 +4057,7 @@ datamodel = Datamodel(tables=[
             Field(name='text5', column='Text5', indexed=False, unique=False, required=False, type='java.lang.String', length=128),
             Field(name='timestampCreated', column='TimestampCreated', indexed=False, unique=False, required=True, type='java.sql.Timestamp'),
             Field(name='timestampModified', column='TimestampModified', indexed=False, unique=False, required=False, type='java.sql.Timestamp'),
-            Field(name='version', column='Version', indexed=False, unique=False, required=True, type='java.lang.Integer'),
+            Field(name='version', column='Version', indexed=False, unique=False, required=False, type='java.lang.Integer'),
             Field(name='yesNo1', column='YesNo1', indexed=False, unique=False, required=False, type='java.lang.Boolean'),
             Field(name='yesNo2', column='YesNo2', indexed=False, unique=False, required=False, type='java.lang.Boolean')
         ],
@@ -4096,7 +4096,7 @@ datamodel = Datamodel(tables=[
             Field(name='role', column='Role', indexed=False, unique=False, required=True, type='java.lang.String', length=50),
             Field(name='timestampCreated', column='TimestampCreated', indexed=False, unique=False, required=True, type='java.sql.Timestamp'),
             Field(name='timestampModified', column='TimestampModified', indexed=False, unique=False, required=False, type='java.sql.Timestamp'),
-            Field(name='version', column='Version', indexed=False, unique=False, required=True, type='java.lang.Integer')
+            Field(name='version', column='Version', indexed=False, unique=False, required=False, type='java.lang.Integer')
         ],
         indexes=[
             Index(name='GiftAgDspMemIDX', column_names=['DisciplineID'])
@@ -4127,7 +4127,7 @@ datamodel = Datamodel(tables=[
             Field(name='remarks', column='Remarks', indexed=False, unique=False, required=False, type='text', length=4096),
             Field(name='timestampCreated', column='TimestampCreated', indexed=False, unique=False, required=True, type='java.sql.Timestamp'),
             Field(name='timestampModified', column='TimestampModified', indexed=False, unique=False, required=False, type='java.sql.Timestamp'),
-            Field(name='version', column='Version', indexed=False, unique=False, required=True, type='java.lang.Integer')
+            Field(name='version', column='Version', indexed=False, unique=False, required=False, type='java.lang.Integer')
         ],
         indexes=[
 
@@ -4166,7 +4166,7 @@ datamodel = Datamodel(tables=[
             Field(name='text5', column='Text5', indexed=False, unique=False, required=False, type='text', length=65535),
             Field(name='timestampCreated', column='TimestampCreated', indexed=False, unique=False, required=True, type='java.sql.Timestamp'),
             Field(name='timestampModified', column='TimestampModified', indexed=False, unique=False, required=False, type='java.sql.Timestamp'),
-            Field(name='version', column='Version', indexed=False, unique=False, required=True, type='java.lang.Integer')
+            Field(name='version', column='Version', indexed=False, unique=False, required=False, type='java.lang.Integer')
         ],
         indexes=[
             Index(name='GiftPrepDspMemIDX', column_names=['DisciplineID'])
@@ -4196,7 +4196,7 @@ datamodel = Datamodel(tables=[
             Field(name='remarks', column='Remarks', indexed=False, unique=False, required=False, type='text', length=4096),
             Field(name='timestampCreated', column='TimestampCreated', indexed=False, unique=False, required=True, type='java.sql.Timestamp'),
             Field(name='timestampModified', column='TimestampModified', indexed=False, unique=False, required=False, type='java.sql.Timestamp'),
-            Field(name='version', column='Version', indexed=False, unique=False, required=True, type='java.lang.Integer')
+            Field(name='version', column='Version', indexed=False, unique=False, required=False, type='java.lang.Integer')
         ],
         indexes=[
 
@@ -4233,7 +4233,7 @@ datamodel = Datamodel(tables=[
             Field(name='requestDate', column='RequestDate', indexed=False, unique=False, required=False, type='java.util.Calendar'),
             Field(name='timestampCreated', column='TimestampCreated', indexed=False, unique=False, required=True, type='java.sql.Timestamp'),
             Field(name='timestampModified', column='TimestampModified', indexed=False, unique=False, required=False, type='java.sql.Timestamp'),
-            Field(name='version', column='Version', indexed=False, unique=False, required=True, type='java.lang.Integer')
+            Field(name='version', column='Version', indexed=False, unique=False, required=False, type='java.lang.Integer')
         ],
         indexes=[
             Index(name='IRColMemIDX', column_names=['CollectionMemberID'])
@@ -4286,7 +4286,7 @@ datamodel = Datamodel(tables=[
             Field(name='timestampCreated', column='TimestampCreated', indexed=False, unique=False, required=True, type='java.sql.Timestamp'),
             Field(name='timestampModified', column='TimestampModified', indexed=False, unique=False, required=False, type='java.sql.Timestamp'),
             Field(name='uri', column='Uri', indexed=False, unique=False, required=False, type='java.lang.String', length=255),
-            Field(name='version', column='Version', indexed=False, unique=False, required=True, type='java.lang.Integer')
+            Field(name='version', column='Version', indexed=False, unique=False, required=False, type='java.lang.Integer')
         ],
         indexes=[
             Index(name='InstNameIDX', column_names=['Name']),
@@ -4330,7 +4330,7 @@ datamodel = Datamodel(tables=[
             Field(name='timestampCreated', column='TimestampCreated', indexed=False, unique=False, required=True, type='java.sql.Timestamp'),
             Field(name='timestampModified', column='TimestampModified', indexed=False, unique=False, required=False, type='java.sql.Timestamp'),
             Field(name='uri', column='Uri', indexed=False, unique=False, required=False, type='java.lang.String', length=255),
-            Field(name='version', column='Version', indexed=False, unique=False, required=True, type='java.lang.Integer')
+            Field(name='version', column='Version', indexed=False, unique=False, required=False, type='java.lang.Integer')
         ],
         indexes=[
             Index(name='InstNetworkNameIDX', column_names=['Name'])
@@ -4362,7 +4362,7 @@ datamodel = Datamodel(tables=[
             Field(name='text1', column='Text1', indexed=False, unique=False, required=False, type='java.lang.String', length=32),
             Field(name='timestampCreated', column='TimestampCreated', indexed=False, unique=False, required=True, type='java.sql.Timestamp'),
             Field(name='timestampModified', column='TimestampModified', indexed=False, unique=False, required=False, type='java.sql.Timestamp'),
-            Field(name='version', column='Version', indexed=False, unique=False, required=True, type='java.lang.Integer')
+            Field(name='version', column='Version', indexed=False, unique=False, required=False, type='java.lang.Integer')
         ],
         indexes=[
             Index(name='JournalNameIDX', column_names=['JournalName']),
@@ -4393,7 +4393,7 @@ datamodel = Datamodel(tables=[
             Field(name='name', column='Name', indexed=False, unique=False, required=True, type='java.lang.String', length=64),
             Field(name='timestampCreated', column='TimestampCreated', indexed=False, unique=False, required=True, type='java.sql.Timestamp'),
             Field(name='timestampModified', column='TimestampModified', indexed=False, unique=False, required=False, type='java.sql.Timestamp'),
-            Field(name='version', column='Version', indexed=False, unique=False, required=True, type='java.lang.Integer')
+            Field(name='version', column='Version', indexed=False, unique=False, required=False, type='java.lang.Integer')
         ],
         indexes=[
 
@@ -4454,7 +4454,7 @@ datamodel = Datamodel(tables=[
             Field(name='text2', column='Text2', indexed=False, unique=False, required=False, type='text', length=65535),
             Field(name='timestampCreated', column='TimestampCreated', indexed=False, unique=False, required=True, type='java.sql.Timestamp'),
             Field(name='timestampModified', column='TimestampModified', indexed=False, unique=False, required=False, type='java.sql.Timestamp'),
-            Field(name='version', column='Version', indexed=False, unique=False, required=True, type='java.lang.Integer'),
+            Field(name='version', column='Version', indexed=False, unique=False, required=False, type='java.lang.Integer'),
             Field(name='yesNo1', column='YesNo1', indexed=False, unique=False, required=False, type='java.lang.Boolean'),
             Field(name='yesNo2', column='YesNo2', indexed=False, unique=False, required=False, type='java.lang.Boolean')
         ],
@@ -4493,7 +4493,7 @@ datamodel = Datamodel(tables=[
             Field(name='remarks', column='Remarks', indexed=False, unique=False, required=False, type='text', length=4096),
             Field(name='timestampCreated', column='TimestampCreated', indexed=False, unique=False, required=True, type='java.sql.Timestamp'),
             Field(name='timestampModified', column='TimestampModified', indexed=False, unique=False, required=False, type='java.sql.Timestamp'),
-            Field(name='version', column='Version', indexed=False, unique=False, required=True, type='java.lang.Integer')
+            Field(name='version', column='Version', indexed=False, unique=False, required=False, type='java.lang.Integer')
         ],
         indexes=[
 
@@ -4528,7 +4528,7 @@ datamodel = Datamodel(tables=[
             Field(name='timestampCreated', column='TimestampCreated', indexed=False, unique=False, required=True, type='java.sql.Timestamp'),
             Field(name='timestampModified', column='TimestampModified', indexed=False, unique=False, required=False, type='java.sql.Timestamp'),
             Field(name='title', column='Title', indexed=False, unique=False, required=False, type='java.lang.String', length=64),
-            Field(name='version', column='Version', indexed=False, unique=False, required=True, type='java.lang.Integer')
+            Field(name='version', column='Version', indexed=False, unique=False, required=False, type='java.lang.Integer')
         ],
         indexes=[
 
@@ -4582,7 +4582,7 @@ datamodel = Datamodel(tables=[
             Field(name='text5', column='Text5', indexed=False, unique=False, required=False, type='text', length=65535),
             Field(name='timestampCreated', column='TimestampCreated', indexed=False, unique=False, required=True, type='java.sql.Timestamp'),
             Field(name='timestampModified', column='TimestampModified', indexed=False, unique=False, required=False, type='java.sql.Timestamp'),
-            Field(name='version', column='Version', indexed=False, unique=False, required=True, type='java.lang.Integer'),
+            Field(name='version', column='Version', indexed=False, unique=False, required=False, type='java.lang.Integer'),
             Field(name='yesNo1', column='YesNo1', indexed=False, unique=False, required=False, type='java.lang.Boolean'),
             Field(name='yesNo2', column='YesNo2', indexed=False, unique=False, required=False, type='java.lang.Boolean')
         ],
@@ -4620,7 +4620,7 @@ datamodel = Datamodel(tables=[
             Field(name='role', column='Role', indexed=False, unique=False, required=True, type='java.lang.String', length=50),
             Field(name='timestampCreated', column='TimestampCreated', indexed=False, unique=False, required=True, type='java.sql.Timestamp'),
             Field(name='timestampModified', column='TimestampModified', indexed=False, unique=False, required=False, type='java.sql.Timestamp'),
-            Field(name='version', column='Version', indexed=False, unique=False, required=True, type='java.lang.Integer')
+            Field(name='version', column='Version', indexed=False, unique=False, required=False, type='java.lang.Integer')
         ],
         indexes=[
             Index(name='LoanAgDspMemIDX', column_names=['DisciplineID'])
@@ -4651,7 +4651,7 @@ datamodel = Datamodel(tables=[
             Field(name='remarks', column='Remarks', indexed=False, unique=False, required=False, type='text', length=4096),
             Field(name='timestampCreated', column='TimestampCreated', indexed=False, unique=False, required=True, type='java.sql.Timestamp'),
             Field(name='timestampModified', column='TimestampModified', indexed=False, unique=False, required=False, type='java.sql.Timestamp'),
-            Field(name='version', column='Version', indexed=False, unique=False, required=True, type='java.lang.Integer')
+            Field(name='version', column='Version', indexed=False, unique=False, required=False, type='java.lang.Integer')
         ],
         indexes=[
 
@@ -4691,7 +4691,7 @@ datamodel = Datamodel(tables=[
             Field(name='text5', column='Text5', indexed=False, unique=False, required=False, type='text', length=65535),
             Field(name='timestampCreated', column='TimestampCreated', indexed=False, unique=False, required=True, type='java.sql.Timestamp'),
             Field(name='timestampModified', column='TimestampModified', indexed=False, unique=False, required=False, type='java.sql.Timestamp'),
-            Field(name='version', column='Version', indexed=False, unique=False, required=True, type='java.lang.Integer')
+            Field(name='version', column='Version', indexed=False, unique=False, required=False, type='java.lang.Integer')
         ],
         indexes=[
             Index(name='LoanPrepDspMemIDX', column_names=['DisciplineID'])
@@ -4724,7 +4724,7 @@ datamodel = Datamodel(tables=[
             Field(name='returnedDate', column='ReturnedDate', indexed=True, unique=False, required=False, type='java.util.Calendar'),
             Field(name='timestampCreated', column='TimestampCreated', indexed=False, unique=False, required=True, type='java.sql.Timestamp'),
             Field(name='timestampModified', column='TimestampModified', indexed=False, unique=False, required=False, type='java.sql.Timestamp'),
-            Field(name='version', column='Version', indexed=False, unique=False, required=True, type='java.lang.Integer')
+            Field(name='version', column='Version', indexed=False, unique=False, required=False, type='java.lang.Integer')
         ],
         indexes=[
             Index(name='LoanReturnedDateIDX', column_names=['ReturnedDate']),
@@ -4788,7 +4788,7 @@ datamodel = Datamodel(tables=[
             Field(name='verbatimElevation', column='VerbatimElevation', indexed=False, unique=False, required=False, type='java.lang.String', length=50),
             Field(name='verbatimLatitude', column='VerbatimLatitude', indexed=False, unique=False, required=False, type='java.lang.String', length=50),
             Field(name='verbatimLongitude', column='VerbatimLongitude', indexed=False, unique=False, required=False, type='java.lang.String', length=50),
-            Field(name='version', column='Version', indexed=False, unique=False, required=True, type='java.lang.Integer'),
+            Field(name='version', column='Version', indexed=False, unique=False, required=False, type='java.lang.Integer'),
             Field(name='visibility', column='Visibility', indexed=False, unique=False, required=False, type='java.lang.Byte'),
             Field(name='yesNo1', column='YesNo1', indexed=False, unique=False, required=False, type='java.lang.Boolean'),
             Field(name='yesNo2', column='YesNo2', indexed=False, unique=False, required=False, type='java.lang.Boolean'),
@@ -4837,7 +4837,7 @@ datamodel = Datamodel(tables=[
             Field(name='remarks', column='Remarks', indexed=False, unique=False, required=False, type='text', length=4096),
             Field(name='timestampCreated', column='TimestampCreated', indexed=False, unique=False, required=True, type='java.sql.Timestamp'),
             Field(name='timestampModified', column='TimestampModified', indexed=False, unique=False, required=False, type='java.sql.Timestamp'),
-            Field(name='version', column='Version', indexed=False, unique=False, required=True, type='java.lang.Integer')
+            Field(name='version', column='Version', indexed=False, unique=False, required=False, type='java.lang.Integer')
         ],
         indexes=[
 
@@ -4869,7 +4869,7 @@ datamodel = Datamodel(tables=[
             Field(name='remarks', column='Remarks', indexed=False, unique=False, required=False, type='text', length=4096),
             Field(name='timestampCreated', column='TimestampCreated', indexed=False, unique=False, required=True, type='java.sql.Timestamp'),
             Field(name='timestampModified', column='TimestampModified', indexed=False, unique=False, required=False, type='java.sql.Timestamp'),
-            Field(name='version', column='Version', indexed=False, unique=False, required=True, type='java.lang.Integer')
+            Field(name='version', column='Version', indexed=False, unique=False, required=False, type='java.lang.Integer')
         ],
         indexes=[
             Index(name='LocCitDspMemIDX', column_names=['DisciplineID'])
@@ -4936,7 +4936,7 @@ datamodel = Datamodel(tables=[
             Field(name='utmOrigLongitude', column='UtmOrigLongitude', indexed=False, unique=False, required=False, type='java.math.BigDecimal'),
             Field(name='utmScale', column='UtmScale', indexed=False, unique=False, required=False, type='java.math.BigDecimal'),
             Field(name='utmZone', column='UtmZone', indexed=False, unique=False, required=False, type='java.lang.Short'),
-            Field(name='version', column='Version', indexed=False, unique=False, required=True, type='java.lang.Integer'),
+            Field(name='version', column='Version', indexed=False, unique=False, required=False, type='java.lang.Integer'),
             Field(name='waterBody', column='WaterBody', indexed=False, unique=False, required=False, type='java.lang.String', length=64),
             Field(name='yesNo1', column='YesNo1', indexed=False, unique=False, required=False, type='java.lang.Boolean'),
             Field(name='yesNo2', column='YesNo2', indexed=False, unique=False, required=False, type='java.lang.Boolean'),
@@ -4968,7 +4968,7 @@ datamodel = Datamodel(tables=[
             Field(name='source', column='Source', indexed=False, unique=False, required=True, type='java.lang.String', length=64),
             Field(name='timestampCreated', column='TimestampCreated', indexed=False, unique=False, required=True, type='java.sql.Timestamp'),
             Field(name='timestampModified', column='TimestampModified', indexed=False, unique=False, required=False, type='java.sql.Timestamp'),
-            Field(name='version', column='Version', indexed=False, unique=False, required=True, type='java.lang.Integer')
+            Field(name='version', column='Version', indexed=False, unique=False, required=False, type='java.lang.Integer')
         ],
         indexes=[
             Index(name='LocalityNameAliasIDX', column_names=['Name'])
@@ -5031,7 +5031,7 @@ datamodel = Datamodel(tables=[
             Field(name='text2', column='Text2', indexed=False, unique=False, required=False, type='text', length=4096),
             Field(name='timestampCreated', column='TimestampCreated', indexed=False, unique=False, required=True, type='java.sql.Timestamp'),
             Field(name='timestampModified', column='TimestampModified', indexed=False, unique=False, required=False, type='java.sql.Timestamp'),
-            Field(name='version', column='Version', indexed=False, unique=False, required=True, type='java.lang.Integer'),
+            Field(name='version', column='Version', indexed=False, unique=False, required=False, type='java.lang.Integer'),
             Field(name='yesNo1', column='YesNo1', indexed=False, unique=False, required=False, type='java.lang.Boolean'),
             Field(name='yesNo2', column='YesNo2', indexed=False, unique=False, required=False, type='java.lang.Boolean')
         ],
@@ -5067,7 +5067,7 @@ datamodel = Datamodel(tables=[
             Field(name='specimenPart', column='SpecimenPart', indexed=False, unique=False, required=False, type='java.lang.String', length=128),
             Field(name='timestampCreated', column='TimestampCreated', indexed=False, unique=False, required=True, type='java.sql.Timestamp'),
             Field(name='timestampModified', column='TimestampModified', indexed=False, unique=False, required=False, type='java.sql.Timestamp'),
-            Field(name='version', column='Version', indexed=False, unique=False, required=True, type='java.lang.Integer'),
+            Field(name='version', column='Version', indexed=False, unique=False, required=False, type='java.lang.Integer'),
             Field(name='viewAngle', column='ViewAngle', indexed=False, unique=False, required=False, type='java.lang.String', length=128),
             Field(name='viewName', column='ViewName', indexed=False, unique=False, required=False, type='java.lang.String', length=128)
         ],
@@ -5108,7 +5108,7 @@ datamodel = Datamodel(tables=[
             Field(name='text5', column='Text5', indexed=False, unique=False, required=False, type='text', length=65535),
             Field(name='timestampCreated', column='TimestampCreated', indexed=False, unique=False, required=True, type='java.sql.Timestamp'),
             Field(name='timestampModified', column='TimestampModified', indexed=False, unique=False, required=False, type='java.sql.Timestamp'),
-            Field(name='version', column='Version', indexed=False, unique=False, required=True, type='java.lang.Integer'),
+            Field(name='version', column='Version', indexed=False, unique=False, required=False, type='java.lang.Integer'),
             Field(name='yesNo1', column='YesNo1', indexed=False, unique=False, required=False, type='java.lang.Boolean'),
             Field(name='yesNo2', column='YesNo2', indexed=False, unique=False, required=False, type='java.lang.Boolean'),
             Field(name='yesNo3', column='YesNo3', indexed=False, unique=False, required=False, type='java.lang.Boolean'),
@@ -5153,7 +5153,7 @@ datamodel = Datamodel(tables=[
             Field(name='text5', column='Text5', indexed=False, unique=False, required=False, type='java.lang.String', length=500),
             Field(name='timestampCreated', column='TimestampCreated', indexed=False, unique=False, required=True, type='java.sql.Timestamp'),
             Field(name='timestampModified', column='TimestampModified', indexed=False, unique=False, required=False, type='java.sql.Timestamp'),
-            Field(name='version', column='Version', indexed=False, unique=False, required=True, type='java.lang.Integer'),
+            Field(name='version', column='Version', indexed=False, unique=False, required=False, type='java.lang.Integer'),
             Field(name='yesNo1', column='YesNo1', indexed=False, unique=False, required=False, type='java.lang.Boolean'),
             Field(name='yesNo2', column='YesNo2', indexed=False, unique=False, required=False, type='java.lang.Boolean'),
             Field(name='yesNo3', column='YesNo3', indexed=False, unique=False, required=False, type='java.lang.Boolean'),
@@ -5197,7 +5197,7 @@ datamodel = Datamodel(tables=[
             Field(name='text2', column='Text2', indexed=False, unique=False, required=False, type='text', length=4096),
             Field(name='timestampCreated', column='TimestampCreated', indexed=False, unique=False, required=True, type='java.sql.Timestamp'),
             Field(name='timestampModified', column='TimestampModified', indexed=False, unique=False, required=False, type='java.sql.Timestamp'),
-            Field(name='version', column='Version', indexed=False, unique=False, required=True, type='java.lang.Integer'),
+            Field(name='version', column='Version', indexed=False, unique=False, required=False, type='java.lang.Integer'),
             Field(name='yesNo1', column='YesNo1', indexed=False, unique=False, required=False, type='java.lang.Boolean'),
             Field(name='yesNo2', column='YesNo2', indexed=False, unique=False, required=False, type='java.lang.Boolean')
         ],
@@ -5247,7 +5247,7 @@ datamodel = Datamodel(tables=[
             Field(name='timestampCreated', column='TimestampCreated', indexed=False, unique=False, required=True, type='java.sql.Timestamp'),
             Field(name='timestampModified', column='TimestampModified', indexed=False, unique=False, required=False, type='java.sql.Timestamp'),
             Field(name='type', column='Type', indexed=False, unique=False, required=False, type='java.lang.String', length=50),
-            Field(name='version', column='Version', indexed=False, unique=False, required=True, type='java.lang.Integer'),
+            Field(name='version', column='Version', indexed=False, unique=False, required=False, type='java.lang.Integer'),
             Field(name='yesNo1', column='YesNo1', indexed=False, unique=False, required=False, type='java.lang.Boolean'),
             Field(name='yesNo2', column='YesNo2', indexed=False, unique=False, required=False, type='java.lang.Boolean')
         ],
@@ -5285,7 +5285,7 @@ datamodel = Datamodel(tables=[
             Field(name='remarks', column='Remarks', indexed=False, unique=False, required=False, type='text', length=4096),
             Field(name='timestampCreated', column='TimestampCreated', indexed=False, unique=False, required=True, type='java.sql.Timestamp'),
             Field(name='timestampModified', column='TimestampModified', indexed=False, unique=False, required=False, type='java.sql.Timestamp'),
-            Field(name='version', column='Version', indexed=False, unique=False, required=True, type='java.lang.Integer')
+            Field(name='version', column='Version', indexed=False, unique=False, required=False, type='java.lang.Integer')
         ],
         indexes=[
 
@@ -5324,7 +5324,7 @@ datamodel = Datamodel(tables=[
             Field(name='timestampCreated', column='TimestampCreated', indexed=False, unique=False, required=True, type='java.sql.Timestamp'),
             Field(name='timestampModified', column='TimestampModified', indexed=False, unique=False, required=False, type='java.sql.Timestamp'),
             Field(name='type', column='Type', indexed=False, unique=False, required=True, type='java.lang.Byte'),
-            Field(name='version', column='Version', indexed=False, unique=False, required=True, type='java.lang.Integer')
+            Field(name='version', column='Version', indexed=False, unique=False, required=False, type='java.lang.Integer')
         ],
         indexes=[
             Index(name='PickListNameIDX', column_names=['Name'])
@@ -5355,7 +5355,7 @@ datamodel = Datamodel(tables=[
             Field(name='timestampModified', column='TimestampModified', indexed=False, unique=False, required=False, type='java.sql.Timestamp'),
             Field(name='title', column='Title', indexed=False, unique=False, required=True, type='java.lang.String', length=1024),
             Field(name='value', column='Value', indexed=False, unique=False, required=False, type='java.lang.String', length=1024),
-            Field(name='version', column='Version', indexed=False, unique=False, required=True, type='java.lang.Integer')
+            Field(name='version', column='Version', indexed=False, unique=False, required=False, type='java.lang.Integer')
         ],
         indexes=[
 
@@ -5383,7 +5383,7 @@ datamodel = Datamodel(tables=[
             Field(name='name', column='Name', indexed=False, unique=False, required=True, type='java.lang.String', length=64),
             Field(name='timestampCreated', column='TimestampCreated', indexed=False, unique=False, required=True, type='java.sql.Timestamp'),
             Field(name='timestampModified', column='TimestampModified', indexed=False, unique=False, required=False, type='java.sql.Timestamp'),
-            Field(name='version', column='Version', indexed=False, unique=False, required=True, type='java.lang.Integer')
+            Field(name='version', column='Version', indexed=False, unique=False, required=False, type='java.lang.Integer')
         ],
         indexes=[
 
@@ -5448,7 +5448,7 @@ datamodel = Datamodel(tables=[
             Field(name='text9', column='Text9', indexed=False, unique=False, required=False, type='text', length=65535),
             Field(name='timestampCreated', column='TimestampCreated', indexed=False, unique=False, required=True, type='java.sql.Timestamp'),
             Field(name='timestampModified', column='TimestampModified', indexed=False, unique=False, required=False, type='java.sql.Timestamp'),
-            Field(name='version', column='Version', indexed=False, unique=False, required=True, type='java.lang.Integer'),
+            Field(name='version', column='Version', indexed=False, unique=False, required=False, type='java.lang.Integer'),
             Field(name='yesNo1', column='YesNo1', indexed=False, unique=False, required=False, type='java.lang.Boolean'),
             Field(name='yesNo2', column='YesNo2', indexed=False, unique=False, required=False, type='java.lang.Boolean'),
             Field(name='yesNo3', column='YesNo3', indexed=False, unique=False, required=False, type='java.lang.Boolean')
@@ -5500,7 +5500,7 @@ datamodel = Datamodel(tables=[
             Field(name='remarks', column='Remarks', indexed=False, unique=False, required=False, type='text', length=4096),
             Field(name='timestampCreated', column='TimestampCreated', indexed=False, unique=False, required=True, type='java.sql.Timestamp'),
             Field(name='timestampModified', column='TimestampModified', indexed=False, unique=False, required=False, type='java.sql.Timestamp'),
-            Field(name='version', column='Version', indexed=False, unique=False, required=True, type='java.lang.Integer')
+            Field(name='version', column='Version', indexed=False, unique=False, required=False, type='java.lang.Integer')
         ],
         indexes=[
             Index(name='PrepAttColMemIDX', column_names=['CollectionMemberID'])
@@ -5530,7 +5530,7 @@ datamodel = Datamodel(tables=[
             Field(name='strValue', column='StrValue', indexed=False, unique=False, required=False, type='java.lang.String', length=255),
             Field(name='timestampCreated', column='TimestampCreated', indexed=False, unique=False, required=True, type='java.sql.Timestamp'),
             Field(name='timestampModified', column='TimestampModified', indexed=False, unique=False, required=False, type='java.sql.Timestamp'),
-            Field(name='version', column='Version', indexed=False, unique=False, required=True, type='java.lang.Integer')
+            Field(name='version', column='Version', indexed=False, unique=False, required=False, type='java.lang.Integer')
         ],
         indexes=[
             Index(name='PrepAttrColMemIDX', column_names=['CollectionMemberID'])
@@ -5593,7 +5593,7 @@ datamodel = Datamodel(tables=[
             Field(name='text9', column='Text9', indexed=False, unique=False, required=False, type='java.lang.String', length=50),
             Field(name='timestampCreated', column='TimestampCreated', indexed=False, unique=False, required=True, type='java.sql.Timestamp'),
             Field(name='timestampModified', column='TimestampModified', indexed=False, unique=False, required=False, type='java.sql.Timestamp'),
-            Field(name='version', column='Version', indexed=False, unique=False, required=True, type='java.lang.Integer'),
+            Field(name='version', column='Version', indexed=False, unique=False, required=False, type='java.lang.Integer'),
             Field(name='yesNo1', column='YesNo1', indexed=False, unique=False, required=False, type='java.lang.Boolean'),
             Field(name='yesNo2', column='YesNo2', indexed=False, unique=False, required=False, type='java.lang.Boolean'),
             Field(name='yesNo3', column='YesNo3', indexed=False, unique=False, required=False, type='java.lang.Boolean'),
@@ -5744,7 +5744,7 @@ datamodel = Datamodel(tables=[
             Field(name='text9', column='Text9', indexed=False, unique=False, required=False, type='java.lang.String', length=50),
             Field(name='timestampCreated', column='TimestampCreated', indexed=False, unique=False, required=True, type='java.sql.Timestamp'),
             Field(name='timestampModified', column='TimestampModified', indexed=False, unique=False, required=False, type='java.sql.Timestamp'),
-            Field(name='version', column='Version', indexed=False, unique=False, required=True, type='java.lang.Integer'),
+            Field(name='version', column='Version', indexed=False, unique=False, required=False, type='java.lang.Integer'),
             Field(name='yesNo1', column='YesNo1', indexed=False, unique=False, required=False, type='java.lang.Boolean'),
             Field(name='yesNo10', column='YesNo10', indexed=False, unique=False, required=False, type='java.lang.Boolean'),
             Field(name='yesNo11', column='YesNo11', indexed=False, unique=False, required=False, type='java.lang.Boolean'),
@@ -5824,7 +5824,7 @@ datamodel = Datamodel(tables=[
             Field(name='timestampCreated', column='TimestampCreated', indexed=False, unique=False, required=True, type='java.sql.Timestamp'),
             Field(name='timestampModified', column='TimestampModified', indexed=False, unique=False, required=False, type='java.sql.Timestamp'),
             Field(name='url', column='URL', indexed=False, unique=False, required=False, type='java.lang.String', length=1024),
-            Field(name='version', column='Version', indexed=False, unique=False, required=True, type='java.lang.Integer'),
+            Field(name='version', column='Version', indexed=False, unique=False, required=False, type='java.lang.Integer'),
             Field(name='yesNo1', column='YesNo1', indexed=False, unique=False, required=False, type='java.lang.Boolean'),
             Field(name='yesNo2', column='YesNo2', indexed=False, unique=False, required=False, type='java.lang.Boolean')
         ],
@@ -5863,7 +5863,7 @@ datamodel = Datamodel(tables=[
             Field(name='timestampCreated', column='TimestampCreated', indexed=False, unique=False, required=True, type='java.sql.Timestamp'),
             Field(name='timestampModified', column='TimestampModified', indexed=False, unique=False, required=False, type='java.sql.Timestamp'),
             Field(name='type', column='Type', indexed=False, unique=False, required=True, type='java.lang.Byte'),
-            Field(name='version', column='Version', indexed=False, unique=False, required=True, type='java.lang.Integer')
+            Field(name='version', column='Version', indexed=False, unique=False, required=False, type='java.lang.Integer')
         ],
         indexes=[
             Index(name='RecordSetNameIDX', column_names=['name'])
@@ -5929,7 +5929,7 @@ datamodel = Datamodel(tables=[
             Field(name='title', column='Title', indexed=True, unique=False, required=True, type='java.lang.String', length=500),
             Field(name='uri', column='Uri', indexed=False, unique=False, required=False, type='text', length=65535),
             Field(name='url', column='URL', indexed=False, unique=False, required=False, type='java.lang.String', length=1024),
-            Field(name='version', column='Version', indexed=False, unique=False, required=True, type='java.lang.Integer'),
+            Field(name='version', column='Version', indexed=False, unique=False, required=False, type='java.lang.Integer'),
             Field(name='volume', column='Volume', indexed=False, unique=False, required=False, type='java.lang.String', length=25),
             Field(name='workDate', column='WorkDate', indexed=False, unique=False, required=False, type='java.lang.String', length=25),
             Field(name='yesNo1', column='YesNo1', indexed=False, unique=False, required=False, type='java.lang.Boolean'),
@@ -5975,7 +5975,7 @@ datamodel = Datamodel(tables=[
             Field(name='remarks', column='Remarks', indexed=False, unique=False, required=False, type='text', length=4096),
             Field(name='timestampCreated', column='TimestampCreated', indexed=False, unique=False, required=True, type='java.sql.Timestamp'),
             Field(name='timestampModified', column='TimestampModified', indexed=False, unique=False, required=False, type='java.sql.Timestamp'),
-            Field(name='version', column='Version', indexed=False, unique=False, required=True, type='java.lang.Integer')
+            Field(name='version', column='Version', indexed=False, unique=False, required=False, type='java.lang.Integer')
         ],
         indexes=[
 
@@ -6013,7 +6013,7 @@ datamodel = Datamodel(tables=[
             Field(name='text3', column='Text3', indexed=False, unique=False, required=False, type='java.lang.String', length=255),
             Field(name='timestampCreated', column='TimestampCreated', indexed=False, unique=False, required=True, type='java.sql.Timestamp'),
             Field(name='timestampModified', column='TimestampModified', indexed=False, unique=False, required=False, type='java.sql.Timestamp'),
-            Field(name='version', column='Version', indexed=False, unique=False, required=True, type='java.lang.Integer'),
+            Field(name='version', column='Version', indexed=False, unique=False, required=False, type='java.lang.Integer'),
             Field(name='yesNo1', column='YesNo1', indexed=False, unique=False, required=False, type='java.lang.Boolean'),
             Field(name='yesNo2', column='YesNo2', indexed=False, unique=False, required=False, type='java.lang.Boolean')
         ],
@@ -6051,7 +6051,7 @@ datamodel = Datamodel(tables=[
             Field(name='remarks', column='Remarks', indexed=False, unique=False, required=False, type='text', length=4096),
             Field(name='timestampCreated', column='TimestampCreated', indexed=False, unique=False, required=True, type='java.sql.Timestamp'),
             Field(name='timestampModified', column='TimestampModified', indexed=False, unique=False, required=False, type='java.sql.Timestamp'),
-            Field(name='version', column='Version', indexed=False, unique=False, required=True, type='java.lang.Integer')
+            Field(name='version', column='Version', indexed=False, unique=False, required=False, type='java.lang.Integer')
         ],
         indexes=[
 
@@ -6088,7 +6088,7 @@ datamodel = Datamodel(tables=[
             Field(name='text2', column='Text2', indexed=False, unique=False, required=False, type='text', length=65535),
             Field(name='timestampCreated', column='TimestampCreated', indexed=False, unique=False, required=True, type='java.sql.Timestamp'),
             Field(name='timestampModified', column='TimestampModified', indexed=False, unique=False, required=False, type='java.sql.Timestamp'),
-            Field(name='version', column='Version', indexed=False, unique=False, required=True, type='java.lang.Integer'),
+            Field(name='version', column='Version', indexed=False, unique=False, required=False, type='java.lang.Integer'),
             Field(name='weight', column='Weight', indexed=False, unique=False, required=False, type='java.lang.String', length=50),
             Field(name='yesNo1', column='YesNo1', indexed=False, unique=False, required=False, type='java.lang.Boolean'),
             Field(name='yesNo2', column='YesNo2', indexed=False, unique=False, required=False, type='java.lang.Boolean')
@@ -6133,7 +6133,7 @@ datamodel = Datamodel(tables=[
             Field(name='name', column='Name', indexed=True, unique=False, required=True, type='java.lang.String', length=64),
             Field(name='ownerPermissionLevel', column='OwnerPermissionLevel', indexed=False, unique=False, required=False, type='java.lang.Integer'),
             Field(name='timestampCreated', column='TimestampCreated', indexed=False, unique=False, required=True, type='java.sql.Timestamp'),
-            Field(name='version', column='Version', indexed=False, unique=False, required=True, type='java.lang.Integer')
+            Field(name='version', column='Version', indexed=False, unique=False, required=False, type='java.lang.Integer')
         ],
         indexes=[
             Index(name='SpAppResNameIDX', column_names=['Name']),
@@ -6164,7 +6164,7 @@ datamodel = Datamodel(tables=[
             Field(name='data', column='data', indexed=False, unique=False, required=False, type='text', length=16000000),
             Field(name='timestampCreated', column='TimestampCreated', indexed=False, unique=False, required=True, type='java.sql.Timestamp'),
             Field(name='timestampModified', column='TimestampModified', indexed=False, unique=False, required=False, type='java.sql.Timestamp'),
-            Field(name='version', column='Version', indexed=False, unique=False, required=True, type='java.lang.Integer')
+            Field(name='version', column='Version', indexed=False, unique=False, required=False, type='java.lang.Integer')
         ],
         indexes=[
 
@@ -6193,7 +6193,7 @@ datamodel = Datamodel(tables=[
             Field(name='timestampCreated', column='TimestampCreated', indexed=False, unique=False, required=True, type='java.sql.Timestamp'),
             Field(name='timestampModified', column='TimestampModified', indexed=False, unique=False, required=False, type='java.sql.Timestamp'),
             Field(name='userType', column='UserType', indexed=False, unique=False, required=False, type='java.lang.String', length=64),
-            Field(name='version', column='Version', indexed=False, unique=False, required=True, type='java.lang.Integer')
+            Field(name='version', column='Version', indexed=False, unique=False, required=False, type='java.lang.Integer')
         ],
         indexes=[
             Index(name='SpAppResourceDirDispTypeIDX', column_names=['DisciplineType'])
@@ -6228,7 +6228,7 @@ datamodel = Datamodel(tables=[
             Field(name='tableNum', column='TableNum', indexed=False, unique=False, required=True, type='java.lang.Short'),
             Field(name='timestampCreated', column='TimestampCreated', indexed=False, unique=False, required=True, type='java.sql.Timestamp'),
             Field(name='timestampModified', column='TimestampModified', indexed=False, unique=False, required=False, type='java.sql.Timestamp'),
-            Field(name='version', column='Version', indexed=False, unique=False, required=True, type='java.lang.Integer')
+            Field(name='version', column='Version', indexed=False, unique=False, required=False, type='java.lang.Integer')
         ],
         indexes=[
 
@@ -6256,7 +6256,7 @@ datamodel = Datamodel(tables=[
             Field(name='oldValue', column='OldValue', indexed=False, unique=False, required=False, type='text', length=65535),
             Field(name='timestampCreated', column='TimestampCreated', indexed=False, unique=False, required=True, type='java.sql.Timestamp'),
             Field(name='timestampModified', column='TimestampModified', indexed=False, unique=False, required=False, type='java.sql.Timestamp'),
-            Field(name='version', column='Version', indexed=False, unique=False, required=True, type='java.lang.Integer')
+            Field(name='version', column='Version', indexed=False, unique=False, required=False, type='java.lang.Integer')
         ],
         indexes=[
 
@@ -6284,7 +6284,7 @@ datamodel = Datamodel(tables=[
             Field(name='schemaVersion', column='SchemaVersion', indexed=False, unique=False, required=False, type='java.lang.String', length=80),
             Field(name='timestampCreated', column='TimestampCreated', indexed=False, unique=False, required=True, type='java.sql.Timestamp'),
             Field(name='timestampModified', column='TimestampModified', indexed=False, unique=False, required=False, type='java.sql.Timestamp'),
-            Field(name='version', column='Version', indexed=False, unique=False, required=True, type='java.lang.Integer')
+            Field(name='version', column='Version', indexed=False, unique=False, required=False, type='java.lang.Integer')
         ],
         indexes=[
 
@@ -6315,7 +6315,7 @@ datamodel = Datamodel(tables=[
             Field(name='formatter', column='Formatter', indexed=False, unique=False, required=False, type='java.lang.String', length=32),
             Field(name='timestampCreated', column='TimestampCreated', indexed=False, unique=False, required=True, type='java.sql.Timestamp'),
             Field(name='timestampModified', column='TimestampModified', indexed=False, unique=False, required=False, type='java.sql.Timestamp'),
-            Field(name='version', column='Version', indexed=False, unique=False, required=True, type='java.lang.Integer')
+            Field(name='version', column='Version', indexed=False, unique=False, required=False, type='java.lang.Integer')
         ],
         indexes=[
 
@@ -6345,7 +6345,7 @@ datamodel = Datamodel(tables=[
             Field(name='rowType', column='RowType', indexed=False, unique=False, required=False, type='java.lang.String', length=500),
             Field(name='timestampCreated', column='TimestampCreated', indexed=False, unique=False, required=True, type='java.sql.Timestamp'),
             Field(name='timestampModified', column='TimestampModified', indexed=False, unique=False, required=False, type='java.sql.Timestamp'),
-            Field(name='version', column='Version', indexed=False, unique=False, required=True, type='java.lang.Integer')
+            Field(name='version', column='Version', indexed=False, unique=False, required=False, type='java.lang.Integer')
         ],
         indexes=[
 
@@ -6376,7 +6376,7 @@ datamodel = Datamodel(tables=[
             Field(name='timestampCreated', column='TimestampCreated', indexed=False, unique=False, required=True, type='java.sql.Timestamp'),
             Field(name='timestampExported', column='TimeStampExported', indexed=False, unique=False, required=False, type='java.sql.Timestamp'),
             Field(name='timestampModified', column='TimestampModified', indexed=False, unique=False, required=False, type='java.sql.Timestamp'),
-            Field(name='version', column='Version', indexed=False, unique=False, required=True, type='java.lang.Integer')
+            Field(name='version', column='Version', indexed=False, unique=False, required=False, type='java.lang.Integer')
         ],
         indexes=[
             Index(name='SPEXPSCHMMAPColMemIDX', column_names=['CollectionMemberID'])
@@ -6408,7 +6408,7 @@ datamodel = Datamodel(tables=[
             Field(name='tableName', column='TableName', indexed=False, unique=False, required=False, type='java.lang.String', length=32),
             Field(name='timestampCreated', column='TimestampCreated', indexed=False, unique=False, required=True, type='java.sql.Timestamp'),
             Field(name='timestampModified', column='TimestampModified', indexed=False, unique=False, required=False, type='java.sql.Timestamp'),
-            Field(name='version', column='Version', indexed=False, unique=False, required=True, type='java.lang.Integer')
+            Field(name='version', column='Version', indexed=False, unique=False, required=False, type='java.lang.Integer')
         ],
         indexes=[
             Index(name='SpFieldValueDefaultColMemIDX', column_names=['CollectionMemberID'])
@@ -6442,7 +6442,7 @@ datamodel = Datamodel(tables=[
             Field(name='timestampCreated', column='TimestampCreated', indexed=False, unique=False, required=True, type='java.sql.Timestamp'),
             Field(name='timestampModified', column='TimestampModified', indexed=False, unique=False, required=False, type='java.sql.Timestamp'),
             Field(name='type', column='Type', indexed=False, unique=False, required=False, type='java.lang.String', length=32),
-            Field(name='version', column='Version', indexed=False, unique=False, required=True, type='java.lang.Integer')
+            Field(name='version', column='Version', indexed=False, unique=False, required=False, type='java.lang.Integer')
         ],
         indexes=[
             Index(name='SpLocaleContainerNameIDX', column_names=['Name'])
@@ -6478,7 +6478,7 @@ datamodel = Datamodel(tables=[
             Field(name='timestampCreated', column='TimestampCreated', indexed=False, unique=False, required=True, type='java.sql.Timestamp'),
             Field(name='timestampModified', column='TimestampModified', indexed=False, unique=False, required=False, type='java.sql.Timestamp'),
             Field(name='type', column='Type', indexed=False, unique=False, required=False, type='java.lang.String', length=32),
-            Field(name='version', column='Version', indexed=False, unique=False, required=True, type='java.lang.Integer'),
+            Field(name='version', column='Version', indexed=False, unique=False, required=False, type='java.lang.Integer'),
             Field(name='webLinkName', column='WebLinkName', indexed=False, unique=False, required=False, type='java.lang.String', length=32)
         ],
         indexes=[
@@ -6511,7 +6511,7 @@ datamodel = Datamodel(tables=[
             Field(name='timestampCreated', column='TimestampCreated', indexed=False, unique=False, required=True, type='java.sql.Timestamp'),
             Field(name='timestampModified', column='TimestampModified', indexed=False, unique=False, required=False, type='java.sql.Timestamp'),
             Field(name='variant', column='Variant', indexed=False, unique=False, required=False, type='java.lang.String', length=2),
-            Field(name='version', column='Version', indexed=False, unique=False, required=True, type='java.lang.Integer')
+            Field(name='version', column='Version', indexed=False, unique=False, required=False, type='java.lang.Integer')
         ],
         indexes=[
             Index(name='SpLocaleLanguageIDX', column_names=['Language']),
@@ -6569,7 +6569,7 @@ datamodel = Datamodel(tables=[
             Field(name='remarks', column='Remarks', indexed=False, unique=False, required=False, type='text'),
             Field(name='timestampCreated', column='TimestampCreated', indexed=False, unique=False, required=True, type='java.sql.Timestamp'),
             Field(name='timestampModified', column='TimestampModified', indexed=False, unique=False, required=False, type='java.sql.Timestamp'),
-            Field(name='version', column='Version', indexed=False, unique=False, required=True, type='java.lang.Integer')
+            Field(name='version', column='Version', indexed=False, unique=False, required=False, type='java.lang.Integer')
         ],
         indexes=[
 
@@ -6609,7 +6609,7 @@ datamodel = Datamodel(tables=[
             Field(name='sqlStr', column='SqlStr', indexed=False, unique=False, required=False, type='text', length=4096),
             Field(name='timestampCreated', column='TimestampCreated', indexed=False, unique=False, required=True, type='java.sql.Timestamp'),
             Field(name='timestampModified', column='TimestampModified', indexed=False, unique=False, required=False, type='java.sql.Timestamp'),
-            Field(name='version', column='Version', indexed=False, unique=False, required=True, type='java.lang.Integer')
+            Field(name='version', column='Version', indexed=False, unique=False, required=False, type='java.lang.Integer')
         ],
         indexes=[
             Index(name='SpQueryNameIDX', column_names=['Name'])
@@ -6654,7 +6654,7 @@ datamodel = Datamodel(tables=[
             Field(name='tableList', column='TableList', indexed=False, unique=False, required=True, type='java.lang.String', length=500),
             Field(name='timestampCreated', column='TimestampCreated', indexed=False, unique=False, required=True, type='java.sql.Timestamp'),
             Field(name='timestampModified', column='TimestampModified', indexed=False, unique=False, required=False, type='java.sql.Timestamp'),
-            Field(name='version', column='Version', indexed=False, unique=False, required=True, type='java.lang.Integer'),
+            Field(name='version', column='Version', indexed=False, unique=False, required=False, type='java.lang.Integer'),
             Field(name='isStrict', column='IsStrict', indexed=False, unique=False, required=True, type='java.lang.Boolean')
         ],
         indexes=[
@@ -6685,7 +6685,7 @@ datamodel = Datamodel(tables=[
             Field(name='repeatField', column='RepeatField', indexed=False, unique=False, required=False, type='java.lang.String', length=255),
             Field(name='timestampCreated', column='TimestampCreated', indexed=False, unique=False, required=True, type='java.sql.Timestamp'),
             Field(name='timestampModified', column='TimestampModified', indexed=False, unique=False, required=False, type='java.sql.Timestamp'),
-            Field(name='version', column='Version', indexed=False, unique=False, required=True, type='java.lang.Integer')
+            Field(name='version', column='Version', indexed=False, unique=False, required=False, type='java.lang.Integer')
         ],
         indexes=[
             Index(name='SpReportNameIDX', column_names=['Name'])
@@ -6720,7 +6720,7 @@ datamodel = Datamodel(tables=[
             Field(name='symbiotaKey', column='SymbiotaKey', indexed=False, unique=False, required=False, type='java.lang.String', length=128),
             Field(name='timestampCreated', column='TimestampCreated', indexed=False, unique=False, required=True, type='java.sql.Timestamp'),
             Field(name='timestampModified', column='TimestampModified', indexed=False, unique=False, required=False, type='java.sql.Timestamp'),
-            Field(name='version', column='Version', indexed=False, unique=False, required=True, type='java.lang.Integer')
+            Field(name='version', column='Version', indexed=False, unique=False, required=False, type='java.lang.Integer')
         ],
         indexes=[
             Index(name='SPSYMINSTColMemIDX', column_names=['CollectionMemberID'])
@@ -6752,7 +6752,7 @@ datamodel = Datamodel(tables=[
             Field(name='timestampCreated', column='TimestampCreated', indexed=False, unique=False, required=True, type='java.sql.Timestamp'),
             Field(name='timestampModified', column='TimestampModified', indexed=False, unique=False, required=False, type='java.sql.Timestamp'),
             Field(name='usageCount', column='UsageCount', indexed=False, unique=False, required=False, type='java.lang.Integer'),
-            Field(name='version', column='Version', indexed=False, unique=False, required=True, type='java.lang.Integer')
+            Field(name='version', column='Version', indexed=False, unique=False, required=False, type='java.lang.Integer')
         ],
         indexes=[
 
@@ -6784,7 +6784,7 @@ datamodel = Datamodel(tables=[
             Field(name='schemaVersion', column='SchemaVersion', indexed=False, unique=False, required=False, type='java.lang.String', length=16),
             Field(name='timestampCreated', column='TimestampCreated', indexed=False, unique=False, required=True, type='java.sql.Timestamp'),
             Field(name='timestampModified', column='TimestampModified', indexed=False, unique=False, required=False, type='java.sql.Timestamp'),
-            Field(name='version', column='Version', indexed=False, unique=False, required=True, type='java.lang.Integer'),
+            Field(name='version', column='Version', indexed=False, unique=False, required=False, type='java.lang.Integer'),
             Field(name='workbenchSchemaVersion', column='WorkbenchSchemaVersion', indexed=False, unique=False, required=False, type='java.lang.String', length=16)
         ],
         indexes=[
@@ -6814,7 +6814,7 @@ datamodel = Datamodel(tables=[
             Field(name='name', column='Name', indexed=True, unique=False, required=True, type='java.lang.String', length=64),
             Field(name='timestampCreated', column='TimestampCreated', indexed=False, unique=False, required=True, type='java.sql.Timestamp'),
             Field(name='timestampModified', column='TimestampModified', indexed=False, unique=False, required=False, type='java.sql.Timestamp'),
-            Field(name='version', column='Version', indexed=False, unique=False, required=True, type='java.lang.Integer')
+            Field(name='version', column='Version', indexed=False, unique=False, required=False, type='java.lang.Integer')
         ],
         indexes=[
             Index(name='SpViewObjNameIDX', column_names=['Name'])
@@ -6842,7 +6842,7 @@ datamodel = Datamodel(tables=[
             Field(name='name', column='Name', indexed=True, unique=False, required=True, type='java.lang.String', length=64),
             Field(name='timestampCreated', column='TimestampCreated', indexed=False, unique=False, required=True, type='java.sql.Timestamp'),
             Field(name='timestampModified', column='TimestampModified', indexed=False, unique=False, required=False, type='java.sql.Timestamp'),
-            Field(name='version', column='Version', indexed=False, unique=False, required=True, type='java.lang.Integer')
+            Field(name='version', column='Version', indexed=False, unique=False, required=False, type='java.lang.Integer')
         ],
         indexes=[
             Index(name='SpVisualQueryNameIDX', column_names=['Name'])
@@ -6878,7 +6878,7 @@ datamodel = Datamodel(tables=[
             Field(name='timestampCreated', column='TimestampCreated', indexed=False, unique=False, required=True, type='java.sql.Timestamp'),
             Field(name='timestampModified', column='TimestampModified', indexed=False, unique=False, required=False, type='java.sql.Timestamp'),
             Field(name='userType', column='UserType', indexed=False, unique=False, required=False, type='java.lang.String', length=32),
-            Field(name='version', column='Version', indexed=False, unique=False, required=True, type='java.lang.Integer')
+            Field(name='version', column='Version', indexed=False, unique=False, required=False, type='java.lang.Integer')
         ],
         indexes=[
 
@@ -6922,7 +6922,7 @@ datamodel = Datamodel(tables=[
             Field(name='timestampCreated', column='TimestampCreated', indexed=False, unique=False, required=True, type='java.sql.Timestamp'),
             Field(name='timestampModified', column='TimestampModified', indexed=False, unique=False, required=False, type='java.sql.Timestamp'),
             Field(name='timestampVersion', column='TimestampVersion', indexed=False, unique=False, required=False, type='java.util.Date'),
-            Field(name='version', column='Version', indexed=False, unique=False, required=True, type='java.lang.Integer'),
+            Field(name='version', column='Version', indexed=False, unique=False, required=False, type='java.lang.Integer'),
             Field(name='uniqueIdentifier', column='UniqueIdentifier', indexed=True, unique=True, required=False, type='java.lang.String', length=128),
         ],
         indexes=[
@@ -6961,7 +6961,7 @@ datamodel = Datamodel(tables=[
             Field(name='remarks', column='Remarks', indexed=False, unique=False, required=False, type='text', length=4096),
             Field(name='timestampCreated', column='TimestampCreated', indexed=False, unique=False, required=True, type='java.sql.Timestamp'),
             Field(name='timestampModified', column='TimestampModified', indexed=False, unique=False, required=False, type='java.sql.Timestamp'),
-            Field(name='version', column='Version', indexed=False, unique=False, required=True, type='java.lang.Integer')
+            Field(name='version', column='Version', indexed=False, unique=False, required=False, type='java.lang.Integer')
         ],
         indexes=[
 
@@ -6991,7 +6991,7 @@ datamodel = Datamodel(tables=[
             Field(name='remarks', column='Remarks', indexed=False, unique=False, required=False, type='text', length=4096),
             Field(name='timestampCreated', column='TimestampCreated', indexed=False, unique=False, required=True, type='java.sql.Timestamp'),
             Field(name='timestampModified', column='TimestampModified', indexed=False, unique=False, required=False, type='java.sql.Timestamp'),
-            Field(name='version', column='Version', indexed=False, unique=False, required=True, type='java.lang.Integer')
+            Field(name='version', column='Version', indexed=False, unique=False, required=False, type='java.lang.Integer')
         ],
         indexes=[
 
@@ -7026,7 +7026,7 @@ datamodel = Datamodel(tables=[
             Field(name='timestampCreated', column='TimestampCreated', indexed=False, unique=False, required=True, type='java.sql.Timestamp'),
             Field(name='timestampModified', column='TimestampModified', indexed=False, unique=False, required=False, type='java.sql.Timestamp'),
             Field(name='title', column='Title', indexed=False, unique=False, required=False, type='java.lang.String', length=64),
-            Field(name='version', column='Version', indexed=False, unique=False, required=True, type='java.lang.Integer')
+            Field(name='version', column='Version', indexed=False, unique=False, required=False, type='java.lang.Integer')
         ],
         indexes=[
 
@@ -7115,7 +7115,7 @@ datamodel = Datamodel(tables=[
             Field(name='unitName3', column='UnitName3', indexed=False, unique=False, required=False, type='java.lang.String', length=50),
             Field(name='unitName4', column='UnitName4', indexed=False, unique=False, required=False, type='java.lang.String', length=50),
             Field(name='usfwsCode', column='UsfwsCode', indexed=False, unique=False, required=False, type='java.lang.String', length=16),
-            Field(name='version', column='Version', indexed=False, unique=False, required=True, type='java.lang.Integer'),
+            Field(name='version', column='Version', indexed=False, unique=False, required=False, type='java.lang.Integer'),
             Field(name='visibility', column='Visibility', indexed=False, unique=False, required=False, type='java.lang.Byte'),
             Field(name='yesNo1', column='YesNo1', indexed=False, unique=False, required=False, type='java.lang.Boolean'),
             Field(name='yesNo10', column='YesNo10', indexed=False, unique=False, required=False, type='java.lang.Boolean'),
@@ -7185,7 +7185,7 @@ datamodel = Datamodel(tables=[
             Field(name='remarks', column='Remarks', indexed=False, unique=False, required=False, type='text', length=4096),
             Field(name='timestampCreated', column='TimestampCreated', indexed=False, unique=False, required=True, type='java.sql.Timestamp'),
             Field(name='timestampModified', column='TimestampModified', indexed=False, unique=False, required=False, type='java.sql.Timestamp'),
-            Field(name='version', column='Version', indexed=False, unique=False, required=True, type='java.lang.Integer')
+            Field(name='version', column='Version', indexed=False, unique=False, required=False, type='java.lang.Integer')
         ],
         indexes=[
 
@@ -7293,7 +7293,7 @@ datamodel = Datamodel(tables=[
             Field(name='text9', column='Text9', indexed=False, unique=False, required=False, type='java.lang.String', length=128),
             Field(name='timestampCreated', column='TimestampCreated', indexed=False, unique=False, required=True, type='java.sql.Timestamp'),
             Field(name='timestampModified', column='TimestampModified', indexed=False, unique=False, required=False, type='java.sql.Timestamp'),
-            Field(name='version', column='Version', indexed=False, unique=False, required=True, type='java.lang.Integer'),
+            Field(name='version', column='Version', indexed=False, unique=False, required=False, type='java.lang.Integer'),
             Field(name='yesNo1', column='YesNo1', indexed=False, unique=False, required=False, type='java.lang.Boolean'),
             Field(name='yesNo10', column='YesNo10', indexed=False, unique=False, required=False, type='java.lang.Boolean'),
             Field(name='yesNo11', column='YesNo11', indexed=False, unique=False, required=False, type='java.lang.Boolean'),
@@ -7409,7 +7409,7 @@ datamodel = Datamodel(tables=[
             Field(name='text2', column='Text2', indexed=False, unique=False, required=False, type='text', length=65535),
             Field(name='timestampCreated', column='TimestampCreated', indexed=False, unique=False, required=True, type='java.sql.Timestamp'),
             Field(name='timestampModified', column='TimestampModified', indexed=False, unique=False, required=False, type='java.sql.Timestamp'),
-            Field(name='version', column='Version', indexed=False, unique=False, required=True, type='java.lang.Integer'),
+            Field(name='version', column='Version', indexed=False, unique=False, required=False, type='java.lang.Integer'),
             Field(name='yesNo1', column='YesNo1', indexed=False, unique=False, required=False, type='java.lang.Boolean'),
             Field(name='yesNo2', column='YesNo2', indexed=False, unique=False, required=False, type='java.lang.Boolean')
         ],
@@ -7439,7 +7439,7 @@ datamodel = Datamodel(tables=[
             Field(name='remarks', column='Remarks', indexed=False, unique=False, required=False, type='java.lang.String', length=255),
             Field(name='timestampCreated', column='TimestampCreated', indexed=False, unique=False, required=True, type='java.sql.Timestamp'),
             Field(name='timestampModified', column='TimestampModified', indexed=False, unique=False, required=False, type='java.sql.Timestamp'),
-            Field(name='version', column='Version', indexed=False, unique=False, required=True, type='java.lang.Integer')
+            Field(name='version', column='Version', indexed=False, unique=False, required=False, type='java.lang.Integer')
         ],
         indexes=[
 
@@ -7475,7 +7475,7 @@ datamodel = Datamodel(tables=[
             Field(name='timestampCreated', column='TimestampCreated', indexed=False, unique=False, required=True, type='java.sql.Timestamp'),
             Field(name='timestampModified', column='TimestampModified', indexed=False, unique=False, required=False, type='java.sql.Timestamp'),
             Field(name='title', column='Title', indexed=False, unique=False, required=False, type='java.lang.String', length=64),
-            Field(name='version', column='Version', indexed=False, unique=False, required=True, type='java.lang.Integer')
+            Field(name='version', column='Version', indexed=False, unique=False, required=False, type='java.lang.Integer')
         ],
         indexes=[
 
@@ -7526,7 +7526,7 @@ datamodel = Datamodel(tables=[
             Field(name='timestampModified', column='TimestampModified', indexed=False, unique=False, required=False, type='java.sql.Timestamp'),
             Field(name='treatmentNumber', column='TreatmentNumber', indexed=True, unique=False, required=False, type='java.lang.String', length=32),
             Field(name='type', column='Type', indexed=False, unique=False, required=False, type='java.lang.String', length=128),
-            Field(name='version', column='Version', indexed=False, unique=False, required=True, type='java.lang.Integer'),
+            Field(name='version', column='Version', indexed=False, unique=False, required=False, type='java.lang.Integer'),
             Field(name='yesNo1', column='YesNo1', indexed=False, unique=False, required=False, type='java.lang.Boolean'),
             Field(name='yesNo2', column='YesNo2', indexed=False, unique=False, required=False, type='java.lang.Boolean'),
             Field(name='yesNo3', column='YesNo3', indexed=False, unique=False, required=False, type='java.lang.Boolean')
@@ -7564,7 +7564,7 @@ datamodel = Datamodel(tables=[
             Field(name='remarks', column='Remarks', indexed=False, unique=False, required=False, type='text', length=4096),
             Field(name='timestampCreated', column='TimestampCreated', indexed=False, unique=False, required=True, type='java.sql.Timestamp'),
             Field(name='timestampModified', column='TimestampModified', indexed=False, unique=False, required=False, type='java.sql.Timestamp'),
-            Field(name='version', column='Version', indexed=False, unique=False, required=True, type='java.lang.Integer')
+            Field(name='version', column='Version', indexed=False, unique=False, required=False, type='java.lang.Integer')
         ],
         indexes=[
 
@@ -7605,7 +7605,7 @@ datamodel = Datamodel(tables=[
             Field(name='timestampCreated', column='TimestampCreated', indexed=False, unique=False, required=True, type='java.sql.Timestamp'),
             Field(name='timestampModified', column='TimestampModified', indexed=False, unique=False, required=False, type='java.sql.Timestamp'),
             Field(name='urlLink', column='UrlLink', indexed=False, unique=False, required=False, type='java.lang.String', length=1024),
-            Field(name='version', column='Version', indexed=False, unique=False, required=True, type='java.lang.Integer'),
+            Field(name='version', column='Version', indexed=False, unique=False, required=False, type='java.lang.Integer'),
             Field(name='voucherNumber', column='VoucherNumber', indexed=False, unique=False, required=False, type='java.lang.String', length=256),
             Field(name='yesNo1', column='YesNo1', indexed=False, unique=False, required=False, type='java.lang.Boolean'),
             Field(name='yesNo2', column='YesNo2', indexed=False, unique=False, required=False, type='java.lang.Boolean'),
@@ -7647,7 +7647,7 @@ datamodel = Datamodel(tables=[
             Field(name='srcFilePath', column='SrcFilePath', indexed=False, unique=False, required=False, type='java.lang.String', length=255),
             Field(name='timestampCreated', column='TimestampCreated', indexed=False, unique=False, required=True, type='java.sql.Timestamp'),
             Field(name='timestampModified', column='TimestampModified', indexed=False, unique=False, required=False, type='java.sql.Timestamp'),
-            Field(name='version', column='Version', indexed=False, unique=False, required=True, type='java.lang.Integer')
+            Field(name='version', column='Version', indexed=False, unique=False, required=False, type='java.lang.Integer')
         ],
         indexes=[
             Index(name='WorkbenchNameIDX', column_names=['name'])
@@ -7739,7 +7739,7 @@ datamodel = Datamodel(tables=[
             Field(name='tableName', column='TableName', indexed=False, unique=False, required=False, type='java.lang.String', length=120),
             Field(name='timestampCreated', column='TimestampCreated', indexed=False, unique=False, required=True, type='java.sql.Timestamp'),
             Field(name='timestampModified', column='TimestampModified', indexed=False, unique=False, required=False, type='java.sql.Timestamp'),
-            Field(name='version', column='Version', indexed=False, unique=False, required=True, type='java.lang.Integer')
+            Field(name='version', column='Version', indexed=False, unique=False, required=False, type='java.lang.Integer')
         ],
         indexes=[
 
@@ -7791,7 +7791,7 @@ datamodel = Datamodel(tables=[
             Field(name='srcFilePath', column='SrcFilePath', indexed=False, unique=False, required=False, type='java.lang.String', length=255),
             Field(name='timestampCreated', column='TimestampCreated', indexed=False, unique=False, required=True, type='java.sql.Timestamp'),
             Field(name='timestampModified', column='TimestampModified', indexed=False, unique=False, required=False, type='java.sql.Timestamp'),
-            Field(name='version', column='Version', indexed=False, unique=False, required=True, type='java.lang.Integer')
+            Field(name='version', column='Version', indexed=False, unique=False, required=False, type='java.lang.Integer')
         ],
         indexes=[
 
@@ -7832,7 +7832,7 @@ datamodel = Datamodel(tables=[
             Field(name='tableName', column='TableName', indexed=False, unique=False, required=False, type='java.lang.String', length=64),
             Field(name='timestampCreated', column='TimestampCreated', indexed=False, unique=False, required=True, type='java.sql.Timestamp'),
             Field(name='timestampModified', column='TimestampModified', indexed=False, unique=False, required=False, type='java.sql.Timestamp'),
-            Field(name='version', column='Version', indexed=False, unique=False, required=True, type='java.lang.Integer'),
+            Field(name='version', column='Version', indexed=False, unique=False, required=False, type='java.lang.Integer'),
             Field(name='viewOrder', column='ViewOrder', indexed=False, unique=False, required=False, type='java.lang.Short'),
             Field(name='xCoord', column='XCoord', indexed=False, unique=False, required=False, type='java.lang.Short'),
             Field(name='yCoord', column='YCoord', indexed=False, unique=False, required=False, type='java.lang.Short')
@@ -8260,7 +8260,7 @@ datamodel = Datamodel(tables=[
         idField=IdField(name='collectionObjectTypeId', column='collectionObjectTypeID', type='java.lang.Integer'),
         fields=[
             Field(name='name', column='Name', indexed=False, unique=False, required=True, type='java.lang.String', length=255),
-            Field(name='version', column='Version', indexed=False, unique=False, required=True, type='java.lang.Integer'),
+            Field(name='version', column='Version', indexed=False, unique=False, required=False, type='java.lang.Integer'),
             Field(name='timestampCreated', column='TimestampCreated', indexed=False, unique=False, required=True, type='java.sql.Timestamp'),
             Field(name='timestampModified', column='TimestampModified', indexed=False, unique=False, required=False, type='java.sql.Timestamp'),
             Field(name='text1', column='Text1', indexed=False, unique=False, required=False, type='java.lang.String', length=255),
@@ -8295,7 +8295,7 @@ datamodel = Datamodel(tables=[
             Field(name='description', column='Description', indexed=False, unique=False, required=False, type='text'),
             Field(name='igsn', column='IGSN', indexed=False, unique=False, required=False, type='java.lang.String', length=255),
             Field(name='guid', column='GUID', indexed=False, unique=False, required=False, type='java.lang.String', length=255),
-            Field(name='version', column='Version', indexed=False, unique=False, required=True, type='java.lang.Integer'),
+            Field(name='version', column='Version', indexed=False, unique=False, required=False, type='java.lang.Integer'),
             Field(name='timestampCreated', column='TimestampCreated', indexed=False, unique=False, required=True, type='java.sql.Timestamp'),
             Field(name='timestampModified', column='TimestampModified', indexed=False, unique=False, required=False, type='java.sql.Timestamp'),
             Field(name='text1', column='Text1', indexed=False, unique=False, required=False, type='java.lang.String', length=255),
@@ -8339,7 +8339,7 @@ datamodel = Datamodel(tables=[
             Field(name='isPrimary', column='IsPrimary', indexed=False, unique=False, required=True, type='java.lang.Boolean'),
             Field(name='isSubstrate', column='IsSubstrate', indexed=False, unique=False, required=True, type='java.lang.Boolean'),
             Field(name='precedence', column='Precedence', indexed=False, unique=False, required=True, type='java.lang.Integer'),
-            Field(name='version', column='Version', indexed=False, unique=False, required=True, type='java.lang.Integer'),
+            Field(name='version', column='Version', indexed=False, unique=False, required=False, type='java.lang.Integer'),
             Field(name='timestampCreated', column='TimestampCreated', indexed=False, unique=False, required=True, type='java.sql.Timestamp'),
             Field(name='timestampModified', column='TimestampModified', indexed=False, unique=False, required=False, type='java.sql.Timestamp'),
             Field(name='text1', column='Text1', indexed=False, unique=False, required=False, type='java.lang.String', length=255),
@@ -8376,7 +8376,7 @@ datamodel = Datamodel(tables=[
         fields=[
             Field(name='name', column='Name', indexed=False, unique=False, required=True, type='java.lang.String', length=255),
             Field(name='type', column='Type', indexed=False, unique=False, required=True, type='java.lang.String', length=255),
-            Field(name='version', column='Version', indexed=False, unique=False, required=True, type='java.lang.Integer'),
+            Field(name='version', column='Version', indexed=False, unique=False, required=False, type='java.lang.Integer'),
             Field(name='timestampCreated', column='TimestampCreated', indexed=False, unique=False, required=True, type='java.sql.Timestamp'),
             Field(name='timestampModified', column='TimestampModified', indexed=False, unique=False, required=False, type='java.sql.Timestamp'),
         ],
@@ -8419,7 +8419,7 @@ datamodel = Datamodel(tables=[
             Field(name='timestampModified', column='TimestampModified', indexed=False, unique=False, required=False, type='java.sql.Timestamp'),
             Field(name='yesno1', column='YesNo1', indexed=False, unique=False, required=False, type='java.lang.Boolean'),
             Field(name='yesno2', column='YesNo2', indexed=False, unique=False, required=False, type='java.lang.Boolean'),
-            Field(name='version', column='Version', indexed=False, unique=False, required=True, type='java.lang.Integer'),
+            Field(name='version', column='Version', indexed=False, unique=False, required=False, type='java.lang.Integer'),
         ],
         indexes=[
 
@@ -8465,7 +8465,7 @@ datamodel = Datamodel(tables=[
             Field(name='verbatimPeriod', column='VerbatimPeriod', indexed=False, unique=False, required=False, type='text'),
             Field(name='yesno1', column='YesNo1', indexed=False, unique=False, required=False, type='java.lang.Boolean'),
             Field(name='yesno2', column='YesNo2', indexed=False, unique=False, required=False, type='java.lang.Boolean'),
-            Field(name='version', column='Version', indexed=False, unique=False, required=True, type='java.lang.Integer'),
+            Field(name='version', column='Version', indexed=False, unique=False, required=False, type='java.lang.Integer'),
         ],
         indexes=[
 
@@ -8499,7 +8499,7 @@ datamodel = Datamodel(tables=[
             Field(name='remarks', column='Remarks', indexed=False, unique=False, required=False, type='text'),
             Field(name='timestampCreated', column='TimestampCreated', indexed=False, unique=False, required=True, type='java.sql.Timestamp'),
             Field(name='timestampModified', column='TimestampModified', indexed=False, unique=False, required=False, type='java.sql.Timestamp'),
-            Field(name='version', column='Version', indexed=False, unique=False, required=True, type='java.lang.Integer'),
+            Field(name='version', column='Version', indexed=False, unique=False, required=False, type='java.lang.Integer'),
         ],
         indexes=[
 
@@ -8529,7 +8529,7 @@ datamodel = Datamodel(tables=[
             Field(name='remarks', column='Remarks', indexed=False, unique=False, required=False, type='text'),
             Field(name='timestampCreated', column='TimestampCreated', indexed=False, unique=False, required=True, type='java.sql.Timestamp'),
             Field(name='timestampModified', column='TimestampModified', indexed=False, unique=False, required=False, type='java.sql.Timestamp'),
-            Field(name='version', column='Version', indexed=False, unique=False, required=True, type='java.lang.Integer'),
+            Field(name='version', column='Version', indexed=False, unique=False, required=False, type='java.lang.Integer'),
         ],
         indexes=[
 
@@ -8562,7 +8562,7 @@ datamodel = Datamodel(tables=[
             Field(name='remarks', column='Remarks', indexed=False, unique=False, required=False, type='text'),
             Field(name='timestampCreated', column='TimestampCreated', indexed=False, unique=False, required=True, type='java.sql.Timestamp'),
             Field(name='timestampModified', column='TimestampModified', indexed=False, unique=False, required=False, type='java.sql.Timestamp'),
-            Field(name='version', column='Version', indexed=False, unique=False, required=True, type='java.lang.Integer'),
+            Field(name='version', column='Version', indexed=False, unique=False, required=False, type='java.lang.Integer'),
         ],
         indexes=[
 
@@ -8595,7 +8595,7 @@ datamodel = Datamodel(tables=[
             Field(name='remarks', column='Remarks', indexed=False, unique=False, required=False, type='text'),
             Field(name='timestampCreated', column='TimestampCreated', indexed=False, unique=False, required=True, type='java.sql.Timestamp'),
             Field(name='timestampModified', column='TimestampModified', indexed=False, unique=False, required=False, type='java.sql.Timestamp'),
-            Field(name='version', column='Version', indexed=False, unique=False, required=True, type='java.lang.Integer'),
+            Field(name='version', column='Version', indexed=False, unique=False, required=False, type='java.lang.Integer'),
         ],
         indexes=[
 
@@ -8626,7 +8626,7 @@ datamodel = Datamodel(tables=[
             Field(name='remarks', column='Remarks', indexed=False, unique=False, required=False, type='text'),
             Field(name='timestampCreated', column='TimestampCreated', indexed=False, unique=False, required=True, type='java.sql.Timestamp'),
             Field(name='timestampModified', column='TimestampModified', indexed=False, unique=False, required=False, type='java.sql.Timestamp'),
-            Field(name='version', column='Version', indexed=False, unique=False, required=True, type='java.lang.Integer'),
+            Field(name='version', column='Version', indexed=False, unique=False, required=False, type='java.lang.Integer'),
         ],
         indexes=[
 
@@ -8663,7 +8663,7 @@ datamodel = Datamodel(tables=[
             Field(name='timestampCreated', column='TimestampCreated', indexed=False, unique=False, required=True, type='java.sql.Timestamp'),
             Field(name='timestampModified', column='TimestampModified', indexed=False, unique=False, required=False, type='java.sql.Timestamp'),
             Field(name='title', column='Title', indexed=False, unique=False, required=False, type='java.lang.String', length=255),
-            Field(name='version', column='Version', indexed=False, unique=False, required=True, type='java.lang.Integer'),
+            Field(name='version', column='Version', indexed=False, unique=False, required=False, type='java.lang.Integer'),
         ],
         indexes=[
 
@@ -8705,7 +8705,7 @@ datamodel = Datamodel(tables=[
             Field(name='text2', column='Text2', indexed=False, unique=False, required=False, type='java.lang.String', length=255),
             Field(name='timestampCreated', column='TimestampCreated', indexed=False, unique=False, required=True, type='java.sql.Timestamp'),
             Field(name='timestampModified', column='TimestampModified', indexed=False, unique=False, required=False, type='java.sql.Timestamp'),
-            Field(name='version', column='Version', indexed=False, unique=False, required=True, type='java.lang.Integer'),
+            Field(name='version', column='Version', indexed=False, unique=False, required=False, type='java.lang.Integer'),
             Field(name='yesno1', column='YesNo1', indexed=False, unique=False, required=False, type='java.lang.Boolean'),
             Field(name='yesno2', column='YesNo2', indexed=False, unique=False, required=False, type='java.lang.Boolean')
         ],
@@ -8741,7 +8741,7 @@ datamodel = Datamodel(tables=[
             Field(name='remarks', column='Remarks', indexed=False, unique=False, required=False, type='text'),
             Field(name='timestampCreated', column='TimestampCreated', indexed=False, unique=False, required=True, type='java.sql.Timestamp'),
             Field(name='timestampModified', column='TimestampModified', indexed=False, unique=False, required=False, type='java.sql.Timestamp'),
-            Field(name='version', column='Version', indexed=False, unique=False, required=False, type='java.lang.Integer')
+            Field(name='version', column='Version', indexed=False, unique=False, required=Falsee, type='java.lang.Integer')
         ],
         indexes=[
             Index(name='SpDataSetAttColMemIDX', column_names=['CollectionMemberID'])


### PR DESCRIPTION
Fixes #6835

<!--
> [!WARNING]  
> This PR affects database migrations. See [migration testing instructions](https://specify.github.io/testing/pull_requests.html#prs-tagged-with-label-migration).
-->

### Checklist

- [ ] Self-review the PR after opening it to make sure the changes look good and
      self-explanatory (or properly documented)
- [ ] Add relevant issue to release milestone
- [ ] Add a reverse migration if a migration is present in the PR

### Testing instructions

- Create a Workbench Data Set, and select any table as the Base Table
- [ ] Verify that Version is a not a required field
