### PR TITLE
Filter taxon name with COType when using QB

### DIFF
--- a/specifyweb/frontend/js_src/lib/components/QueryComboBox/index.tsx
+++ b/specifyweb/frontend/js_src/lib/components/QueryComboBox/index.tsx
@@ -544,6 +544,10 @@ export function QueryComboBox({
                                         : fieldName === 'taxonTreeDefId'
                                           ? {
                                               field: 'definition',
+                                              queryBuilderFieldPath: [
+                                                'definition',
+                                                'id',
+                                              ],
                                               isRelationship: true,
                                               operation: 'in',
                                               isNot: false,


### PR DESCRIPTION
Fixes #7251

### Checklist

- [ ] Self-review the PR after opening it to make sure the changes look good and
      self-explanatory (or properly documented)
- [ ] Add relevant issue to release milestone

### Testing instructions

- Go to Data Entry > Collection Object
- Add a Determination
- Click the Search button in the Taxon QCBX
- [ ] Verify the filter line uses the taxon tree id corresponding to the COType you selected or the default one 
