### PR TITLE
fix(forms): correct geography form

### DIFF
--- a/config/backstop/global.views.xml
+++ b/config/backstop/global.views.xml
@@ -1676,11 +1676,11 @@
 			<columnDef os="exp">p,2px,p:g(2),5px:g,p,2px,p:g(2),25px,p,0px,p,p:g</columnDef>
 			<rowDef auto="true" cell="p" sep="2dlu"/>
 			<rows>
-			  <cell type="label" labelfor="parent"/>
+				<row>
+					<cell type="label" labelfor="parent"/>
 					<cell type="field" id="parent" uitype="querycbx" isrequired="true" initialize="name=Geography;title=Geography;editbtn=false;newbtn=false;editoncreate=true" name="parent" colspan="3"/>
 					<cell type="label" labelfor="geographyCode"/>
 					<cell type="field" id="geographyCode" name="geographyCode" uitype="text"/>
-				<row>
 				</row>
 				<row>
 					<cell type="label" labelfor="name"/>


### PR DESCRIPTION
Fixes #7157

This solves an issue where the default form for `Geography` was not correctly defined, preventing the parent from appearing.

### Checklist

- [X] Self-review the PR after opening it to make sure the changes look good and
      self-explanatory (or properly documented)
- [X] Add relevant issue to release milestone
- [ ] Add pr to documentation list
- [ ] Add automated tests
- [ ] Add a reverse migration if a migration is present in the PR

### Testing instructions

These instructions verify that the `Parent` field is now present and functional on the default Geography form. Essentially, this should work just like it did before.

1.  Log into any collection that does not have a Geography view definition defined for it.
2.  Navigate to **Data Entry** from the main sidebar menu.
3.  Select **Geography** from the list of forms to create a new record.
4.  Verify that the **Parent** field is now visible on the form.
5.  Use the **Parent** QCBX, search for and select an existing Geography record (e.g., "North America").
6.  Fill in any other required fields (like "Name") and save the new record.
7.  Reopen the record you just created and confirm that the parent was set correctly.
