### PR TITLE
uncomment apply_absolute_date

### DIFF
--- a/specifyweb/frontend/js_src/lib/components/QueryBuilder/Wrapped.tsx
+++ b/specifyweb/frontend/js_src/lib/components/QueryBuilder/Wrapped.tsx
@@ -234,19 +234,6 @@ function Wrapped({
       countOnly: mode === 'count',
     });
 
-    // Handle checking if catalogNumber is present for series query
-    const queryFields = getQueryFieldRecords?.(fields) ?? query.fields;
-    const canEnableSmushed =
-      queryFields.length === 0 ||
-      queryFields.some(
-        (field) => field.fieldName === 'catalogNumber' && field.isDisplay
-      );
-    queryResource.set('smushed', canEnableSmushed && query.smushed);
-    setQuery({
-      ...query,
-      smushed: canEnableSmushed && query.smushed,
-    });
-
     /*
      * Wait for new query to propagate before re running it
      * TEST: check if this still works after updating to React 18
@@ -323,6 +310,14 @@ function Wrapped({
       ),
     [state, table.name]
   );
+
+  React.useEffect(() => {
+    if (!showSeries)
+      setQuery({
+        ...query,
+        smushed: false,
+      });
+  }, [showSeries]);
 
   return treeRanksLoaded ? (
     <ReadOnlyContext.Provider value={isReadOnly}>

--- a/specifyweb/frontend/js_src/lib/components/QueryBuilder/Wrapped.tsx
+++ b/specifyweb/frontend/js_src/lib/components/QueryBuilder/Wrapped.tsx
@@ -575,11 +575,17 @@ function Wrapped({
                 showSeries={showSeries}
                 tableName={table.name}
                 onRunCountOnly={(): void => runQuery('count')}
-                onSubmitClick={(): void =>
+                onSubmitClick={(): void => {
+                  const canEnableSmushed = query.fields.some(
+                    (field) => field.fieldName === "catalogNumber" && field.isDisplay
+                  );
+                
+                  queryResource.attributes.smushed = canEnableSmushed ? !(query.smushed ?? false) : false;
+
                   form?.checkValidity() === false
                     ? runQuery('regular')
                     : undefined
-                }
+                }}
                 onToggleDistinct={(): void =>
                   setQuery({
                     ...query,
@@ -587,16 +593,12 @@ function Wrapped({
                   })
                 }
                 onToggleHidden={setShowHiddenFields}
-                onToggleSeries={(): void => {
-                  const canEnableSmushed = query.fields.some(
-                    (field) => field.fieldName === "catalogNumber" && field.isDisplay
-                  );
-                
+                onToggleSeries={(): void =>
                   setQuery({
                     ...query,
-                    smushed: canEnableSmushed ? !(query.smushed ?? false) : false,
-                  });
-                }}
+                    smushed: !(query.smushed ?? false),
+                  })
+                }
               />
             </div>
             {hasPermission('/querybuilder/query', 'execute') && (

--- a/specifyweb/frontend/js_src/lib/components/QueryBuilder/Wrapped.tsx
+++ b/specifyweb/frontend/js_src/lib/components/QueryBuilder/Wrapped.tsx
@@ -587,12 +587,16 @@ function Wrapped({
                   })
                 }
                 onToggleHidden={setShowHiddenFields}
-                onToggleSeries={(): void =>
+                onToggleSeries={(): void => {
+                  const canEnableSmushed = query.fields.some(
+                    (field) => field.fieldName === "catalogNumber" && field.isDisplay
+                  );
+                
                   setQuery({
                     ...query,
-                    smushed: !(query.smushed ?? false),
-                  })
-                }
+                    smushed: canEnableSmushed ? !(query.smushed ?? false) : false,
+                  });
+                }}
               />
             </div>
             {hasPermission('/querybuilder/query', 'execute') && (

--- a/specifyweb/frontend/js_src/lib/components/QueryBuilder/Wrapped.tsx
+++ b/specifyweb/frontend/js_src/lib/components/QueryBuilder/Wrapped.tsx
@@ -233,6 +233,18 @@ function Wrapped({
       fields: getQueryFieldRecords?.(fields) ?? query.fields,
       countOnly: mode === 'count',
     });
+
+    // Handle checking if catalogNumber is present for series query
+    const queryFields = getQueryFieldRecords?.(fields) ?? query.fields;
+    const canEnableSmushed = queryFields.length === 0 || queryFields.some(
+      (field) => field.fieldName === "catalogNumber" && field.isDisplay
+    );
+    queryResource.set('smushed', canEnableSmushed && query.smushed);
+    setQuery({
+      ...query,
+      smushed: canEnableSmushed && query.smushed,
+    })
+
     /*
      * Wait for new query to propagate before re running it
      * TEST: check if this still works after updating to React 18
@@ -576,12 +588,6 @@ function Wrapped({
                 tableName={table.name}
                 onRunCountOnly={(): void => runQuery('count')}
                 onSubmitClick={(): void => {
-                  const canEnableSmushed = query.fields.some(
-                    (field) => field.fieldName === "catalogNumber" && field.isDisplay
-                  );
-                
-                  queryResource.set('smushed', canEnableSmushed ? !(query.smushed ?? false) : false);
-
                   form?.checkValidity() === false
                     ? runQuery('regular')
                     : undefined

--- a/specifyweb/frontend/js_src/lib/components/QueryBuilder/Wrapped.tsx
+++ b/specifyweb/frontend/js_src/lib/components/QueryBuilder/Wrapped.tsx
@@ -236,14 +236,16 @@ function Wrapped({
 
     // Handle checking if catalogNumber is present for series query
     const queryFields = getQueryFieldRecords?.(fields) ?? query.fields;
-    const canEnableSmushed = queryFields.length === 0 || queryFields.some(
-      (field) => field.fieldName === "catalogNumber" && field.isDisplay
-    );
+    const canEnableSmushed =
+      queryFields.length === 0 ||
+      queryFields.some(
+        (field) => field.fieldName === 'catalogNumber' && field.isDisplay
+      );
     queryResource.set('smushed', canEnableSmushed && query.smushed);
     setQuery({
       ...query,
       smushed: canEnableSmushed && query.smushed,
-    })
+    });
 
     /*
      * Wait for new query to propagate before re running it
@@ -587,11 +589,11 @@ function Wrapped({
                 showSeries={showSeries}
                 tableName={table.name}
                 onRunCountOnly={(): void => runQuery('count')}
-                onSubmitClick={(): void => {
+                onSubmitClick={(): void =>
                   form?.checkValidity() === false
                     ? runQuery('regular')
                     : undefined
-                }}
+                }
                 onToggleDistinct={(): void =>
                   setQuery({
                     ...query,

--- a/specifyweb/frontend/js_src/lib/components/QueryBuilder/Wrapped.tsx
+++ b/specifyweb/frontend/js_src/lib/components/QueryBuilder/Wrapped.tsx
@@ -580,7 +580,7 @@ function Wrapped({
                     (field) => field.fieldName === "catalogNumber" && field.isDisplay
                   );
                 
-                  queryResource.attributes.smushed = canEnableSmushed ? !(query.smushed ?? false) : false;
+                  queryResource.set('smushed', canEnableSmushed ? !(query.smushed ?? false) : false);
 
                   form?.checkValidity() === false
                     ? runQuery('regular')

--- a/specifyweb/stored_queries/execution.py
+++ b/specifyweb/stored_queries/execution.py
@@ -892,7 +892,7 @@ def build_query(
     id_field = getattr(model, model._id)
     catalog_number_field = model.catalogNumber if hasattr(model, 'catalogNumber') else None
 
-    # field_specs = [apply_absolute_date(field_spec) for field_spec in field_specs]
+    field_specs = [apply_absolute_date(field_spec) for field_spec in field_specs]
     field_specs = [apply_specify_user_name(field_spec, user) for field_spec in field_specs]
 
     query_construct_query = session.query(id_field)


### PR DESCRIPTION
Fixes #7021

Uncomment apply_absolute_date line in the execution.py file.  Looks like this line was commented out during development and needed to be added back it.  This is to fix the issue of querying for collection objects based on the timestampCreated field in relative mode all records are returned, despite the timestamp created not falling within the designated range.

### Checklist

- [ ] Self-review the PR after opening it to make sure the changes look good and
      self-explanatory (or properly documented)
- [ ] Add relevant issue to release milestone
- [ ] Add pr to documentation list
- [ ] Add automated tests
- [ ] Add a reverse migration if a migration is present in the PR

### Testing instructions

- [ ] Create a specify query in the CO QB viewer.  Set the query to filter by the "Timestamp created" and set some condition on that filter.  See that the CO query results are limited and not returning all COs. 
- [ ] Go through testing instructions from: https://github.com/specify/specify7/pull/4952
