### PR TITLE
Add unit test for node renumbering

### DIFF
--- a/specifyweb/backend/trees/tests/test_tree_extras/test_tree_save.py
+++ b/specifyweb/backend/trees/tests/test_tree_extras/test_tree_save.py
@@ -1,5 +1,5 @@
 from specifyweb.backend.businessrules.exceptions import TreeBusinessRuleException
-from specifyweb.backend.trees.extras import renumber_tree
+from specifyweb.backend.trees.extras import renumber_tree, validate_tree_numbering
 from specifyweb.specify.models import Taxon, Taxontreedefitem
 from specifyweb.backend.trees.tests.test_trees import GeographyTree
 
@@ -286,6 +286,7 @@ class TestTreeSave(GeographyTree):
         renumber_tree(table)
 
         # Test that the node numbers in the tree are correct
+        # NOTE: Using validate_tree_numbering now instead, but keeping query here for future reference and testing
         bad_node_number_count = (
             Taxon.objects
             .filter(parent__isnull=False)
@@ -301,4 +302,5 @@ class TestTreeSave(GeographyTree):
             .count()
         )
 
-        self.assertEqual(bad_node_number_count, 0)
+        # self.assertEqual(bad_node_number_count, 0)
+        validate_tree_numbering('taxon')


### PR DESCRIPTION
Fixes #7540

Add unit test for node renumbering.  Shuffle the node numbers for the taxon prior to running the node renumbering function in the unit test.

Implemented this sql check into Django's ORM
```sql
select count(*)
from taxon t
join taxon p on t.parentid = p.taxonid
where t.nodenumber not between p.nodenumber and p.highestchildnodenumber;
```
=>
```python
bad_node_number_count = (
    Taxon.objects
    .filter(parent__isnull=False)
    .filter(
        nodenumber__isnull=False,
        parent__nodenumber__isnull=False,
        parent__highestchildnodenumber__isnull=False,
    )
    .filter(
        Q(nodenumber__lt=F('parent__nodenumber')) |
        Q(nodenumber__gt=F('parent__highestchildnodenumber'))
    )
    .count()
)
```

### Checklist

- [x] Self-review the PR after opening it to make sure the changes look good and
      self-explanatory (or properly documented)
- [x] Add relevant issue to release milestone
- [x] Add pr to documentation list
- [x] Add automated tests

### Testing instructions

- [x] All unit tests pass in the back-end GitHub Action test.
