### PR TITLE
Fix: replace legacy table icons with SvgIcon

### DIFF
--- a/specifyweb/frontend/js_src/jest.config.ts
+++ b/specifyweb/frontend/js_src/jest.config.ts
@@ -115,6 +115,7 @@ const config: Config.InitialOptions = {
   moduleNameMapper: {
     '\\.(jpg|jpeg|png|webp|svg|ttf|webm)$':
       '<rootDir>/lib/tests/__mocks__/fileMock.ts',
+      '^react-dom/server$': 'react-dom/server.node',
     '\\.(css)$': '<rootDir>/lib/tests/__mocks__/styleFileMock.ts',
   },
 

--- a/specifyweb/frontend/js_src/lib/components/Leaflet/extend.ts
+++ b/specifyweb/frontend/js_src/lib/components/Leaflet/extend.ts
@@ -17,7 +17,8 @@ import 'leaflet.featuregroup.subgroup';
 import GestureHandling from 'leaflet-gesture-handling';
 
 import { localityText } from '../../localization/locality';
-import { legacyNonJsxIcons } from '../Atoms/Icons';
+import { icons } from '../Atoms/Icons';
+import { renderToStaticMarkup } from 'react-dom/server';
 import { className } from '../Atoms/className';
 // @ts-expect-error Path to non-ts file
 import iconRetinaUrl from 'leaflet/dist/images/marker-icon-2x.png';
@@ -53,7 +54,7 @@ export const leafletControls = {
           '!cursor-pointer',
           'rounded'
         );
-        button.innerHTML = legacyNonJsxIcons.arrowsExpand;
+        button.innerHTML = renderToStaticMarkup(icons.arrowsExpand);
 
         let isFullScreen = false;
         L.DomEvent.on(button, 'click', (event) => {
@@ -94,7 +95,7 @@ export const leafletControls = {
         // Hidden by default, until map enters the full-screen mode
         'hidden'
       );
-      button.innerHTML = legacyNonJsxIcons.printer;
+      button.innerHTML = renderToStaticMarkup(icons.document);
 
       L.DomEvent.on(button, 'click', (event) => {
         L.DomEvent.stopPropagation(event);

--- a/specifyweb/frontend/js_src/lib/components/Leaflet/index.ts
+++ b/specifyweb/frontend/js_src/lib/components/Leaflet/index.ts
@@ -9,7 +9,8 @@ import { f } from '../../utils/functools';
 import type { RA, WritableArray } from '../../utils/types';
 import { overwriteReadOnly } from '../../utils/types';
 import { className } from '../Atoms/className';
-import { legacyNonJsxIcons } from '../Atoms/Icons';
+import { icons } from '../Atoms/Icons';
+import { renderToStaticMarkup } from 'react-dom/server';
 import { userPreferences } from '../Preferences/userPreferences';
 import { splitJoinedMappingPath } from '../WbPlanView/mappingHelpers';
 import type { LeafletInstance } from './addOns';
@@ -187,7 +188,7 @@ export const formatLocalityData = (
             <span
               title="${commonText.opensInNewTab()}"
               aria-label="${commonText.opensInNewTab()}"
-            >${legacyNonJsxIcons.link}</span>
+            >${renderToStaticMarkup(icons.externalLink)}</span>
           </a>`,
         ]
       : []),

--- a/specifyweb/frontend/js_src/lib/components/WorkBench/WbSpreadsheet.tsx
+++ b/specifyweb/frontend/js_src/lib/components/WorkBench/WbSpreadsheet.tsx
@@ -13,7 +13,8 @@ import { LANGUAGE } from '../../localization/utils/config';
 import { wbText } from '../../localization/workbench';
 import type { RA } from '../../utils/types';
 import { writable } from '../../utils/types';
-import { iconClassName, legacyNonJsxIcons } from '../Atoms/Icons';
+import { iconClassName, icons } from '../Atoms/Icons';
+import { renderToStaticMarkup } from 'react-dom/server';
 import { ReadOnlyContext } from '../Core/Contexts';
 import { strictGetTable } from '../DataModel/tables';
 import { getIcon, unknownIcon } from '../InitialContext/icons';
@@ -124,7 +125,7 @@ function WbSpreadsheetComponent({
                         <span
                           title="${commonText.opensInNewTab()}"
                           aria-label="${commonText.opensInNewTab()}"
-                        >${legacyNonJsxIcons.link}</span>
+                        >${renderToStaticMarkup(icons.externalLink)}</span>
                       </a>`;
                       })
                       .join('');


### PR DESCRIPTION
Fixes #6504

Replaced legacy Specify 6-style icons in WorkBench/Batch Edit result-cell links with standardized svgIcons assets. This ensures consistent icon usage across the app while avoiding reliance on outdated LegacyNonJSXIcons. The bug was caused by injecting raw SVG (Sp-6 styled) icons; the fix uses renderToStaticMarkup with our current icon set so visuals stay aligned without breaking existing DOM logic.

### Checklist

- [ ] Self-review the PR after opening it to make sure the changes look good and
      self-explanatory (or properly documented)
- [ ] Add relevant issue to release milestone

### Testing instructions

- Upload dataset using workbench.
- [ ] Right-click a cell in the uploaded dataset to check the link uses the SvgIcon table icon.
- [ ] Open Batch Edit on the same dataset and check same SvgIcon appears.
