### PR TITLE
Fix "Deselect All" removing required Carry Forward fields.

### DIFF
--- a/specifyweb/frontend/js_src/lib/components/FormMeta/CarryForward.tsx
+++ b/specifyweb/frontend/js_src/lib/components/FormMeta/CarryForward.tsx
@@ -30,6 +30,8 @@ import { relationshipIsToMany } from '../WbPlanView/mappingHelpers';
 /**
  * Fields to always carry forward (unless "Deselect All" is pressed), but not
  * show in the UI.
+ * NOTE: "Deselect All" no longer deselects these fields to prevent issues.
+ * This behavior is probably desirable. Only downside is bigger preferences.
  */
 const invisibleCarry = new Set([
   'collection',
@@ -362,18 +364,17 @@ function CarryForwardConfigDialog({
             disabled={config.length === 0}
             onClick={(): void =>
               handleChange(
-                // Don't deselect hidden fields if they are not visible
-                showHiddenFields
-                  ? []
-                  : table.fields
-                      .filter(
-                        ({ name, isVirtual, overrides }) =>
-                          !isVirtual &&
-                          !reverseRelationships.includes(name) &&
-                          overrides.isHidden &&
-                          config.includes(name)
-                      )
-                      .map(({ name }) => name)
+                table.fields
+                  .filter(
+                    ({ name, isVirtual, overrides, isRequired }) =>
+                      !isVirtual &&
+                      !reverseRelationships.includes(name) &&
+                      // Don't deselect hidden fields if they are not visible
+                      ((!showHiddenFields && overrides.isHidden) ||
+                        isRequired) &&
+                      config.includes(name)
+                  )
+                  .map(({ name }) => name)
               )
             }
           >


### PR DESCRIPTION
Fixes #7197 

Previously, clicking "Deselect All" on Carry Forward or Bulk Carry Forward config would completely clear your configured fields, including required ones. This PR makes it so required fields are not erased by the button.

This PR will not retroactively fix databases that already disabled required fields. I can look into doing that if its deemed important enough @specify/ux-testing .

### Checklist

- [x] Self-review the PR after opening it to make sure the changes look good and
      self-explanatory (or properly documented)
- [x] Add relevant issue to release milestone
- [ ] Add pr to documentation list
- [ ] Add automated tests

### Testing instructions
- Make sure your Collection Object Form has Collection Object Type.
- Make sure you have at least 1 non-default Collection Object Type with a catalogNumber formatter different than your default one.
- Go to Data Entry for Collection Object
- Enable Bulk Carry Foward and click the gear to configure fields.
- Enable "Reveal Hidden Form Fields" and click "Deselect All"
- On the form, choose a non-default Collection Object Type that uses a different catalogNumber format. Fill in fields and save.
- [ ] You should be able to bulk carry forward without an error. All new records should have the correct COT and catalogNumber format.
- Go to App Resources -> User Prefrences -> JSON Editor
- [ ] Make sure the required fields appear in "bulkCarryForward"
```json
"bulkCarryForward":{"CollectionObject":["collectionMemberId","collection","collectionObjectType"]}
```