### PR TITLE
Fix:use original filename for image preview alt text

### DIFF
--- a/specifyweb/frontend/js_src/lib/components/Molecules/SyncAttachmentPicker.tsx
+++ b/specifyweb/frontend/js_src/lib/components/Molecules/SyncAttachmentPicker.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import { useBooleanState } from '../../hooks/useBooleanState';
 import { useErrorContext } from '../../hooks/useErrorContext';
 import { attachmentsText } from '../../localization/attachments';
@@ -33,7 +34,7 @@ function deriveAltFromUrl(source?: string, fallback = 'Image preview'): string {
     pathname.split('/').pop();
 
   return rawName
-    ? decodeURIComponent(rawName).replace(/[+]/g, ' ').trim()
+    ? decodeURIComponent(rawName).replaceAll('+', ' ').trim()
     : fallback;
 }
 

--- a/specifyweb/frontend/js_src/lib/components/Molecules/SyncAttachmentPicker.tsx
+++ b/specifyweb/frontend/js_src/lib/components/Molecules/SyncAttachmentPicker.tsx
@@ -18,7 +18,29 @@ import type { Attachment } from '../DataModel/types';
 import { Dialog } from './Dialog';
 import { Tabs } from './Tabs';
 
-const types = ['url', 'image', 'attachments', 'attachments'] as const;
+// const types = ['url', 'image', 'attachments', 'attachments'] as const;
+const types = ['url', 'image', 'attachments'] as const;
+function deriveAltFromUrl(src?: string, fallback = 'Image preview'): string {
+  if (!src) return fallback;
+  try {
+    const u = new URL(src, window.location.origin);
+    const candidate =
+      u.searchParams.get('downloadname') ||
+      u.searchParams.get('filename') ||
+      u.pathname.split('/').pop() ||
+      '';
+    const decoded = decodeURIComponent(candidate.replace(/\+/g, ' '))
+      .replace(/\u202F|\u00A0/g, ' ')
+      .trim();
+    return decoded || fallback;
+  } catch {
+    const last = (src.split('/').pop() ?? '').replace(/\+/g, ' ');
+    const decoded = decodeURIComponent(last)
+      .replace(/\u202F|\u00A0/g, ' ')
+      .trim();
+    return decoded || fallback;
+  }
+}
 
 export function SyncAttachmentPicker({
   url,
@@ -36,9 +58,10 @@ export function SyncAttachmentPicker({
 
   const [urlNotFound, setUrlNotFound] = React.useState(false);
 
-  const [type, setType] = React.useState<
-    'attachments' | 'attachments' | 'image' | 'url'
-  >('url');
+  // const [type, setType] = React.useState<
+  //   'attachments' | 'attachments' | 'image' | 'url'
+  // >('url');
+  const [type, setType] = React.useState<typeof types[number]>('url');
 
   function handleAttachment(attachment: SerializedResource<Attachment>): void {
     loading(
@@ -73,7 +96,8 @@ export function SyncAttachmentPicker({
 
       {url !== undefined && (
         <img
-          alt={url.slice(url.lastIndexOf('/') + 1) ?? url}
+          // alt={url.slice(url.lastIndexOf('/') + 1) ?? url}
+          alt={deriveAltFromUrl(url)}
           className="h-40 max-h-full w-40 max-w-full object-contain"
           src={url}
         />

--- a/specifyweb/frontend/js_src/lib/components/Molecules/SyncAttachmentPicker.tsx
+++ b/specifyweb/frontend/js_src/lib/components/Molecules/SyncAttachmentPicker.tsx
@@ -18,25 +18,25 @@ import type { Attachment } from '../DataModel/types';
 import { Dialog } from './Dialog';
 import { Tabs } from './Tabs';
 
-// const types = ['url', 'image', 'attachments', 'attachments'] as const;
+// Const types = ['url', 'image', 'attachments', 'attachments'] as const;
 const types = ['url', 'image', 'attachments'] as const;
-function deriveAltFromUrl(src?: string, fallback = 'Image preview'): string {
-  if (!src) return fallback;
+function deriveAltFromUrl(source?: string, fallback = 'Image preview'): string {
+  if (!source) return fallback;
   try {
-    const u = new URL(src, window.location.origin);
+    const u = new URL(source, window.location.origin);
     const candidate =
       u.searchParams.get('downloadname') ||
       u.searchParams.get('filename') ||
       u.pathname.split('/').pop() ||
       '';
-    const decoded = decodeURIComponent(candidate.replace(/\+/g, ' '))
-      .replace(/\u202F|\u00A0/g, ' ')
+    const decoded = decodeURIComponent(candidate.replaceAll('+', ' '))
+      .replaceAll(/\u202F|\u00A0/g, ' ')
       .trim();
     return decoded || fallback;
   } catch {
-    const last = (src.split('/').pop() ?? '').replace(/\+/g, ' ');
+    const last = (source.split('/').pop() ?? '').replaceAll('+', ' ');
     const decoded = decodeURIComponent(last)
-      .replace(/\u202F|\u00A0/g, ' ')
+      .replaceAll(/\u202f|\xa0/g, ' ')
       .trim();
     return decoded || fallback;
   }
@@ -58,9 +58,11 @@ export function SyncAttachmentPicker({
 
   const [urlNotFound, setUrlNotFound] = React.useState(false);
 
-  // const [type, setType] = React.useState<
-  //   'attachments' | 'attachments' | 'image' | 'url'
-  // >('url');
+  /*
+   * Const [type, setType] = React.useState<
+   *   'attachments' | 'attachments' | 'image' | 'url'
+   * >('url');
+   */
   const [type, setType] = React.useState<typeof types[number]>('url');
 
   function handleAttachment(attachment: SerializedResource<Attachment>): void {
@@ -96,7 +98,7 @@ export function SyncAttachmentPicker({
 
       {url !== undefined && (
         <img
-          // alt={url.slice(url.lastIndexOf('/') + 1) ?? url}
+          // Alt={url.slice(url.lastIndexOf('/') + 1) ?? url}
           alt={deriveAltFromUrl(url)}
           className="h-40 max-h-full w-40 max-w-full object-contain"
           src={url}

--- a/specifyweb/frontend/js_src/lib/components/Molecules/SyncAttachmentPicker.tsx
+++ b/specifyweb/frontend/js_src/lib/components/Molecules/SyncAttachmentPicker.tsx
@@ -75,7 +75,7 @@ export function SyncAttachmentPicker({
   // when user picks an attachment
   function handleAttachment(nextAttachment: SerializedResource<Attachment>): void {
   
-    const originalName: string | undefined = nextAttachment?.origName;
+    const originalName: string | undefined = (nextAttachment as any)?.origName;
     if (originalName) setAltText(originalName);
 
     loading(

--- a/specifyweb/frontend/js_src/lib/components/Molecules/SyncAttachmentPicker.tsx
+++ b/specifyweb/frontend/js_src/lib/components/Molecules/SyncAttachmentPicker.tsx
@@ -25,7 +25,7 @@ function fileNameFromUrl(imageUrl?: string): string | undefined {
   try {
     const urlObject = new URL(
       imageUrl,
-      typeof window !== 'undefined' ? window.location.origin : 'http://localhost'
+      typeof window === 'undefined' ? 'http://localhost' : window.location.origin
     );
 
     const queryName =
@@ -35,15 +35,15 @@ function fileNameFromUrl(imageUrl?: string): string | undefined {
     const lastPathSegment = urlObject.pathname.split('/').pop() ?? '';
     const raw = queryName ?? lastPathSegment;
 
-    const decodedName = decodeURIComponent(raw.replace(/\+/g, ' '))
-      .replace(/\u202F|\u00A0/g, ' ')
+    const decodedName = decodeURIComponent(raw.replaceAll('+', ' '))
+      .replaceAll(/\u202f|\xa0/g, ' ')
       .trim();
 
     return decodedName || undefined;
   } catch {
     const raw = imageUrl.split('/').pop() ?? '';
-    const decodedName = decodeURIComponent(raw.replace(/\+/g, ' '))
-      .replace(/\u202F|\u00A0/g, ' ')
+    const decodedName = decodeURIComponent(raw.replaceAll('+', ' '))
+      .replaceAll(/\u202f|\xa0/g, ' ')
       .trim();
     return decodedName || undefined;
   }
@@ -69,10 +69,10 @@ export function SyncAttachmentPicker({
 
   const [type, setType] = React.useState<typeof types[number]>('url');
 
-  // state
+  // State
   const [altText, setAltText] = React.useState<string | undefined>(undefined);
 
-  // when user picks an attachment
+  // When user picks an attachment
   function handleAttachment(nextAttachment: SerializedResource<Attachment>): void {
   
     const originalName: string | undefined = (nextAttachment as any)?.origName;


### PR DESCRIPTION
Fixes #3709

### Checklist

- [x] Self-review the PR after opening it to make sure the changes look good and
self-explanatory (or properly documented)
- [x] Add relevant issue to release milestone

### Testing instructions
- Go to user tools → Choose Preferences → Change home page image.
- [x] Confirm the alt attribute just shows image name.
