### PR TITLE
Add a loan return button in the query builder

### DIFF
--- a/specifyweb/backend/stored_queries/execution.py
+++ b/specifyweb/backend/stored_queries/execution.py
@@ -670,110 +670,110 @@ def recordset(collection, user, user_agent, recordset_info): # pragma: no cover
     return new_rs_id
 
 
-# def return_loan_preps(collection, user, agent, data):
-#     spquery = data["query"]
-#     commit = data["commit"]
+def return_loan_preps(collection, user, agent, data):
+    spquery = data["query"]
+    commit = data["commit"]
 
-#     tableid = spquery["contexttableid"]
-#     if not (tableid == Loanpreparation.specify_model.tableId):
-#         raise AssertionError(
-#             f"Unexpected tableId '{tableid}' in request. Expected {Loanpreparation.specify_model.tableId}",
-#             {
-#                 "tableId": tableid,
-#                 "expectedTableId": Loanpreparation.specify_model.tableId,
-#                 "localizationKey": "unexpectedTableId",
-#             },
-#         )
+    tableid = spquery["contexttableid"]
+    if not (tableid == Loanpreparation.specify_model.tableId):
+        raise AssertionError(
+            f"Unexpected tableId '{tableid}' in request. Expected {Loanpreparation.specify_model.tableId}",
+            {
+                "tableId": tableid,
+                "expectedTableId": Loanpreparation.specify_model.tableId,
+                "localizationKey": "unexpectedTableId",
+            },
+        )
 
-#     with models.session_context() as session:
-#         model = models.models_by_tableid[tableid]
+    with models.session_context() as session:
+        model = models.models_by_tableid[tableid]
 
-#         field_specs = fields_from_json(spquery["fields"])
+        field_specs = fields_from_json(spquery["fields"])
 
-#         query, __ = build_query(session, collection, user, tableid, field_specs)
-#         lrp = orm.aliased(models.LoanReturnPreparation)
-#         loan = orm.aliased(models.Loan)
-#         query = query.join(loan).outerjoin(lrp)
-#         unresolved = (
-#             model.quantity
-#             - sql.functions.coalesce(sql.functions.sum(lrp.quantityResolved), 0)
-#         ).label("unresolved")
-#         query = query.with_entities(
-#             model._id, unresolved, loan.loanId, loan.loanNumber
-#         ).group_by(model._id)
-#         to_return = [
-#             (lp_id, quantity, loan_id, loan_no)
-#             for lp_id, quantity, loan_id, loan_no in query
-#             if quantity > 0
-#         ]
-#         if not commit:
-#             return to_return
-#         with transaction.atomic():
-#             for lp_id, quantity, _, _ in to_return:
-#                 lp = Loanpreparation.objects.select_for_update().get(pk=lp_id)
-#                 was_resolved = lp.isresolved
-#                 lp.quantityresolved = lp.quantityresolved + quantity
-#                 lp.quantityreturned = lp.quantityreturned + quantity
-#                 lp.isresolved = True
-#                 lp.save()
+        query, __ = build_query(session, collection, user, tableid, field_specs)
+        lrp = orm.aliased(models.LoanReturnPreparation)
+        loan = orm.aliased(models.Loan)
+        query = query.join(loan).outerjoin(lrp)
+        unresolved = (
+            sql.functions.coalesce(model.quantity, 0)
+            - sql.functions.coalesce(sql.functions.sum(lrp.quantityResolved), 0)
+        ).label("unresolved")
+        query = query.with_entities(
+            model._id, unresolved, loan.loanId, loan.loanNumber
+        ).group_by(model._id)
+        to_return = [
+            (lp_id, quantity, loan_id, loan_no)
+            for lp_id, quantity, loan_id, loan_no in query
+            if quantity > 0
+        ]
+        if not commit:
+            return to_return
+        with transaction.atomic():
+            for lp_id, quantity, _, _ in to_return:
+                lp = Loanpreparation.objects.select_for_update().get(pk=lp_id)
+                was_resolved = lp.isresolved
+                lp.quantityresolved = lp.quantityresolved + quantity
+                lp.quantityreturned = lp.quantityreturned + quantity
+                lp.isresolved = True
+                lp.save()
 
