### PR TITLE
QueryBuilder: Show catalognumber format tool when mapped to-many

### DIFF
--- a/specifyweb/frontend/js_src/lib/components/QueryBuilder/Line.tsx
+++ b/specifyweb/frontend/js_src/lib/components/QueryBuilder/Line.tsx
@@ -29,6 +29,7 @@ import {
 import type { MappingPath } from '../WbPlanView/Mapper';
 import {
   formattedEntry,
+  getGenericMappingPath,
   mappingPathToString,
   parsePartialField,
   valueIsPartialField,
@@ -426,7 +427,9 @@ export function QueryLine({
               {field.filters.map((filter, index) => {
                 const terminatingField = isFieldComplete
                   ? genericTables[baseTableName].getField(
-                      mappingPathToString(field.mappingPath)
+                      mappingPathToString(
+                        getGenericMappingPath(field.mappingPath)
+                      )
                     )
                   : undefined;
 


### PR DESCRIPTION
Fixes #6990

The underlying Issue here stemmed from the fact that both the WorkBench and QueryBuilder maintains indices when mapping to-many relationships: for example a mapping of `CollectionObject -> determinations` might be mapped "behind the scenes" as `CollectionObject -> determinations -> #1`. In the WorkBench, if a second Determination is mapped then it would be mapped as `CollectionObject -> determinations -> #2`, and so. 

For https://github.com/specify/specify7/pull/5485 when determining the terminating field of the query line/filter, it would use the internal mapping path (including to-many indices). This PR removes to-many indices from the mapping path when determining the terminating field. 

### Checklist

- [ ] Self-review the PR after opening it to make sure the changes look good and
      self-explanatory (or properly documented)
- [ ] Add relevant issue to release milestone
- [ ] Add pr to documentation list
- [ ] Add automated tests
- [ ] Add a reverse migration if a migration is present in the PR

### Testing instructions
- Ensure there are at least two CollectionObjectTypes in the Collection which have different CatalogNumberFormatNames 
  - You can use the QueryBuilder to query on CollectionObjectType and see all types and their formats in a Collection
  - If there are not at least two CollectionObjectTypes with differing CatalogNumberFormatNames, you can always create a new CollectionObjectType (don't forget to log out or reload the page after creating the type, or the format selection tool for catalognumber in the QueryBuilder might not initially appear)
 
- Open or go to a new query for a base table which is not CollectionObject, but has a path to CollectionObject along which there is a least one to-many relationship. 
  - Some examples include: 
 
| Base Table Name | Field Path                                                       |
|-----------------|------------------------------------------------------------------|
| Accession       | collectionObjects -> catalogNumber                               |
| Appraisal       | collectionObjects -> catalogNumber                               |
| CollectingEvent | collectionObjects -> catalogNumber                               |
| Locality        | collectingEvents -> collectionObjects -> catalogNumber           |
| Attachment      | collectionObjectAttachments -> collectionObject -> catalogNumber |

- Add `CollectionObject -> catalogNumber` to the query, and change the filter from `Any` to any filter which expects the format to be preserved (any of `Equal`, `Greater than`, `Greater than or equal to`, `Less than`, `Less than or equal to`, `Between` or `In`)
- [ ] Ensure the gear icon appears next to the query field, and it allows you to select the Catalog Number format for the field

- Open or go to a new query for a base table which has a path to CollectionObject along which there are no to-many relationships
  - Some examples include: 

| Base Table Name  | Field Path                                       |
|------------------|--------------------------------------------------|
| CollectionObject | catalogNumber |
| Preparation      | collectionObject -> catalogNumber                |
| Determination    | collectionObject -> catalogNumber                |
| DNA Sequence     | collectionObject -> catalogNumber                |
| Loan Preparation | preparation -> collectionObject -> catalogNumber | 

- Add `CollectionObject -> catalogNumber` to the query, and change the filter from `Any` to any filter which expects the format to be preserved (any of `Equal`, `Greater than`, `Greater than or equal to`, `Less than`, `Less than or equal to`, `Between` or `In`)
- [ ] Ensure the gear icon appears next to the query field, and it allows you to select the Catalog Number format for the field
