### PR TITLE
Address null recordset id

### DIFF
--- a/specifyweb/stored_queries/execution.py
+++ b/specifyweb/stored_queries/execution.py
@@ -655,7 +655,7 @@ def recordset(collection, user, user_agent, recordset_info): # pragma: no cover
         recordset.SpecifyUserID = user.id
         session.add(recordset)
         session.flush()
-        new_rs_id = recordset.recordSetId
+        new_rs_id = recordset.recordSetId if recordset.recordSetId else recordset._id
 
         model = models.models_by_tableid[tableid]
 


### PR DESCRIPTION
Fixes #7206

Fix null recordset id error when creating a record set.

### Checklist

- [ ] Self-review the PR after opening it to make sure the changes look good and
      self-explanatory (or properly documented)
- [ ] Add relevant issue to release milestone
- [ ] Add pr to documentation list
- [ ] Add automated tests
- [ ] Add a reverse migration if a migration is present in the PR

### Testing instructions

- Create any query in the QB
- Click on the button to create a record set, and save it.  
- [ ] Verify no errors appear and that the record set has been created.
- [ ] Verify you can create a record set with selected results 
- [ ] Verify you can create record set from data entry 

