### PR TITLE
Fix EML `<pubDate>` element ordering and add XML declaration

### DIFF
--- a/specifyweb/export/dwca.py
+++ b/specifyweb/export/dwca.py
@@ -250,4 +250,22 @@ def write_eml(source, output_path, pub_date=None, package_id=None):
 
     pubDate = ET.SubElement(dataset, 'pubDate')
     pubDate.text = pub_date.isoformat()
-    ET.ElementTree(eml).write(output_path, encoding='utf-8')
+
+    # Common EML order: title, creator, metadataProvider, associatedParty, pubDate, language, abstract, etc.
+    # Insert pubDate after the last associatedParty, if it exists.
+    # If no associatedParty is found, insert pubDate at the end of the dataset.
+    attribute = list(dataset)
+    insert_position = len(attribute)
+
+    # Look for specific elements to position pubDate correctly
+    for i, element in enumerate(attribute):
+        if element.tag in ['language', 'abstract', 'keywordSet', 'intellectualRights', 
+                          'distribution', 'coverage', 'contact', 'methods', 'project']:
+            insert_position = i
+            break
+    
+    dataset.insert(insert_position, pubDate)
+
+    tree = ET.ElementTree(eml)
+    # Write with XML declaration, matching GBIF behavior
+    tree.write(output_path, encoding='utf-8', xml_declaration=True)


### PR DESCRIPTION
Fixes #6421

Ensures the `<pubDate>` element is inserted after the last `<associatedParty>` or before another common element if possible, with a fallback to the previous behavior. Also writes the XML with a declaration to align with GBIF requirements.

### Testing instructions

Perform this testing on both `v7.11.0` and `issue-6421`
- [ ] Create a DwC archive package in a collection with existing DwC export resources
- [ ] Download the DWC archive
- [ ] Extract the archive

Once complete:
- [ ] Compare the two `eml.xml` files to each other
- [ ] Verify that `<pubDate>` appears 

```diff
--- before
+++ after
@@ -1,6 +1,7 @@
-
+<?xml version='1.0' encoding='utf-8'?>
 <eml:eml xmlns:eml="eml://ecoinformatics.org/eml-2.1.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="eml://ecoinformatics.org/eml-2.1.1 http://rs.gbif.org/schema/eml-gbif-profile/1.1/eml.xsd" packageId="e0fcabb5-162c-4bc5-aaed-ae3d074c6f09" system="Specify" scope="system" xml:lang="en">
 
 <dataset>
       <alternateIdentifier>10.15468/bfd6ci</alternateIdentifier>
@@ -23,6 +24,7 @@
     </individualName>
 <electronicMailAddress>albenson@usgs.gov</electronicMailAddress>    <role>USER</role>
     </associatedParty>
-      <language>ENGLISH</language>
+      <pubDate>2025-07-03</pubDate><language>ENGLISH</language>
     <abstract>
         <para>This dataset is generated from the records for specimens housed at the Fish and Wildlife Research institute (FWRI) in St. Petersburg, FL. As a division of the State of Florida’s Fish and Wildlife Conservation Commission (FWC), FWRI houses voucher specimens supporting the research and monitoring efforts of FWC staff and other state agencies, as well as depositions from academic researchers and industrial projects. The samples are largely restricted geographically to the waters in and around Florida, USA. Sampling events primarily span from the 1950s through the present.</para>
     </abstract>
@@ -52,7 +54,7 @@
     </individualName>
 <organizationName>Fish and Wildlife Research Institute</organizationName><positionName>Curator</positionName><electronicMailAddress>SIS@myfwc.com</electronicMailAddress>      </contact>
 
-<pubDate>2024-01-10</pubDate></dataset>
+</dataset>
 
 <additionalMetadata>
     <metadata>
```