### PR TITLE
Refactor picklist case handling in format.py

### DIFF
--- a/specifyweb/backend/stored_queries/format.py
+++ b/specifyweb/backend/stored_queries/format.py
@@ -8,7 +8,7 @@ from xml.etree.ElementTree import Element
 from xml.sax.saxutils import quoteattr
 
 from specifyweb.specify.api.utils import get_picklists
-from sqlalchemy import Table as SQLTable, inspect, case
+from sqlalchemy import Table as SQLTable, inspect, case, type_coerce
 from sqlalchemy.orm import aliased, Query
 from sqlalchemy.sql.expression import func, cast, literal, Label
 from sqlalchemy.sql.functions import concat


### PR DESCRIPTION
Fixes #7456

Refactor picklist handling to improve null handling and type coercion when building a case statement for the QB.

Example query that gets generated:
```sql
SELECT dnasequence.`DnaSequenceID`, CAST(dnasequence.`MoleculeType` AS CHAR) AS `MoleculeType` 
FROM dnasequence
WHERE dnasequence.`CollectionMemberID` = 4
LIMIT 0, 40;
```

For testing, check for picklists that don't have any picklistitems:
```sql
select *
from picklist p
where p.PickListID not in (select i.picklistid from picklistitem i);
```
or
```sql
select p.*
from picklist p
left join picklistitem i ON p.PickListID = i.PickListID
where i.PickListID IS NULL;
```

### Checklist

- [ ] Self-review the PR after opening it to make sure the changes look good and
      self-explanatory (or properly documented)
- [ ] Add relevant issue to release milestone
- [ ] Add pr to documentation list

### Testing instructions

- On any database, find a pick list with the type "Field From Table" that is assigned to a field. This can be done by querying the picklist table directly for that type, then using the "Find Usages" button in the Form Meta Menu for that pick list to find where it is assigned in the schema config. For testing, you can use the sp7demofish_2025_09_09 database which has a pick list assigned to the "Molecule Type" field in the "DNA Sequence" table

- [x] See that the query runs without errors.
- [x] Test other queries with Picklists to verify that they still function without error. (Use various type of pick lists) 
