### PR TITLE
Fix format.py error

### DIFF
--- a/specifyweb/backend/stored_queries/format.py
+++ b/specifyweb/backend/stored_queries/format.py
@@ -221,7 +221,7 @@ class ObjectFormatter:
             if fieldNodeAttrib.get('trimzeros') == 'true':
                 numeric_str = cast(cast(e, types.Numeric(65)), types.String())
                 e = case(
-                    (e.op('REGEXP')(r'^-?[0-9]+(\\.[0-9]+)?$'), numeric_str),
+                    (e.op('REGEXP')(r'^-?[0-9]+(\.[0-9]+)?$'), numeric_str),
                     else_=cast(e, types.String()),
                 )
             fmt = fieldNodeAttrib.get('format')


### PR DESCRIPTION
Fixes #7586 

Fix courtesy of @melton-jason 

### Checklist

- [ ] Self-review the PR after opening it to make sure the changes look good and
      self-explanatory (or properly documented)
- [ ] Add relevant issue to release milestone
- [ ] Add pr to documentation list
- [ ] Add automated tests
- [ ] Add a reverse migration if a migration is present in the PR

### Testing instructions
- Load up specify and look at the server logs (On the test panel you can click the gear and view logs)
- [ ] Make sure this error does not appear.
```
PS C:\Users\a114s239\Projects\specify7> docker exec specify7 ve/bin/python manage.py makemigrations
/opt/specify7/specifyweb/backend/stored_queries/format.py:451: SyntaxWarning: invalid escape sequence '\.'
  [(field.op('REGEXP')('^-?[0-9]+(\.[0-9]+)?$'), cast(field, types.Numeric(65)))],
No changes detected
```
- [ ] Make sure the trim zeros option still works in table formatters in queries.
- Note: This error may only occur on windows? So you may not encounter this error in main.