-#                 auditlog.update(
-#                     lp,
-#                     agent,
-#                     None,
-#                     [
-#                         FieldChangeInfo(
-#                             field_name="quantityresolved",
-#                             old_value=lp.quantityresolved - quantity,
-#                             new_value=lp.quantityresolved,
-#                         ),
-#                         FieldChangeInfo(
-#                             field_name="quantityreturned",
-#                             old_value=lp.quantityreturned - quantity,
-#                             new_value=lp.quantityreturned,
-#                         ),
-#                         FieldChangeInfo(
-#                             field_name="isresolved",
-#                             old_value=was_resolved,
-#                             new_value=True,
-#                         ),
-#                     ],
-#                 )
+                auditlog.update(
+                    lp,
+                    agent,
+                    None,
+                    [
+                        FieldChangeInfo(
+                            field_name="quantityresolved",
+                            old_value=lp.quantityresolved - quantity,
+                            new_value=lp.quantityresolved,
+                        ),
+                        FieldChangeInfo(
+                            field_name="quantityreturned",
+                            old_value=lp.quantityreturned - quantity,
+                            new_value=lp.quantityreturned,
+                        ),
+                        FieldChangeInfo(
+                            field_name="isresolved",
+                            old_value=was_resolved,
+                            new_value=True,
+                        ),
+                    ],
+                )
 
