### PR TITLE
Keep record readonly but QB editable in formatters

### DIFF
--- a/specifyweb/frontend/js_src/lib/components/Formatters/Preview.tsx
+++ b/specifyweb/frontend/js_src/lib/components/Formatters/Preview.tsx
@@ -84,18 +84,20 @@ export function useResourcePreview(
                 className="flex gap-2 rounded bg-[color:var(--form-background)] p-2"
                 key={index}
               >
-                <ResourceLink
-                  component={Link.Icon}
-                  props={{
-                    icon: 'eye',
-                  }}
-                  resource={resource}
-                  resourceView={{
-                    onDeleted: (): void =>
-                      setResources(removeItem(resources, index)),
-                  }}
-                />
-                <output className="whitespace-pre-wrap">{output}</output>
+                <ReadOnlyContext.Provider value>
+                  <ResourceLink
+                    component={Link.Icon}
+                    props={{
+                      icon: 'eye',
+                    }}
+                    resource={resource}
+                    resourceView={{
+                      onDeleted: (): void =>
+                        setResources(removeItem(resources, index)),
+                    }}
+                  />
+                  <output className="whitespace-pre-wrap">{output}</output>
+                </ReadOnlyContext.Provider>
               </div>
             );
           })
@@ -140,11 +142,7 @@ export function ResourcePreview({
     ),
     false
   );
-  return (
-    <ReadOnlyContext.Provider value>
-      {children((_, index) =>
-        formatted === undefined ? commonText.loading() : formatted[index]
-      )}
-    </ReadOnlyContext.Provider>
+  return children((_, index) =>
+    formatted === undefined ? commonText.loading() : formatted[index]
   );
 }


### PR DESCRIPTION
Fixes #7120

### Checklist

- [ ] Self-review the PR after opening it to make sure the changes look good and
      self-explanatory (or properly documented)
- [ ] Add relevant issue to release milestone

### Testing instructions

- Go to App Resources -> Record Formatters
- Click on any format
- [ ] Verify you can interact with the search QB and add fields than query 
