### PR TITLE
Update Django version to 4.2.24

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ wheel
 # backports.zoneinfo==0.2.1
 kombu==5.5.2
 celery[redis]==5.5.1
-Django==4.2.22
+Django==4.2.24
 mysqlclient==2.1.1
 SQLAlchemy==1.4.54
 sqlalchemy2-stubs


### PR DESCRIPTION
Fixes #7405

Upgrade Django from version 4.2.22 to version 4.2.24.  The change-log only includes minor patches, so no code changes were necessary.  The main reason for upgrading is for fixing a potential SQL injection issue in FilteredRelation column aliases.  This PR resolves this Dependabot alert https://github.com/specify/specify7/security/dependabot/135.

### Checklist

- [x] Self-review the PR after opening it to make sure the changes look good and
      self-explanatory (or properly documented)
- [x] Add relevant issue to release milestone
- [ ] Add pr to documentation list

### Testing instructions

- [x] General Testing.  Do basic operations in each area of Specify.  We don't use `FilteredRelation` anywhere in our code, so there should theoretically be now new bugs or behavior changes.