-#                 new_lrp = Loanreturnpreparation.objects.create(
-#                     quantityresolved=quantity,
-#                     quantityreturned=quantity,
-#                     loanpreparation_id=lp_id,
-#                     returneddate=data.get("returneddate", None),
-#                     receivedby_id=data.get("receivedby", None),
-#                     createdbyagent=agent,
-#                     discipline=collection.discipline,
-#                 )
-#                 auditlog.insert(new_lrp, agent)
-#             loans_to_close = (
-#                 Loan.objects.select_for_update()
-#                 .filter(
-#                     pk__in={loan_id for _, _, loan_id, _ in to_return},
-#                     isclosed=False,
-#                 )
-#                 .exclude(loanpreparations__isresolved=False)
-#             )
-#             for loan in loans_to_close:
-#                 loan.isclosed = True
-#                 loan.save()
-#                 auditlog.update(
-#                     loan,
-#                     agent,
-#                     None,
-#                     [
-#                         {
-#                             "field_name": "isclosed",
-#                             "old_value": False,
-#                             "new_value": True,
-#                         },
-#                     ],
-#                 )
-#         return to_return
+                new_lrp = Loanreturnpreparation.objects.create(
+                    quantityresolved=quantity,
+                    quantityreturned=quantity,
+                    loanpreparation_id=lp_id,
+                    returneddate=data.get("returneddate", None),
+                    receivedby_id=data.get("receivedby", None),
+                    createdbyagent=agent,
+                    discipline=collection.discipline,
+                )
+                auditlog.insert(new_lrp, agent)
+            loans_to_close = (
+                Loan.objects.select_for_update()
+                .filter(
+                    pk__in={loan_id for _, _, loan_id, _ in to_return},
+                    isclosed=False,
+                )
+                .exclude(loanpreparations__isresolved=False)
+            )
+            for loan in loans_to_close:
+                loan.isclosed = True
+                loan.save()
+                auditlog.update(
+                    loan,
+                    agent,
+                    None,
+                    [
+                        {
+                            "field_name": "isclosed",
+                            "old_value": False,
+                            "new_value": True,
+                        },
+                    ],
+                )
+        return to_return
 
 def execute(
     session,

--- a/specifyweb/backend/stored_queries/urls.py
+++ b/specifyweb/backend/stored_queries/urls.py
@@ -9,6 +9,6 @@ urlpatterns = [
     path('exportkml/', views.export_kml),
     path('make_recordset/', views.make_recordset),
     path('merge_recordsets/', views.merge_recordsets),
-    # path('return_loan_preps/', views.return_loan_preps),
+    path('return_loan_preps/', views.return_loan_preps),
     path('batch_edit/', views.batch_edit)
 ]

--- a/specifyweb/backend/stored_queries/views.py
+++ b/specifyweb/backend/stored_queries/views.py
@@ -23,6 +23,9 @@ from specifyweb.specify.api import toJson, uri_for_model
 from specifyweb.specify.models import Collection, Recordset, Recordsetitem, \
     Loanreturnpreparation, Loanpreparation, Loan
 from specifyweb.specify.views import login_maybe_required
+from .execution import execute, run_ephemeral_query, do_export, recordset, \
+    return_loan_preps as rlp
+
 
 logger = logging.getLogger(__name__)
 
@@ -294,23 +297,22 @@ def merge_recordsets(request: HttpRequest) -> JsonResponse:
 @login_maybe_required
 @never_cache
 def return_loan_preps(request):
-    ...
-    # check_permission_targets(request.specify_collection.id, request.specify_user.id, [QueryBuilderPt.execute])
-    # check_table_permissions(request.specify_collection, request.specify_user, Loanreturnpreparation, "create")
-    # check_table_permissions(request.specify_collection, request.specify_user, Loanpreparation, "read")
-    # check_table_permissions(request.specify_collection, request.specify_user, Loan, "update")
-    # try:
-    #     data = json.load(request)
-    # except ValueError as e:
-    #     return HttpResponseBadRequest(e)
+    check_permission_targets(request.specify_collection.id, request.specify_user.id, [QueryBuilderPt.execute])
+    check_table_permissions(request.specify_collection, request.specify_user, Loanreturnpreparation, "create")
+    check_table_permissions(request.specify_collection, request.specify_user, Loanpreparation, "read")
+    check_table_permissions(request.specify_collection, request.specify_user, Loan, "update")
+    try:
+        data = json.load(request)
+    except ValueError as e:
+        return HttpResponseBadRequest(e)
 
-    # to_return = rlp(request.specify_collection, request.specify_user, request.specify_user_agent, data)
+    to_return = rlp(request.specify_collection, request.specify_user, request.specify_user_agent, data)
 
-    # resp = defaultdict(lambda: {'loanpreparations': list()})
-    # for lp_id, quantity, loan_id, loan_no in to_return:
-    #     item = resp[loan_id]
-    #     item['loannumber'] = loan_no
-    #     item['loanpreparations'].append({'loanpreparationid': lp_id, 'quantity': int(quantity)})
+    resp = defaultdict(lambda: {'loanpreparations': list()})
+    for lp_id, quantity, loan_id, loan_no in to_return:
+        item = resp[loan_id]
+        item['loannumber'] = loan_no
+        item['loanpreparations'].append({'loanpreparationid': lp_id, 'quantity': int(quantity)})
 
-    # return JsonResponse(resp, safe=False)
+    return JsonResponse(resp, safe=False)
 

--- a/specifyweb/frontend/js_src/lib/components/QueryBuilder/Header.tsx
+++ b/specifyweb/frontend/js_src/lib/components/QueryBuilder/Header.tsx
@@ -15,11 +15,17 @@ import { resourceEvents } from '../DataModel/resource';
 import { tables } from '../DataModel/tables';
 import type { RecordSet, SpQuery, SpQueryField } from '../DataModel/types';
 import { TableIcon } from '../Molecules/TableIcon';
-import { hasToolPermission } from '../Permissions/helpers';
+import {
+  hasPermission,
+  hasTablePermission,
+  hasToolPermission,
+} from '../Permissions/helpers';
 import { SaveQueryButtons, ToggleMappingViewButton } from './Components';
 import { useQueryViewPref } from './Context';
 import { QueryEditButton } from './Edit';
 import type { MainState } from './reducer';
+import { ErrorBoundary } from '../Errors/ErrorBoundary';
+import { QueryLoanReturn } from './LoanReturn';
 
 export type QueryView = {
   readonly basicView: RA<number>;
@@ -103,6 +109,19 @@ export function QueryHeader({
           />
         )}
       </div>
+      {state.baseTableName === 'LoanPreparation' &&
+      hasPermission('/querybuilder/query', 'execute') &&
+      hasTablePermission('Loan', 'update') &&
+      hasTablePermission('LoanReturnPreparation', 'create') &&
+      hasTablePermission('LoanPreparation', 'read') ? (
+        <ErrorBoundary dismissible>
+          <QueryLoanReturn
+            fields={state.fields}
+            getQueryFieldRecords={getQueryFieldRecords}
+            queryResource={queryResource}
+          />
+        </ErrorBoundary>
+      ) : undefined}
       <div className="flex flex-wrap justify-center gap-2">
         <Button.Small onClick={() => setIsBasic(!isBasic)}>
           {isBasic

--- a/specifyweb/frontend/js_src/lib/components/QueryBuilder/LoanReturn.tsx
+++ b/specifyweb/frontend/js_src/lib/components/QueryBuilder/LoanReturn.tsx
@@ -1,0 +1,231 @@
+import React from 'react';
+import type { LocalizedString } from 'typesafe-i18n';
+import type { State } from 'typesafe-reducer';
+
+import { useAsyncState } from '../../hooks/useAsyncState';
+import { useId } from '../../hooks/useId';
+import { commonText } from '../../localization/common';
+import { interactionsText } from '../../localization/interactions';
+import { queryText } from '../../localization/query';
+import { ajax } from '../../utils/ajax';
+import { getDateInputValue } from '../../utils/dayJs';
+import type { RA, RR } from '../../utils/types';
+import { sortFunction } from '../../utils/utils';
+import { Button } from '../Atoms/Button';
+import { Form } from '../Atoms/Form';
+import { Link } from '../Atoms/Link';
+import { Submit } from '../Atoms/Submit';
+import { LoadingContext } from '../Core/Contexts';
+import { getField } from '../DataModel/helpers';
+import type {
+  SerializedRecord,
+  SerializedResource,
+} from '../DataModel/helperTypes';
+import type { SpecifyResource } from '../DataModel/legacyTypes';
+import {
+  getResourceViewUrl,
+  idFromUrl,
+  resourceToJson,
+} from '../DataModel/resource';
+import { tables } from '../DataModel/tables';
+import type {
+  LoanPreparation,
+  LoanReturnPreparation,
+  SpQuery,
+  SpQueryField,
+} from '../DataModel/types';
+import { SpecifyForm } from '../Forms/SpecifyForm';
+import { userInformation } from '../InitialContext/userInformation';
+import { loanReturnPrepForm } from '../Interactions/LoanReturn';
+import { Dialog } from '../Molecules/Dialog';
+import { mappingPathIsComplete } from '../WbPlanView/helpers';
+import { QueryButton } from './Components';
+import type { QueryField } from './helpers';
+
+const returnLoanPreps = async (
+  query: SerializedRecord<SpQuery>,
+  loanReturnPreparation: SpecifyResource<LoanReturnPreparation>,
+  commit: boolean
+): Promise<
+  RA<{
+    readonly loanId: number;
+    readonly loanNumber: LocalizedString;
+    readonly totalPreps: number;
+  }>
+> =>
+  ajax<
+    RR<
+      number,
+      {
+        readonly loanpreparations: RA<SerializedRecord<LoanPreparation>>;
+        readonly loannumber: LocalizedString;
+      }
+    >
+  >('/stored_query/return_loan_preps/', {
+    method: 'POST',
+    headers: { Accept: 'application/json' },
+    body: {
+      query,
+      commit,
+      returneddate: loanReturnPreparation.get('returnedDate'),
+      receivedby: idFromUrl(loanReturnPreparation.get('receivedBy') ?? ''),
+    },
+  }).then(({ data }) =>
+    Object.entries(data)
+      .map(([loanId, { loanpreparations, loannumber }]) => ({
+        loanId: Number.parseInt(loanId),
+        loanNumber: loannumber,
+        totalPreps: loanpreparations.reduce(
+          (count, { quantity }) => count + (quantity ?? 0),
+          0
+        ),
+      }))
+      .sort(sortFunction(({ loanNumber }) => loanNumber))
+  );
+
+export function QueryLoanReturn({
+  fields,
+  queryResource,
+  getQueryFieldRecords,
+}: {
+  readonly fields: RA<QueryField>;
+  readonly queryResource: SpecifyResource<SpQuery>;
+  readonly getQueryFieldRecords:
+    | (() => RA<SerializedResource<SpQueryField>>)
+    | undefined;
+}): JSX.Element {
+  const showConfirmation = (): boolean =>
+    fields.some(({ mappingPath }) => !mappingPathIsComplete(mappingPath));
+  const [state, setState] = React.useState<
+    | State<
+        'Dialog',
+        {
+          readonly queryResource: SerializedRecord<SpQuery>;
+          readonly loanReturnPreparation: SpecifyResource<LoanReturnPreparation>;
+        }
+      >
+    | State<'Main'>
+    | State<'Returned'>
+  >({
+    type: 'Main',
+  });
+  const [toReturn] = useAsyncState(
+    React.useCallback(
+      async () =>
+        state.type === 'Dialog'
+          ? returnLoanPreps(
+              state.queryResource,
+              state.loanReturnPreparation,
+              false
+            )
+          : undefined,
+      [state]
+    ),
+    true
+  );
+  const id = useId('query-loan-return');
+  const loading = React.useContext(LoadingContext);
+  return (
+    <>
+      <QueryButton
+        disabled={fields.length === 0}
+        showConfirmation={showConfirmation}
+        onClick={(): void =>
+          setState({
+            type: 'Dialog',
+            loanReturnPreparation: new tables.LoanReturnPreparation.Resource({
+              returneddate: getDateInputValue(new Date()),
+              receivedby: userInformation.agent.resource_uri,
+            }),
+            queryResource: resourceToJson(
+              typeof getQueryFieldRecords === 'function'
+                ? queryResource.set('fields', getQueryFieldRecords())
+                : queryResource
+            ),
+          })
+        }
+      >
+        {interactionsText.returnLoan({
+          tableLoan: tables.Loan.label,
+        })}
+      </QueryButton>
+      {state.type === 'Dialog' && Array.isArray(toReturn) ? (
+        <Dialog
+          buttons={
+            toReturn.length === 0 ? (
+              commonText.close()
+            ) : (
+              <>
+                <Button.DialogClose>{commonText.cancel()}</Button.DialogClose>
+                <Submit.Success
+                  form={id('form')}
+                  title={interactionsText.returnSelectedPreparations()}
+                >
+                  {interactionsText.return()}
+                </Submit.Success>
+              </>
+            )
+          }
+          header={tables.LoanPreparation.label}
+          onClose={(): void => setState({ type: 'Main' })}
+        >
+          {toReturn.length === 0 ? (
+            queryText.noPreparationsToReturn()
+          ) : (
+            <Form
+              id={id('form')}
+              onSubmit={(): void =>
+                loading(
+                  returnLoanPreps(
+                    state.queryResource,
+                    state.loanReturnPreparation,
+                    true
+                  ).then((): void => setState({ type: 'Returned' }))
+                )
+              }
+            >
+              <SpecifyForm
+                display="block"
+                resource={state.loanReturnPreparation}
+                viewDefinition={loanReturnPrepForm()}
+              />
+              <table className="grid-table grid-cols-2 gap-2">
+                <thead>
+                  <tr>
+                    <th scope="col">
+                      {getField(tables.Loan, 'loanNumber').label}
+                    </th>
+                    <th scope="col">
+                      {getField(tables.LoanPreparation, 'quantity').label}
+                    </th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {toReturn.map(({ loanId, loanNumber, totalPreps }) => (
+                    <tr key={loanId}>
+                      <td>
+                        <Link.NewTab href={getResourceViewUrl('Loan', loanId)}>
+                          {loanNumber}
+                        </Link.NewTab>
+                      </td>
+                      <td className="justify-end tabular-nums">{totalPreps}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </Form>
+          )}
+        </Dialog>
+      ) : undefined}
+      {state.type === 'Returned' && (
+        <Dialog
+          buttons={commonText.close()}
+          header={tables.LoanPreparation.label}
+          onClose={(): void => setState({ type: 'Main' })}
+        >
+          {queryText.itemsReturned()}
+        </Dialog>
+      )}
+    </>
+  );
+}

--- a/specifyweb/frontend/js_src/lib/localization/query.ts
+++ b/specifyweb/frontend/js_src/lib/localization/query.ts
@@ -984,4 +984,21 @@ export const queryText = createDictionary({
       'Пожалуйста, сохраните запрос перед запуском пакетного редактирования.',
     'uk-ua': 'Будь ласка, збережіть запит перед запуском пакетного редагування',
   },
+  noPreparationsToReturn: {
+    'en-us': 'There are no unresolved items to return',
+    'ru-ru': 'Нет нерешенных вопросов для возврата',
+    'es-es': 'No hay items sin resolver para devolver',
+    'fr-fr': "Il n'y a aucun article non résolu à retourner",
+    'uk-ua': 'Немає невирішених елементів для повернення',
+    'de-ch':
+      'Es gibt keine ungelösten Elemente, die zurückgegeben werden müssen',
+  },
+  itemsReturned: {
+    'en-us': 'Items have been returned',
+    'ru-ru': 'Товары были возвращены',
+    'es-es': 'Los items han sido devueltos',
+    'fr-fr': 'Les articles ont été retournés',
+    'uk-ua': 'Товари повернуто',
+    'de-ch': 'Artikel wurden zurückgegeben',
+  },
 } as const);


### PR DESCRIPTION
Fixes #7303

### Checklist

- [ ] Self-review the PR after opening it to make sure the changes look good and
      self-explanatory (or properly documented)
- [ ] Add relevant issue to release milestone
- [ ] Add pr to documentation list
- [ ] Add automated tests
- [ ] Add a reverse migration if a migration is present in the PR

### Testing instructions

- Go to queries
- Select loan preparation table
- Click on 'Return Loan Records' button
- [ ] Verify that all the records have been set to their max for quantity resolved and returned by checking the column value in the results. 
==>  In the case the quantity is double than what it should be, open the record in a new tab and verify that it's correct there (known issue, will not be fixed here) 
==>  Do not pay attention to the column Is Resolved in the query results if present
