### PR TITLE
Fix:Only allow empty values for negation for "In", "Contains", or =

### DIFF
--- a/specifyweb/backend/stored_queries/queryfieldspec.py
+++ b/specifyweb/backend/stored_queries/queryfieldspec.py
@@ -417,8 +417,13 @@ class QueryFieldSpec(
                 op, mod_orm_field, value = apply_special_filter_cases(orm_field, field, table, value, op, op_num, uiformatter, collection, user)
                 f = op(mod_orm_field, value)
 
+            NULL_SAFE_NEGATE_OPS = {1, 10, 11}
+
             if negate:
-                predicate = null_safe_not(mod_orm_field or orm_field, f)
+                if op_num in NULL_SAFE_NEGATE_OPS:
+                    predicate = null_safe_not(mod_orm_field or orm_field, f)
+                else:
+                    predicate = sql.not_(f)
             else:
                 predicate = f
         else:


### PR DESCRIPTION
Fixes #7646
Fixes #7547
Fixes #7611 

### Checklist

- [ ] Self-review the PR after opening it to make sure the changes look good and
      self-explanatory (or properly documented)
- [ ] Add relevant issue to release milestone
- [ ] Add pr to documentation list
- [ ] Add automated tests
- [ ] Add a reverse migration if a migration is present in the PR

### Testing instructions

**New Fix: Empty filter with Negate that are not a part of:** 
NOT In
NOT Contains
NOT Equals

- Go to Queries.
- Create a new query.
- Add a filter using the Empty operator on any field.
- [ ] Verify that only records with empty / NULL values are returned.
- Click the Negate button for the filter.
- [ ] Verify that all non-empty records are returned.

**Previous Fix: NOT operator with In / Contains / Equals**
- Create a query with a field that contains empty / NULL values.
- Apply a filter using the NOT operator with one of the following:
NOT In
NOT Contains
NOT Equals

- [ ] Verify that records with empty / NULL values are included in the results.

**Stat error:** 

- Go to statistics
- [ ] Verify there are no errors for the tree stats (See https://github.com/specify/specify7/issues/7547)

**Imported Queries** 

- Go to queries
- Select New
- Import one of the queries listed here (https://github.com/specify/specify7/issues/7611)
- Press Query
- [ ] Verify the imported query runs
