### PR TITLE
Fix: Disable manual typing in tree-level rank picklists

### DIFF
--- a/specifyweb/frontend/js_src/lib/components/PickLists/index.tsx
+++ b/specifyweb/frontend/js_src/lib/components/PickLists/index.tsx
@@ -159,10 +159,10 @@ export function PickListComboBox({
 
   const isReadOnly = React.useContext(ReadOnlyContext);
 
-  const resolvedName = (pickList?.get?.('name') ?? pickListName) || '';
-  const isFrontEndPicklist = resolvedName.startsWith('_');
+  const isSpecialByPrefix =
+  typeof pickListName === 'string' && pickListName.startsWith('_');
   const isSpecialPicklist =
-    isDisabled || isFrontEndPicklist || pickList?.get?.('readOnly') === true;
+    isDisabled || isSpecialByPrefix || pickList?.get?.('readOnly') === true;
 
   return (
     <>


### PR DESCRIPTION
Fixes #4985

### Checklist

- [ ] Self-review the PR after opening it to make sure the changes look good and
      self-explanatory (or properly documented)
- [ ] Add relevant issue to release milestone


### Testing instructions
-  Go to the data entry and select Taxon/Geography.
- [ ] Check that rank picklists (e.g. Taxonomic/Geographic levels) are not typeable.
- [ ] Check other picklists (Locality ) still use AutoComplete (type-to-search).
