### PR TITLE
Remove GBIF and iDigBio description from geomap popover in query results

### DIFF
--- a/specifyweb/frontend/js_src/lib/components/SpecifyNetwork/Map.tsx
+++ b/specifyweb/frontend/js_src/lib/components/SpecifyNetwork/Map.tsx
@@ -222,10 +222,16 @@ export function useExtendedMap(
     gbif?.description,
     iDigBio?.description,
   ]);
-  return items.length === 0 ? undefined : (
+  return !Boolean(gbif?.description) &&
+    !Boolean(iDigBio?.description) ? undefined : (
     <details>
       <summary>{developmentText.details()}</summary>
-      {items}
+      {items.map((item, index) => (
+        <React.Fragment key={index}>
+          {item}
+          {index < items.length - 1 && ' '}
+        </React.Fragment>
+      ))}
     </details>
   );
 }


### PR DESCRIPTION
Fixes #6171

The reason why the geomap feature is mentioning GBIF and iDigBio for query results is that it is using the same component as the specify network functionality. This PR adds a conditional check to see if a gbif or iDigBio description is present, and if not, does not show the details component.

The existing condition (`items.length === 0`) shouldn't trigger as long as the localization string is set, so I don't think there are any edge cases to consider with swapping it out. Without a GBIF description or iDigBio description, the specifyNetworkText isn't really appropriate.

Alternative solutions I considered:
- Add a different localized description on what the geomap for the query results is showing (the location of the records) *however* I think that this is exactly what the user expects and doesn't need any further explanation.
- Change the language in the existing localization string to cover both the specify network and query context (seems like it would be hard without an incredibly verbose description).

### Checklist

- [x] Self-review the PR after opening it to make sure the changes look good and
      self-explanatory (or properly documented)
- [ ] Add relevant issue to release milestone
- [ ] Add pr to documentation list
- [ ] Add automated tests

### Testing instructions

- [ ] Create a query that contains a locality field. Run the query and click "GeoMap". Observe that the details dropdown is no longer present. (I have tested this and working for me)
- [ ] Find some records which the Specify Network Locality tool could be used on. Open the Specify Network Locality tool and see that the details dropdown is present, and that there is no longer two space errors. (I have *not* tested this, as I don't have any records that seem to match what the network tool is expecting)
