### PR TITLE
fix to front-end tests with `pr-7645`

### DIFF
--- a/specifyweb/frontend/js_src/lib/components/QueryBuilder/Results.tsx
+++ b/specifyweb/frontend/js_src/lib/components/QueryBuilder/Results.tsx
@@ -150,7 +150,7 @@ export function QueryResults(props: QueryResultsProps): JSX.Element {
     undefinedResult === -1 ? results : results?.slice(0, undefinedResult)
   ) as RA<QueryResultRow> | undefined;
 
-  const deletingRef = React.useRef<Set<number>>(new Set()); // Track recent deleted IDs to prevent duplicate deletion
+  const deletingRef = React.useRef<ReadonlySet<number>>(new Set()); // Track recent deleted IDs to prevent duplicate deletion
 
   // TEST: try deleting while records are being fetched
   /**


### PR DESCRIPTION
Fixes #7705 

This is a pr to fix failed front-end tests that occurred after merging [pr-7645](https://github.com/specify/specify7/pull/7645) to main. There was a JS/TS issue where `deletingRef` was defined as `ReadonlySet` when it should have been `Set` to allow `add()` or `delete()` methods to be used on it. 

 Please see that pr for more information on the issue that I am asking you to test again below. 
<!--
> [!WARNING]  
> This PR affects database migrations. See [migration testing instructions](https://specify.github.io/testing/pull_requests.html#prs-tagged-with-label-migration).
-->

### Checklist

- [ ] Self-review the PR after opening it to make sure the changes look good and
      self-explanatory (or properly documented)
- [ ] Add relevant issue to release milestone
- [ ] Add pr to documentation list
- [ ] Add automated tests
- [ ] Add a reverse migration if a migration is present in the PR

### Testing instructions 

Same instructions as in [pr-7645](https://github.com/specify/specify7/pull/7645) (restated below): 
- [ ] Create a query with at least 2 records
- [ ] Delete all the records that show up
- [ ] Verify that the results count decreases by 1 following each removal
- [ ] Verify that the results count is zero and non-negative once all records are deleted