### PR TITLE
Handle empty join path in batch edit

### DIFF
--- a/specifyweb/backend/stored_queries/batch_edit.py
+++ b/specifyweb/backend/stored_queries/batch_edit.py
@@ -1119,6 +1119,8 @@ def rewrite_coordinate_fields(row, _mapped_rows: dict[tuple[tuple[str, ...], ...
     }
 
     for join_path in join_paths:
+        if len(join_path) == 0:
+            continue
         field_name = join_path[-1]
         replacement_field = field_replacement_map.get(field_name, None)
         replace_join_path = tuple((*join_path[:-1], replacement_field))


### PR DESCRIPTION
Fixes #7421

Handle the error that occurs when adding a formatted field in the QB and then using batch edit with that query.  The error occurs when a blank tuple is in the join path.  Ignoring that blank tuple and continuing with the rest of the join paths avoids the error.

### Checklist

- [x] Self-review the PR after opening it to make sure the changes look good and
      self-explanatory (or properly documented)
- [x] Add relevant issue to release milestone
- [ ] Add pr to documentation list

### Testing instructions

- Create a query
- Add at least 1 formatted field
- Click Batch Edit
- [x] See that the batch edit screen appears without errors
