### PR TITLE
Remove leading zeroes from formatted COs in query results if using separator

### DIFF
--- a/specifyweb/stored_queries/format.py
+++ b/specifyweb/stored_queries/format.py
@@ -194,6 +194,10 @@ class ObjectFormatter:
             new_expr = self.pseudo_sprintf(fieldNodeAttrib['format'], new_expr)
 
         if 'sep' in fieldNodeAttrib:
+            if specify_field.name == 'catalogNumber':
+                # Special Case: Leading zeroes are removed from catalog number if formatter has separator.
+                # See: https://github.com/specify/specify7/issues/7037
+                new_expr = func.regexp_replace(new_expr, '^0+', '')
             new_expr = concat(fieldNodeAttrib['sep'], new_expr)
 
         return new_query, blank_nulls(new_expr) if do_blank_null else new_expr, formatter_field_spec


### PR DESCRIPTION
Fixes #7037 

<img width="643" height="164" alt="image" src="https://github.com/user-attachments/assets/24de0ec2-9f65-4f73-bef8-a5eddcc13455" />

A hardcoded fix.
DataObjFormatters have technically been functioning correctly since https://github.com/specify/specify7/pull/3545, however users relied on the old (seemingly unintended?) behavior.

Another potential solution would be to make it a per-field setting in a record formatter.

### Checklist

- [ ] Self-review the PR after opening it to make sure the changes look good and
      self-explanatory (or properly documented)
- [x] Add relevant issue to release milestone
- [ ] Add pr to documentation list
- [ ] Add automated tests
- [ ] Add a reverse migration if a migration is present in the PR

### Testing instructions
- Add a prefix to your Collection Object record format.
  - Go to App Resources and edit the record formatter for Collection Object.
  - Add any separator to the catalogNumber field. I used CO.
  - Create a new query for Collection Objects.
- Create a new query for CO.
- Add Formatted and catalogNumber.
- Query
- [ ] The formatted CO should have no leading zeroes on the catalogNumber. The catalogNumber by itself should appear normally.
- [ ] Make sure the catalogNumber field still appears normally in queries and in forms.
- [ ] Make sure this doesn't affect other CatalogNumber field formats, like YEAR-######. For example, COs with a YEAR-###### catalogNumber should display as COYEAR-000001.
- [ ] Make sure the record formatter for COs correctly trims the zeroes in any other contexts you can think of. Reports?
- [ ] If you have no separator on the CO format, the catalog number should still have leading zeroes.
