### PR TITLE
Add the endsWith operator to complement the startsWith operator in queries

### DIFF
--- a/specifyweb/frontend/js_src/lib/components/QueryBuilder/FieldFilter.tsx
+++ b/specifyweb/frontend/js_src/lib/components/QueryBuilder/FieldFilter.tsx
@@ -58,6 +58,7 @@ export type QueryFieldFilter =
   | 'lessOrEqual'
   | 'like'
   | 'startsWith'
+  | 'endsWith'
   | 'true'
   | 'trueOrNull';
 export const filtersWithDefaultValue = new Set<QueryFieldFilter>([
@@ -516,6 +517,14 @@ export const queryFieldFilters: RR<QueryFieldFilter, FieldFilter> = {
     label: queryText.startsWith(),
     description: undefined,
     renderPickList: false,
+    component: SingleField,
+    hasParser: false,
+  },
+  endsWith: {
+    id: 18,
+    label: queryText.endsWith(),
+    description: undefined,
+    renderPicklist: false,
     component: SingleField,
     hasParser: false,
   },

--- a/specifyweb/frontend/js_src/lib/components/QueryBuilder/FieldFilter.tsx
+++ b/specifyweb/frontend/js_src/lib/components/QueryBuilder/FieldFilter.tsx
@@ -524,7 +524,7 @@ export const queryFieldFilters: RR<QueryFieldFilter, FieldFilter> = {
     id: 18,
     label: queryText.endsWith(),
     description: undefined,
-    renderPicklist: false,
+    renderPickList: false,
     component: SingleField,
     hasParser: false,
   },

--- a/specifyweb/frontend/js_src/lib/components/QueryBuilder/useQueryFieldFilters.tsx
+++ b/specifyweb/frontend/js_src/lib/components/QueryBuilder/useQueryFieldFilters.tsx
@@ -145,6 +145,15 @@ export function useQueryFieldFilters(): RR<
           id: { visible: true },
         },
       },
+      endsWith: {
+        ...queryFieldFilters.endsWith,
+        types: {
+          text: { visible: true },
+          number: { visible: true },
+          date: { visible: true },
+          id: { visible: true },
+        },
+      },
       empty: {
         ...queryFieldFilters.empty,
         types: {

--- a/specifyweb/frontend/js_src/lib/localization/query.ts
+++ b/specifyweb/frontend/js_src/lib/localization/query.ts
@@ -608,6 +608,9 @@ export const queryText = createDictionary({
     'de-ch': 'Beginnt mit',
     'pt-br': 'Começa com',
   },
+  endsWith: {
+    'en-us': 'Ends With',
+  },
   or: {
     'en-us': 'or',
     'ru-ru': 'или',

--- a/specifyweb/stored_queries/query_ops.py
+++ b/specifyweb/stored_queries/query_ops.py
@@ -23,26 +23,26 @@ class QueryOps(namedtuple("QueryOps", "uiformatter")):
     """
 
     OPERATIONS = [
-        # operation,      # op number
-        "op_like",  # 0
-        "op_equals",  # 1
-        "op_greaterthan",  # 2
-        "op_lessthan",  # 3
-        "op_greaterthanequals",  # 4
-        "op_lessthanequals",  # 5
-        "op_true",  # 6
-        "op_false",  # 7
-        "op_dontcare",  # 8
-        "op_between",  # 9
-        "op_in",  # 10
-        "op_contains",  # 11
-        "op_empty",  # 12
-        "op_trueornull",  # 13
-        "op_falseornull",  # 14
-        "op_startswith",  # 15
-        "op_age_range",  # 16
-        "op_age_period",  # 17
-        "op_endswith",  # 18
+        # operation,               # op number
+        "op_like",                 # 0
+        "op_equals",               # 1
+        "op_greaterthan",          # 2
+        "op_lessthan",             # 3
+        "op_greaterthanequals",    # 4
+        "op_lessthanequals",       # 5
+        "op_true",                 # 6
+        "op_false",                # 7
+        "op_dontcare",             # 8
+        "op_between",              # 9
+        "op_in",                   # 10
+        "op_contains",             # 11
+        "op_empty",                # 12
+        "op_trueornull",           # 13
+        "op_falseornull",          # 14
+        "op_startswith",           # 15
+        "op_age_range",            # 16
+        "op_age_period",           # 17
+        "op_endswith",             # 18
     ]
 
     PRECALCUALTED_OPERATION_NUMS = {16, 17}


### PR DESCRIPTION
This was discussed [on the forum](https://discourse.specifysoftware.org/t/feature-request-endswith-for-string-searches/2501), but never formalized into a feature issue here. I can create a corresponding feature issue to match.

The `endsWith` operator mirrors the logic for the `startsWith` operator, with the exception that it has no additional logic for leading zeros. https://github.com/specify/specify7/issues/6415 would also be applicable to `endsWith`, however was considered out of scope for the initial implementation.

There are some small formatting changes (single quotes to double and line length) on a few out of scope lines due to my configuration formatting with ruff when I save the buffer. If there is a particular format that you use for python, I can apply it.

I have chosen to group `endsWith` next to `startsWith` in contexts where `id` is already out of order, but put `endsWith` in sequence when the existing `id` sequence is intact.

### Checklist

- [x] Self-review the PR after opening it to make sure the changes look good and
      self-explanatory (or properly documented)
- [ ] Add relevant issue to release milestone
- [ ] Add pr to documentation list
- [ ] Add automated tests

### Testing instructions

- [ ] Create a query and see that there is a new operator, "Ends With".
- [ ] Confirm that the "Ends With" operator is available for the same field types as Starts With, namely `text`, `number`, `date`, and `id`.
- [ ] Run a query using the "Ends With" operator for each of these field types, ensuring that it returns the expected results--items that end with the value provided.
