### PR TITLE
Remove attachment column resizing code

### DIFF
--- a/specifyweb/frontend/js_src/lib/components/WorkBench/handsontable.ts
+++ b/specifyweb/frontend/js_src/lib/components/WorkBench/handsontable.ts
@@ -26,7 +26,6 @@ export function configureHandsontable(
 ): void {
   identifyDefaultValues(hot, mappings);
   curryCells(hot, mappings, dataset, pickLists);
-  setColumnWidths(hot, dataset);
   setSort(hot, dataset);
 }
 
@@ -217,29 +216,4 @@ export function getHotPlugin<NAME extends keyof Plugins>(
   if (plugins[pluginName] === undefined)
     plugins[pluginName] = hot.getPlugin(pluginName);
   return plugins[pluginName]!;
-}
-
-function setColumnWidths(hot: Handsontable, dataset: Dataset): void {
-  let colWidths: WritableArray<number> | undefined = undefined;
-  /**
-   * The attachments column contains text that is different from what is actually displayed.
-   * For simplicity, the width is limited to 100px to reflect the likely shorter displayed text.
-   */
-  const attachmentColumnMaxWidth = 100;
-  const attachmentsColumnIndex = hot.toVisualColumn(
-    getAttachmentsColumn(dataset)
-  );
-  if (
-    attachmentsColumnIndex !== -1 &&
-    hot.getColWidth(attachmentsColumnIndex) > attachmentColumnMaxWidth
-  ) {
-    colWidths = [];
-    colWidths[attachmentsColumnIndex] = Math.min(
-      hot.getColWidth(attachmentsColumnIndex),
-      attachmentColumnMaxWidth
-    );
-  }
-  hot.updateSettings({
-    colWidths,
-  });
 }

--- a/specifyweb/frontend/js_src/lib/components/WorkBench/handsontable.ts
+++ b/specifyweb/frontend/js_src/lib/components/WorkBench/handsontable.ts
@@ -3,7 +3,6 @@ import type { Plugins } from 'handsontable/plugins';
 import type { CellProperties } from 'handsontable/settings';
 
 import { getCache } from '../../utils/cache';
-import type { WritableArray } from '../../utils/types';
 import { writable } from '../../utils/types';
 import { schema } from '../DataModel/schema';
 import { userPreferences } from '../Preferences/userPreferences';


### PR DESCRIPTION
Fixes #7407, #7416

Results in an oversized attachments column, but all other columns should be correct.

Quick fix, if the attachment column size is too bad I can try a better fix.

Also fixes validation.



### Checklist

- [ ] Self-review the PR after opening it to make sure the changes look good and
      self-explanatory (or properly documented)
- [ ] Add relevant issue to release milestone
- [ ] Add pr to documentation list
- [ ] Add automated tests
- [ ] Add a reverse migration if a migration is present in the PR

### Testing instructions

- Import Attachments in Workbench
- Use existing mapping with many columns
- [ ] All columns aren't tiny, and should have automatic widths fitting their contents (Basically #7407 doesn't happen)
- Create a new normal dataset or batch edit dataset
- Fill in or modify data
- [ ] Make sure you can validate and modified cells are highlighted (https://github.com/specify/specify7/issues/7416)
- [ ] Make sure you can upload