### PR TITLE
Issue 7069

### DIFF
--- a/specifyweb/frontend/js_src/lib/components/DataModel/__tests__/businessRules.test.ts
+++ b/specifyweb/frontend/js_src/lib/components/DataModel/__tests__/businessRules.test.ts
@@ -234,10 +234,12 @@ describe('Collection Object business rules', () => {
       expect(result.current[0]).toStrictEqual([]);
     });
 
-    // FEATURE: Support collection business logic on initializiation again.
-    // These were first introduced in
-    // https://github.com/specify/specify7/pull/6581, but removed due to
-    // https://github.com/specify/specify7/issues/7069
+    /*
+     * FEATURE: Support collection business logic on initializiation again.
+     * These were first introduced in
+     * https://github.com/specify/specify7/pull/6581, but removed due to
+     * https://github.com/specify/specify7/issues/7069
+     */
     test.skip('CollectionObject -> determinations: determinations on initializtion is current by default', () => {
       // We don't directly use the base because the determination is marked as current by default
       const collectionObject = new tables.CollectionObject.Resource({
@@ -393,10 +395,12 @@ describe('CollectionObjectGroup business rules', () => {
   });
 });
 
-// FEATURE: Support collection business logic on initializiation again.
-// These were first introduced in
-// https://github.com/specify/specify7/pull/6581, but removed due to
-// https://github.com/specify/specify7/issues/7069
+/*
+ * FEATURE: Support collection business logic on initializiation again.
+ * These were first introduced in
+ * https://github.com/specify/specify7/pull/6581, but removed due to
+ * https://github.com/specify/specify7/issues/7069
+ */
 describe.skip('Dependent Collections isPrimary', () => {
   const testCases: RA<
     readonly [parentTable: keyof Tables, table: string, fieldName: string]

--- a/specifyweb/frontend/js_src/lib/components/DataModel/__tests__/businessRules.test.ts
+++ b/specifyweb/frontend/js_src/lib/components/DataModel/__tests__/businessRules.test.ts
@@ -140,39 +140,140 @@ describe('Collection Object business rules', () => {
   };
   overrideAjax(otherCollectionObjectTypeUrl, otherCollectionObjectType);
 
-  test('CollectionObject -> determinations: Save blocked when a determination does not belong to COT tree', async () => {
-    const collectionObject = getBaseCollectionObject();
-    collectionObject.set(
-      'collectionObjectType',
-      getResourceApiUrl('CollectionObjectType', 1)
-    );
-
-    const determination =
-      collectionObject.getDependentResource('determinations')?.models[0];
-
-    const { result } = renderHook(() =>
-      useSaveBlockers(determination, tables.Determination.getField('Taxon'))
-    );
-
-    await act(async () => {
-      await collectionObject?.businessRuleManager?.checkField(
-        'collectionObjectType'
+  describe('determinations', () => {
+    test('CollectionObject -> determinations: Save blocked when a determination does not belong to COT tree', async () => {
+      const collectionObject = getBaseCollectionObject();
+      collectionObject.set(
+        'collectionObjectType',
+        getResourceApiUrl('CollectionObjectType', 1)
       );
-    });
-    expect(result.current[0]).toStrictEqual([
-      resourcesText.invalidDeterminationTaxon(),
-    ]);
 
-    collectionObject.set(
-      'collectionObjectType',
-      getResourceApiUrl('CollectionObjectType', 2)
-    );
-    await act(async () => {
-      await collectionObject?.businessRuleManager?.checkField(
-        'collectionObjectType'
+      const determination =
+        collectionObject.getDependentResource('determinations')?.models[0];
+
+      const { result } = renderHook(() =>
+        useSaveBlockers(determination, tables.Determination.getField('Taxon'))
       );
+
+      await act(async () => {
+        await collectionObject?.businessRuleManager?.checkField(
+          'collectionObjectType'
+        );
+      });
+      expect(result.current[0]).toStrictEqual([
+        resourcesText.invalidDeterminationTaxon(),
+      ]);
+
+      collectionObject.set(
+        'collectionObjectType',
+        getResourceApiUrl('CollectionObjectType', 2)
+      );
+      await act(async () => {
+        await collectionObject?.businessRuleManager?.checkField(
+          'collectionObjectType'
+        );
+      });
+      expect(result.current[0]).toStrictEqual([]);
     });
-    expect(result.current[0]).toStrictEqual([]);
+
+    test('Newly added determinations are current by default', async () => {
+      const collectionObject = getBaseCollectionObject();
+      const determinations =
+        collectionObject.getDependentResource('determinations');
+
+      determinations?.add(new tables.Determination.Resource());
+
+      // Old determination gets unchecked as current
+      expect(determinations?.models[0].get('isCurrent')).toBe(false);
+      // New determination becomes current by default
+      expect(determinations?.models[1].get('isCurrent')).toBe(true);
+    });
+
+    test('Save blocked when no current determinations exist', async () => {
+      const collectionObject = getBaseCollectionObject();
+      const determination =
+        collectionObject.getDependentResource('determinations')?.models[0];
+
+      determination?.set('isCurrent', false);
+
+      const { result } = renderHook(() =>
+        useSaveBlockers(
+          collectionObject,
+          tables.Determination.getField('isCurrent')
+        )
+      );
+
+      await act(async () => {
+        await determination?.businessRuleManager?.checkField('isCurrent');
+      });
+
+      expect(result.current[0]).toStrictEqual([
+        'A current determination is required.',
+      ]);
+    });
+
+    test('Save is not blocked when all determinations are deleted', async () => {
+      const collectionObject = getBaseCollectionObject();
+      const determinations =
+        collectionObject.getDependentResource('determinations');
+      const determination = determinations?.models[0];
+
+      determinations?.remove(determination!);
+
+      const { result } = renderHook(() =>
+        useSaveBlockers(
+          collectionObject,
+          tables.Determination.getField('isCurrent')
+        )
+      );
+
+      await act(async () => {
+        await determination?.businessRuleManager?.checkField('isCurrent');
+      });
+
+      expect(result.current[0]).toStrictEqual([]);
+    });
+
+    // FEATURE: Support collection business logic on initializiation again.
+    // These were first introduced in
+    // https://github.com/specify/specify7/pull/6581, but removed due to
+    // https://github.com/specify/specify7/issues/7069
+    test.skip('CollectionObject -> determinations: determinations on initializtion is current by default', () => {
+      // We don't directly use the base because the determination is marked as current by default
+      const collectionObject = new tables.CollectionObject.Resource({
+        determinations: [
+          {
+            /*
+             * We don't directly use IDs because then the determinations will not be 'new' and the
+             * businessrule not executed
+             */
+            guid: '1',
+          },
+        ],
+      });
+      const determinations =
+        collectionObject.getDependentResource('determinations');
+      expect(determinations?.length).toBe(1);
+      expect(determinations?.models[0].get('isCurrent')).toBe(true);
+    });
+
+    test.skip('CollectionObject -> determinations: multiple determinations on intialization handled', () => {
+      const collectionObject = new tables.CollectionObject.Resource({
+        determinations: [
+          {
+            guid: '1',
+          },
+          {
+            guid: '2',
+          },
+        ],
+      });
+      const determinations =
+        collectionObject.getDependentResource('determinations');
+      expect(determinations?.length).toBe(2);
+      expect(determinations?.models[0]?.get('isCurrent')).toBe(false);
+      expect(determinations?.models[1]?.get('isCurrent')).toBe(true);
+    });
   });
 
   // Uniqueness rule check
@@ -211,101 +312,6 @@ describe('Collection Object business rules', () => {
     expect(collectionObject.get('catalogNumber')).toBe(expectedCatNumber);
     // Wait for any pending promise to complete before test finishes
     await collectionObject.businessRuleManager?.pendingPromise;
-  });
-
-  test('CollectionObject -> determinations: determinations on initializtion is current by default', () => {
-    // We don't directly use the base because the determination is marked as current by default
-    const collectionObject = new tables.CollectionObject.Resource({
-      determinations: [
-        {
-          /*
-           * We don't directly use IDs because then the determinations will not be 'new' and the
-           * businessrule not executed
-           */
-          guid: '1',
-        },
-      ],
-    });
-    const determinations =
-      collectionObject.getDependentResource('determinations');
-    expect(determinations?.length).toBe(1);
-    expect(determinations?.models[0].get('isCurrent')).toBe(true);
-  });
-
-  test('CollectionObject -> determinations: multiple determinations on intialization handled', () => {
-    const collectionObject = new tables.CollectionObject.Resource({
-      determinations: [
-        {
-          guid: '1',
-        },
-        {
-          guid: '2',
-        },
-      ],
-    });
-    const determinations =
-      collectionObject.getDependentResource('determinations');
-    expect(determinations?.length).toBe(2);
-    expect(determinations?.models[0]?.get('isCurrent')).toBe(false);
-    expect(determinations?.models[1]?.get('isCurrent')).toBe(true);
-  });
-
-  test('CollectionObject -> determinations: Newly added determinations are current by default', async () => {
-    const collectionObject = getBaseCollectionObject();
-    const determinations =
-      collectionObject.getDependentResource('determinations');
-
-    determinations?.add(new tables.Determination.Resource());
-
-    // Old determination gets unchecked as current
-    expect(determinations?.models[0].get('isCurrent')).toBe(false);
-    // New determination becomes current by default
-    expect(determinations?.models[1].get('isCurrent')).toBe(true);
-  });
-
-  test('CollectionObject -> determinations: Save blocked when no current determinations exist', async () => {
-    const collectionObject = getBaseCollectionObject();
-    const determination =
-      collectionObject.getDependentResource('determinations')?.models[0];
-
-    determination?.set('isCurrent', false);
-
-    const { result } = renderHook(() =>
-      useSaveBlockers(
-        collectionObject,
-        tables.Determination.getField('isCurrent')
-      )
-    );
-
-    await act(async () => {
-      await determination?.businessRuleManager?.checkField('isCurrent');
-    });
-
-    expect(result.current[0]).toStrictEqual([
-      'A current determination is required.',
-    ]);
-  });
-
-  test('CollectionObject -> determinations: Save is not blocked when all determinations are deleted', async () => {
-    const collectionObject = getBaseCollectionObject();
-    const determinations =
-      collectionObject.getDependentResource('determinations');
-    const determination = determinations?.models[0];
-
-    determinations?.remove(determination!);
-
-    const { result } = renderHook(() =>
-      useSaveBlockers(
-        collectionObject,
-        tables.Determination.getField('isCurrent')
-      )
-    );
-
-    await act(async () => {
-      await determination?.businessRuleManager?.checkField('isCurrent');
-    });
-
-    expect(result.current[0]).toStrictEqual([]);
   });
 });
 
@@ -387,7 +393,11 @@ describe('CollectionObjectGroup business rules', () => {
   });
 });
 
-describe('Dependent Collections isPrimary', () => {
+// FEATURE: Support collection business logic on initializiation again.
+// These were first introduced in
+// https://github.com/specify/specify7/pull/6581, but removed due to
+// https://github.com/specify/specify7/issues/7069
+describe.skip('Dependent Collections isPrimary', () => {
   const testCases: RA<
     readonly [parentTable: keyof Tables, table: string, fieldName: string]
   > = [

--- a/specifyweb/frontend/js_src/lib/components/DataModel/collectionApi.ts
+++ b/specifyweb/frontend/js_src/lib/components/DataModel/collectionApi.ts
@@ -91,13 +91,7 @@ export const DependentCollection = Base.extend({
         ),
         { table: this.table.name, records }
       );
-    Base.call(this, null, options);
-    /*
-     * If models are passed during collection initializtion, manually add them
-     * to the collection after initialization.
-     * This ensures proper onAdd functionality is triggered on initialization
-     */
-    records.forEach((record) => this.add(record));
+    Base.call(this, records, options);
   },
   initialize(_tables, options) {
     setupToOne(this, options);

--- a/specifyweb/frontend/js_src/lib/components/DataModel/scoping.ts
+++ b/specifyweb/frontend/js_src/lib/components/DataModel/scoping.ts
@@ -1,4 +1,5 @@
-import { defined, RA } from '../../utils/types';
+import type { RA } from '../../utils/types';
+import { defined } from '../../utils/types';
 import { takeBetween } from '../../utils/utils';
 import { getCollectionPref } from '../InitialContext/remotePrefs';
 import { getTablePermissions } from '../Permissions';

--- a/specifyweb/frontend/js_src/lib/components/DataModel/scoping.ts
+++ b/specifyweb/frontend/js_src/lib/components/DataModel/scoping.ts
@@ -1,4 +1,4 @@
-import type { RA } from '../../utils/types';
+import { defined, RA } from '../../utils/types';
 import { takeBetween } from '../../utils/utils';
 import { getCollectionPref } from '../InitialContext/remotePrefs';
 import { getTablePermissions } from '../Permissions';
@@ -51,11 +51,14 @@ export function initializeResource(resource: SpecifyResource<AnySchema>): void {
     hasTablePermission('Preparation', 'create') &&
     resource.createdBy !== 'clone'
   ) {
-    const preps = collectionObject.getDependentResource('preparations') ?? [];
-    if (preps.length === 0)
+    if (collectionObject.getDependentResource('preparations') === undefined)
       collectionObject.set('preparations', [
         serializeResource(new tables.Preparation.Resource()),
       ]);
+    const preps = defined(
+      collectionObject.getDependentResource('preparations')
+    );
+    if (preps.length === 0) preps?.add(new tables.Preparation.Resource());
   }
 
   if (
@@ -63,12 +66,16 @@ export function initializeResource(resource: SpecifyResource<AnySchema>): void {
     hasTablePermission('Determination', 'create') &&
     resource.createdBy !== 'clone'
   ) {
-    const determinations =
-      collectionObject.getDependentResource('determinations') ?? [];
-    if (determinations.length === 0)
+    if (collectionObject.getDependentResource('determinations') === undefined) {
       collectionObject.set('determinations', [
         serializeResource(new tables.Determination.Resource()),
       ]);
+    }
+    const determinations = defined(
+      collectionObject.getDependentResource('determinations')
+    );
+    if (determinations.length === 0)
+      determinations.add(new tables.Determination.Resource());
   }
 }
 


### PR DESCRIPTION
Fixes #7069 

Caused by the changes in #6581. 

Specifically, 

> @specify/dev-testing 
> I have modified the frontend Collection API such that if a dependent collection is initialized with resources, it makes sure to first create the empty collection and then explicitly add the resources to the collection (triggering any onAdd events). 
> Essentially, in terms of frontend business rules all `customInit` behavior specific for dependent collections can be moved/merged to `onAdd` : which is hopefully more intuitive. What do you all think? 

The `onAdded` business rule of `Determination` for example did not account for existing Determinations on existing CollectionObjects: 

https://github.com/specify/specify7/blob/4c3ccc496622d614b35d7129c953111dae5b1150/specifyweb/frontend/js_src/lib/components/DataModel/businessRuleDefs.ts#L417-L437

The BackBone ORM would receive the CollectionObject from the backend, create the empty Determination Collection, and then iteratively add Determinations in the order they appeared in the response (which triggered the onAdded sequentially for each Determination). 

### Checklist

- [ ] Self-review the PR after opening it to make sure the changes look good and
      self-explanatory (or properly documented)
- [ ] Add relevant issue to release milestone
- [ ] Add pr to documentation list
- [ ] Add automated tests
- [ ] Add a reverse migration if a migration is present in the PR

### Testing instructions
(Taken from #6581, with added tests) 

For Determination: 
- In App Resource -> Remote Preferences, make sure the following preference is present: CO_CREATE_DET_<collection_id>=true
  - For more information, see the Speciforum: [Automatically Creating a new Preparation, Determination, or Collection Object Attribute upon Collection Object creation](https://discourse.specifysoftware.org/t/automatically-create-a-new-preparation-determination-or-collection-object-attribute-upon-co-creation/1014) 
- Navigate to a new Collection Object form in Data Entry
- [ ] Ensure a Determination is being automatically created and that the `Is Current` checkbox is true
- [ ] Add a new Determination to the Collection Object and ensure the new Determination is now current
- [ ] Ensure the old Determination now has the `Is Current` checkbox unchecked
- [ ] Check the `Is Current` checkbox on the first Determination and ensure no other Determinations have the `Is Current` checkbox unchecked

- Open an existing CollectionObject with more than one Determination. 
- [ ] Ensure the first Determination is the current Determination
- Make an edit to the CollectionObject and save
- [ ] Ensure the Determination that was previously current is still current
- Add a new Determination to the CollectionObject and save
- [ ] Ensure the lastly added Determination is the current Determination
- [ ] Reload the page (if needed) and ensure the aforementioned Determination is displayed as the fist Determination
- Make a change to the CollectionObject and save
- [ ] Ensure that the previous Determination is still current 

- (If needed) Add `isPrimary` to the Collector form, and `collectors` to the Collecting Event form
- Navigate to a new Collecting Event form (or Collection Object form with Collecting Event as subview) 
- [ ] Add a Collector and ensure the Collector is the primary Collector
- [ ] Add another Collector and ensure the first Collector is still the primary Collector
- [ ] Check the second Collector as primary and ensure the previous Collector no longer has the `is Primary` checkbox checked
- [ ] Uncheck the second Collector's `Is Primary` checkbox and ensure the first Collector is no the primary Collector
