### PR TITLE
Fix Discipline Type Picklist run_key_migration_function.py

### DIFF
--- a/specifyweb/specify/management/commands/run_key_migration_functions.py
+++ b/specifyweb/specify/management/commands/run_key_migration_functions.py
@@ -75,7 +75,7 @@ def fix_schema_config(stdout: WriteToStdOut | None = None):
         usc.update_paleo_desc, # specify 0033
         usc.update_accession_date_fields, # specify 0034
         usc.create_discipline_type_picklist, # specify 0042
-        usc.update_discipline_type_splocalecontaineritem # specify specify 0042
+        usc.update_discipline_type_splocalecontaineritem # specify 0042
     ]
     log_and_run(funcs, stdout)
 


### PR DESCRIPTION
Fixes #7584 

There were missing commas, which would only crash sometimes.

<!--
> [!WARNING]  
> This PR affects database migrations. See [migration testing instructions](https://specify.github.io/testing/pull_requests.html#prs-tagged-with-label-migration).
-->

### Checklist

- [ ] Self-review the PR after opening it to make sure the changes look good and
      self-explanatory (or properly documented)
- [ ] Add relevant issue to release milestone
- [ ] Add pr to documentation list
- [ ] Add automated tests
- [ ] Add a reverse migration if a migration is present in the PR

### Testing instructions

- [ ] Run migration specify 0042
- [ ] Make sure you can revert it
