### PR TITLE
fix: deleting records in query builder has a minimum of zero results

### DIFF
--- a/specifyweb/frontend/js_src/lib/components/QueryBuilder/Results.tsx
+++ b/specifyweb/frontend/js_src/lib/components/QueryBuilder/Results.tsx
@@ -169,7 +169,8 @@ export function QueryResults(props: QueryResultsProps): JSX.Element {
       setResults(newResults(results));
       if (removeCount === 0) return;
       setTotalCount((totalCount) =>
-        totalCount === undefined ? undefined : totalCount - removeCount
+        totalCount === undefined ? undefined : Math.max(0, totalCount - removeCount)
+      
       );
       const newSelectedRows = (selectedRows: ReadonlySet<number>) =>
         new Set(Array.from(selectedRows).filter((id) => id !== recordId));


### PR DESCRIPTION
Fixes #4988

This PR introduces a change to fix a ui issue when a user deletes records through the query builder. Before the change, after deleting the last record in a specific query, the results header would incorrectly return as `Results: (-1)`. After the change, the results header will only show `Results: (0)` when the last record is deleted. 

This change is in the following line:  https://github.com/specify/specify7/blob/81f9974d7663271fe6c7fcd1c1295a52b7cbb5d6/specifyweb/frontend/js_src/lib/components/QueryBuilder/Results.tsx#L172 

This prevents a negative account from showing up in the results header. 

<!--
> [!WARNING]  
> This PR affects database migrations. See [migration testing instructions](https://specify.github.io/testing/pull_requests.html#prs-tagged-with-label-migration).
-->

### Checklist

- [x] Self-review the PR after opening it to make sure the changes look good and
      self-explanatory (or properly documented)
- [x] Add relevant issue to release milestone
- [ ] Add pr to documentation list
- [ ] Add automated tests
- [ ] Add a reverse migration if a migration is present in the PR

### Testing instructions

- [ ] Create a query (or use existing one)
- [ ] Delete all the records that show up
- [ ] Verify that the results count is zero and non-negative
