### PR TITLE
fix(trees): preserve whitespace for `textBefore` and `after`

### DIFF
--- a/specifyweb/frontend/js_src/lib/components/DataModel/schemaOverrides.ts
+++ b/specifyweb/frontend/js_src/lib/components/DataModel/schemaOverrides.ts
@@ -176,36 +176,48 @@ const globalFieldOverrides: {
   },
   TaxonTreeDefItem: {
     fullNameSeparator: { whiteSpaceSensitive: true },
+    textBefore: { whiteSpaceSensitive: true },
+    textAfter: { whiteSpaceSensitive: true },
   },
   GeographyTreeDef: {
     fullNameDirection: { visibility: 'readOnly' },
   },
   GeographyTreeDefItem: {
     fullNameSeparator: { whiteSpaceSensitive: true },
+    textBefore: { whiteSpaceSensitive: true },
+    textAfter: { whiteSpaceSensitive: true },
   },
   StorageTreeDef: {
     fullNameDirection: { visibility: 'readOnly' },
   },
   StorageTreeDefItem: {
     fullNameSeparator: { whiteSpaceSensitive: true },
+    textBefore: { whiteSpaceSensitive: true },
+    textAfter: { whiteSpaceSensitive: true },
   },
   GeologicTimePeriodTreeDef: {
     fullNameDirection: { visibility: 'readOnly' },
   },
   GeologicTimePeriodTreeDefItem: {
     fullNameSeparator: { whiteSpaceSensitive: true },
+    textBefore: { whiteSpaceSensitive: true },
+    textAfter: { whiteSpaceSensitive: true },
   },
   TectonicUnitTreeDef: {
     fullNameDirection: { visibility: 'readOnly' },
   },
   TectonicUnitTreeDefItem: {
     fullNameSeparator: { whiteSpaceSensitive: true },
+    textBefore: { whiteSpaceSensitive: true },
+    textAfter: { whiteSpaceSensitive: true },
   },
   LithoStratTreeDef: {
     fullNameDirection: { visibility: 'readOnly' },
   },
   LithoStratTreeDefItem: {
     fullNameSeparator: { whiteSpaceSensitive: true },
+    textBefore: { whiteSpaceSensitive: true },
+    textAfter: { whiteSpaceSensitive: true },
   },
 };
 


### PR DESCRIPTION
Fixes #7331

Always ensures that spaces are not trimmed from the following fields:
- TaxonTreeDefItem -> `textBefore`, `textAfter`
- GeographyTreeDefItem -> `textBefore`, `textAfter`
- StorageTreeDefItem -> `textBefore`, `textAfter`
- GeologicTimePeriodTreeDefItem -> `textBefore`, `textAfter`
- LithoStratTreeDefItem -> `textBefore`, `textAfter`

Before, if I wanted to set the `textAfter` for the "County" level in the Geography tree, it would not let me put a space before the word "County" making `DouglasCounty` instead of `Douglas County`.

<img width="400" height="964" alt="image" src="https://github.com/user-attachments/assets/c9f0318b-2b5c-475f-9b08-47b37d9be501" />


This keeps the space.

### Checklist

- [x] Self-review the PR after opening it to make sure the changes look good
      and self-explanatory (or properly documented)
- [ ] Add automatic tests
- [x] Add relevant issue to release milestone

### Testing instructions

`textBefore` and `textAfter`
- Make any edit to a TreeDefItem which is included in the `fullName` and save
- In the Tree Viewer or Query Builder, identify a node at a low level (Species, Subspecies, etc.)
- [ ] Ensure the Full Name of the tree node was constructed as expected with the new text before or after, including whitespace