### PR TITLE
Sqlalchemy id field build fix

### DIFF
--- a/specifyweb/backend/stored_queries/execution.py
+++ b/specifyweb/backend/stored_queries/execution.py
@@ -660,7 +660,7 @@ def recordset(collection, user, user_agent, recordset_info): # pragma: no cover
         recordset.SpecifyUserID = user.id
         session.add(recordset)
         session.flush()
-        new_rs_id = recordset.recordSetId if recordset.recordSetId else recordset._id
+        new_rs_id = recordset.recordSetId
 
         model = models.models_by_tableid[tableid]
 


### PR DESCRIPTION
Fixes #7207

Fix the sqlalchemy build_models.py file to handle all ID fields after the sqlalchemy upgrade from version to 1.2.11 to 1.4.54.

### Checklist

- [x] Self-review the PR after opening it to make sure the changes look good and
      self-explanatory (or properly documented)
- [x] Add relevant issue to release milestone
- [ ] Add pr to documentation list

### Testing instructions

- [x] Try out different QB queries to make sure no errors related to ID fields appear.
- [x] Create record sets of those test queries.  Make sure that they save without errors.
- [x] Make sure that the newly created record sets can be reopened. 
