### PR TITLE
Remove limit on number of matches in disambiguation results

### DIFF
--- a/specifyweb/backend/workbench/upload/treerecord.py
+++ b/specifyweb/backend/workbench/upload/treerecord.py
@@ -106,9 +106,9 @@ class TreeRank(NamedTuple):
         """
 
         assert self.rank_name is not None, "Rank name is required"
-        assert self.tree is not None and self.tree.lower() in SPECIFY_TREES, (
-            "Tree is required"
-        )
+        assert (
+            self.tree is not None and self.tree.lower() in SPECIFY_TREES
+        ), "Tree is required"
 
         if self.treedef_id is None:
             logger.info(
@@ -321,9 +321,12 @@ class ScopedTreeRecord(NamedTuple):
             definition_id=target_rank_treedef_id, parent=None
         ).first()
 
-        return self._replace(
-            treedef=target_rank_treedef, treedefitems=treedefitems, root=root
-        ), None
+        return (
+            self._replace(
+                treedef=target_rank_treedef, treedefitems=treedefitems, root=root
+            ),
+            None,
+        )
 
     """
         Adjusts tree scope for TreeRankRecords with NULL treedef_ids.
@@ -689,9 +692,9 @@ class BoundTreeRecord(NamedTuple):
             key = repr(sorted(tdiwpr.match_key() for tdiwpr in tried_to_match))
             return tdiwprs, MatchedMultiple(ids, key, info)
         else:
-            assert n_matches == 0, (
-                f"More than one match found when matching '{tdiwprs}' in '{model}'"
-            )
+            assert (
+                n_matches == 0
+            ), f"More than one match found when matching '{tdiwprs}' in '{model}'"
             if parent is not None:
                 info = ReportInfo(
                     tableName=self.name,
@@ -788,9 +791,9 @@ class BoundTreeRecord(NamedTuple):
         matched: Matched | NoMatch,
         references=None,
     ) -> UploadResult:
-        assert to_upload, (
-            f"Invalid Error: {to_upload}, can not upload matched results: {matched}"
-        )
+        assert (
+            to_upload
+        ), f"Invalid Error: {to_upload}, can not upload matched results: {matched}"
         model = getattr(models, self.name)
 
         parent_info: dict | None


### PR DESCRIPTION
Fixes #7238

I am not sure why there was a limit of the first 10 matches put in place (if anyone can think of it this PR will need to be reworked to solve the problem from a different angle!). This PR removes that limit entirely to solve the problem of only the first 10 matches being shown in disambiguation. I also tested with batch editing, which was the context where the limit was originally applied, and didn't run into any problems without it.

Formatted with [Black](https://github.com/psf/black) this time, since that is the formatter used in `pre-commit-config.yml`.

### Testing instructions

Adapted from the steps to reproduce the issue

- [ ] Create more than 10 Geography records with the same name and rank but different parents
- [ ] Go to the WorkBench. Create a data set with Geography as the base table
- [ ] Map the rank of the Geography records from Step 1
- [ ] Map the rank below that and save
- [ ] In the first column, enter the name of the Geography records from step 1
- [ ] Enter a value in the second column
- [ ] Save and Validate
- [ ] Right click on the resulting error cell and click Disambiguate
- [ ] See that **all** records from Step 1 appear. (Previously only ten would show)

Optional:
Any other testing that you think show why the limit was necessary.