### PR TITLE
Upgrade Django from version 4.2.24 to 4.2.27

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ wheel
 kombu==5.5.2
 redis==6.4.0
 celery==5.5.1
-Django==4.2.26
+Django==4.2.27
 mysqlclient==2.1.1
 SQLAlchemy==1.4.54
 sqlalchemy2-stubs


### PR DESCRIPTION
Fixes #7590

Upgrade Django from version 4.2.24 to 4.2.27 to solve the vulnerability issue with the Django QuerySet.  This also resolves all the current Django related security vulnerabilities identified via dependabot:
- https://github.com/specify/specify7/security/dependabot/139
- https://github.com/specify/specify7/security/dependabot/137
- https://github.com/specify/specify7/security/dependabot/147
- https://github.com/specify/specify7/security/dependabot/146
- https://github.com/specify/specify7/security/dependabot/136

### Checklist

- [x] Self-review the PR after opening it to make sure the changes look good and
      self-explanatory (or properly documented)
- [x] Add relevant issue to release milestone
- [ ] Add pr to documentation list

### Testing instructions

- [x] See that all unit tests and build pass.
- [x] Check the general functionality of each of Specify's main functionalities.
