### PR TITLE
Feat: Handle uniqueness rules for yesNo fields in schema config

### DIFF
--- a/specifyweb/frontend/js_src/lib/components/Forms/Save.tsx
+++ b/specifyweb/frontend/js_src/lib/components/Forms/Save.tsx
@@ -329,7 +329,7 @@ function SaveBlockedDialog({
     () =>
       generateMappingPathPreview(
         field[0].table.name,
-        field.map(({ name }) => name)
+        field.map(({ label }) => label)
       ),
     [field]
   );

--- a/specifyweb/specify/api/crud.py
+++ b/specifyweb/specify/api/crud.py
@@ -325,6 +325,8 @@ def apply_filters(logged_in_collection, params, model, control_params=GetCollect
         elif param.endswith('__in') or param.endswith('__range'):
             # this is a bit kludgy
             val = val.split(',')
+        elif isinstance(val, str) and val.lower() in ("true", "false"):
+            val = val.lower() == "true"
 
         filters.update({param: val})
 


### PR DESCRIPTION
Fixes #7437

### Checklist

- [ ] Self-review the PR after opening it to make sure the changes look good and
      self-explanatory (or properly documented)
- [ ] Add relevant issue to release milestone

### Testing instructions

- Add yesNo1 to the determination subview (or any other boolean field in a table) 
- Go to schema config
- Select determination as the base table
- Add a uniqueness rule where yesNo1 is unique to collection object
- Open existing or create a new CO with 2 determinations
- Save
- Check and uncheck the yesNo box
- [ ] verify the rule is applied 
