### PR TITLE
Fix autonumbering locking with GET_LOCK and RELEASE_LOCK

### DIFF
--- a/specifyweb/specify/models_utils/lock_tables.py
+++ b/specifyweb/specify/models_utils/lock_tables.py
@@ -4,7 +4,6 @@ import logging
 
 logger = logging.getLogger(__name__)
 
-
 @contextmanager
 def lock_tables(*tables):
     cursor = connection.cursor()
@@ -13,8 +12,35 @@ def lock_tables(*tables):
         yield
     else:
         try:
+            # NOTE: Should not do within a transaction.atomic() block
             cursor.execute('lock tables %s' %
                            ' write, '.join(tables) + ' write')
             yield
         finally:
             cursor.execute('unlock tables')
+
+@contextmanager
+def mysql_named_lock(name: str, timeout: int = 10):
+    """
+    Connection-scoped mutex using MySQL GET_LOCK/RELEASE_LOCK.
+    Safe to use inside transaction.atomic().
+    """
+    if connection.vendor != "mysql":
+        yield
+        return
+
+    with connection.cursor() as cur:
+        cur.execute("SELECT GET_LOCK(%s, %s)", [name, timeout])
+        got = cur.fetchone()[0]
+
+    if not got:
+        raise TimeoutError(f"Could not acquire MySQL named lock {name!r}")
+
+    try:
+        yield
+    finally:
+        try:
+            with connection.cursor() as cur:
+                cur.execute("SELECT RELEASE_LOCK(%s)", [name])
+        except Exception:
+            logger.info("Failed to release MySQL named lock %r", name, exc_info=True)


### PR DESCRIPTION
Fixes #6490

Look at Django docs, it seems that explicitly locking mysql tables from within a Django atomic transaction can lead to issues of tables not getting unlocked.  The `post_resource` function has the `transaction.atomic` decorator, which calls create_obj -> autonumber_and_save -> do_autonumbering -> lock_tables.  This is likely an issue.

LOCK TABLES implicitly commits any active transaction, and while tables are locked the connection is restricted to those tables only.  When Django later tries to manage the savepoint/transaction stack, the connection state can no longer matches expectations. This can leave the connection stuck.

This solution tires using `GET_LOCK` and `RELEASE_LOCK`, acting like a mutex.  Using these instead of `lock tables` should avoid problems of query transactions getting stuck.

This solution is still a work in progress.

### Checklist

- [ ] Self-review the PR after opening it to make sure the changes look good and
      self-explanatory (or properly documented)
- [ ] Add relevant issue to release milestone
- [ ] Add pr to documentation list

### Testing instructions

TBD
