### PR TITLE
Preserve visual column order in workbench exports

### DIFF
--- a/specifyweb/frontend/js_src/lib/components/WbToolkit/index.tsx
+++ b/specifyweb/frontend/js_src/lib/components/WbToolkit/index.tsx
@@ -51,14 +51,14 @@ export function WbToolkit({
 
     const prepareExport = (
       dataset: Dataset,
-    ): { columns: RA<string>; rows: RA<RA<string>> } => {
-      const defaultOrder = dataset.columns.map((_, i) => i); // use the existing order as default
+    ): { readonly columns: RA<string>; readonly rows: RA<RA<string>> } => {
+      const defaultOrder = dataset.columns.map((_, i) => i); // Use the existing order as default
 
       const order =
         dataset.visualorder &&
         dataset.visualorder.length === dataset.columns.length
           ? dataset.visualorder
-          : defaultOrder; // try to apply visual order if present, otherwise just fallback to default
+          : defaultOrder; // Try to apply visual order if present, otherwise just fallback to default
 
       let columns = order.map((colIndex) => dataset.columns[colIndex]);
       const rows = dataset.rows.map((row) =>

--- a/specifyweb/frontend/js_src/lib/components/WbToolkit/index.tsx
+++ b/specifyweb/frontend/js_src/lib/components/WbToolkit/index.tsx
@@ -1,25 +1,25 @@
-import type Handsontable from 'handsontable';
-import React from 'react';
+import type Handsontable from "handsontable";
+import React from "react";
 
-import { attachmentsText } from '../../localization/attachments';
-import { commonText } from '../../localization/common';
-import { wbText } from '../../localization/workbench';
-import type { RA } from '../../utils/types';
-import { Button } from '../Atoms/Button';
-import { raise } from '../Errors/Crash';
-import { ErrorBoundary } from '../Errors/ErrorBoundary';
-import { hasTablePermission } from '../Permissions/helpers';
-import { userPreferences } from '../Preferences/userPreferences';
-import type { Dataset } from '../WbPlanView/Wrapped';
-import { resolveVariantFromDataset } from '../WbUtils/datasetVariants';
-import { getAttachmentsColumn } from '../WorkBench/attachmentHelpers';
-import { downloadDataSet } from '../WorkBench/helpers';
-import type { WbMapping } from '../WorkBench/mapping';
-import { WbChangeOwner } from './ChangeOwner';
-import { WbConvertCoordinates } from './CoordinateConverter';
-import { WbRawPlan } from './DevShowPlan';
-import { WbGeoLocate } from './GeoLocate';
-import { WbLeafletMap } from './WbLeafletMap';
+import { attachmentsText } from "../../localization/attachments";
+import { commonText } from "../../localization/common";
+import { wbText } from "../../localization/workbench";
+import type { RA } from "../../utils/types";
+import { Button } from "../Atoms/Button";
+import { raise } from "../Errors/Crash";
+import { ErrorBoundary } from "../Errors/ErrorBoundary";
+import { hasTablePermission } from "../Permissions/helpers";
+import { userPreferences } from "../Preferences/userPreferences";
+import type { Dataset } from "../WbPlanView/Wrapped";
+import { resolveVariantFromDataset } from "../WbUtils/datasetVariants";
+import { getAttachmentsColumn } from "../WorkBench/attachmentHelpers";
+import { downloadDataSet } from "../WorkBench/helpers";
+import type { WbMapping } from "../WorkBench/mapping";
+import { WbChangeOwner } from "./ChangeOwner";
+import { WbConvertCoordinates } from "./CoordinateConverter";
+import { WbRawPlan } from "./DevShowPlan";
+import { WbGeoLocate } from "./GeoLocate";
+import { WbLeafletMap } from "./WbLeafletMap";
 
 export function WbToolkit({
   dataset,
@@ -44,26 +44,45 @@ export function WbToolkit({
 }): JSX.Element {
   const handleExport = (): void => {
     const delimiter = userPreferences.get(
-      'workBench',
-      'editor',
-      'exportFileDelimiter'
+      "workBench",
+      "editor",
+      "exportFileDelimiter",
     );
 
-    let datasetColumns = dataset.columns;
-    // Don't export attachments column
-    const attachmentsColumnIndex = getAttachmentsColumn(dataset);
-    if (attachmentsColumnIndex !== -1) {
-      datasetColumns = dataset.columns.map((col, index) =>
-        index === attachmentsColumnIndex ? attachmentsText.attachments() : col
-      );
-    }
+    const prepareExport = (dataset: {
+      columns: RA<string>;
+      rows: RA<RA<string>>;
+      visualorder?: RA<number> | null;
+    }): { columns: RA<string>; rows: RA<RA<string>> } => {
+      const defaultOrder = dataset.columns.map((_, i) => i); // use the existing order as default
 
-    downloadDataSet(
-      dataset.name,
-      dataset.rows,
-      datasetColumns,
-      delimiter
-    ).catch(raise);
+      const order =
+        dataset.visualorder &&
+        dataset.visualorder.length === dataset.columns.length
+          ? dataset.visualorder
+          : defaultOrder; // try to apply visual order if present, otherwise just fallback to default
+
+      const columns = order.map((colIndex) => dataset.columns[colIndex]);
+      const rows = dataset.rows.map((row) =>
+        order.map((colIndex) => row[colIndex] ?? ""),
+      );
+
+      // Don't export attachments column
+      const attachmentsColumnIndex = getAttachmentsColumn(dataset);
+      if (attachmentsColumnIndex !== -1) {
+        columns = columns.map((col, i) =>
+          order[i] === attachmentsColumnIndex
+            ? attachmentsText.attachments()
+            : col,
+        );
+      }
+
+      return { columns, rows };
+    };
+
+    const { columns, rows } = prepareExport(dataset);
+
+    downloadDataSet(dataset.name, rows, columns, delimiter).catch(raise);
   };
 
   const hasLocality =
@@ -77,7 +96,7 @@ export function WbToolkit({
       className="flex flex-wrap gap-x-1 gap-y-2"
       role="toolbar"
     >
-      {variant.canTransfer() && hasTablePermission('SpecifyUser', 'read') ? (
+      {variant.canTransfer() && hasTablePermission("SpecifyUser", "read") ? (
         <ErrorBoundary dismissible>
           <WbChangeOwner
             dataset={dataset}

--- a/specifyweb/frontend/js_src/lib/components/WbToolkit/index.tsx
+++ b/specifyweb/frontend/js_src/lib/components/WbToolkit/index.tsx
@@ -49,11 +49,9 @@ export function WbToolkit({
       "exportFileDelimiter",
     );
 
-    const prepareExport = (dataset: {
-      columns: RA<string>;
-      rows: RA<RA<string>>;
-      visualorder?: RA<number> | null;
-    }): { columns: RA<string>; rows: RA<RA<string>> } => {
+    const prepareExport = (
+      dataset: Dataset,
+    ): { columns: RA<string>; rows: RA<RA<string>> } => {
       const defaultOrder = dataset.columns.map((_, i) => i); // use the existing order as default
 
       const order =

--- a/specifyweb/frontend/js_src/lib/components/WbToolkit/index.tsx
+++ b/specifyweb/frontend/js_src/lib/components/WbToolkit/index.tsx
@@ -60,7 +60,7 @@ export function WbToolkit({
           ? dataset.visualorder
           : defaultOrder; // try to apply visual order if present, otherwise just fallback to default
 
-      const columns = order.map((colIndex) => dataset.columns[colIndex]);
+      let columns = order.map((colIndex) => dataset.columns[colIndex]);
       const rows = dataset.rows.map((row) =>
         order.map((colIndex) => row[colIndex] ?? ""),
       );


### PR DESCRIPTION
Fixes #6172

The issue states that the column order was not respected for datasets with CoG, I can also replicate the issue on `7.11.1` when no CoG are present.

Previously, the export function was using `dataset.columns`. My understanding is that `dataset.columns` isn't modified by dragging columns in the interface, `dataset.visualorder` is.

This PR doesn't touch any of the logic for how `dataset.visualorder` is handled or saved on the backend, it just uses it over `dataset.columns` when exporting to csv/tsv. This successfully allowed for reordering to be respected in exports in my testing, while keeping the changes minimal. Long-term it seems to make sense that the order used in export should be the visual order.

This PR does affect active work done by alesan99 on the attachments in the workbench, as I bundled the lines about ignoring the attachment column in exports into the same process, as they all fall into the scope of preparing columns for export.

### Checklist

- [X] Self-review the PR after opening it to make sure the changes look good and
      self-explanatory (or properly documented)
- [ ] Add relevant issue to release milestone
- [ ] Add pr to documentation list
- [ ] Add automated tests

### Testing instructions

- [ ] Create a new Collection Object data set with a number of random columns & relationship fields.
- [ ] Rearrange the columns.
- [ ] Save the dataset
- [ ] Go to Tools > Export. See that the order of the columns is respected.
- [ ] At least one test (run through the above) with a CoG dataset (as I don't have a geospecify database in my testing)