### PR TITLE
Revert get_collection to first collection name

### DIFF
--- a/specifyweb/attachment_gw/views.py
+++ b/specifyweb/attachment_gw/views.py
@@ -72,11 +72,8 @@ def get_collection(request=None):
     # do any better than using the first collection
     # and hoping that all the assets are in the same
     # folder.
-    # from specifyweb.specify.models import Collection
-    # return Collection.objects.all()[0].collectionname
-
-    # The default coll parameter to assets is the database name
-    return settings.DATABASE_NAME
+    from specifyweb.specify.models import Collection
+    return Collection.objects.all()[0].collectionname
 
 @openapi(schema={
     "get": {


### PR DESCRIPTION
Fixes #7061

Revert get_collection to first collection name

### Checklist

- [ ] Self-review the PR after opening it to make sure the changes look good and
      self-explanatory (or properly documented)
- [ ] Add relevant issue to release milestone
- [ ] Add pr to documentation list
- [ ] Add automated tests
- [ ] Add a reverse migration if a migration is present in the PR

### Testing instructions

- [ ] Check that the assets load when using each collection in the database.
