### PR TITLE
fix: render `specialPickLists` as read-only

### DIFF
--- a/specifyweb/frontend/js_src/lib/components/PickLists/index.tsx
+++ b/specifyweb/frontend/js_src/lib/components/PickLists/index.tsx
@@ -160,7 +160,7 @@ export function PickListComboBox({
   const isReadOnly = React.useContext(ReadOnlyContext);
   return (
     <>
-      {pickList?.get('readOnly') === true || isDisabled ? (
+      {pickList?.get('readOnly') === true || isDisabled || (pickList === undefined && pickListName.startsWith('_')) ? (
         <Select
           id={id}
           // "null" value is represented as an empty string


### PR DESCRIPTION
Fixes #4985, alternative implementation of #7391

https://github.com/specify/specify7/blob/b45cef28f3c8a5109ee132f8c26a18b78d020f52/specifyweb/frontend/js_src/lib/components/FormFields/ComboBox.tsx#L40-L45

### Checklist

- [X] Self-review the PR after opening it to make sure the changes look good and
      self-explanatory (or properly documented)
- [ ] Add relevant issue to release milestone
- [ ] Add pr to documentation list
- [ ] Add automated tests
- [ ] Add a reverse migration if a migration is present in the PR

### Testing instructions

<!-- What are the steps to verify the fixes/changes in this PR? -->
<!-- Can part of that be replaced by automated tests? -->
