### PR TITLE
Refresh page after starting default tree import

### DIFF
--- a/specifyweb/frontend/js_src/lib/components/TreeView/CreateTree.tsx
+++ b/specifyweb/frontend/js_src/lib/components/TreeView/CreateTree.tsx
@@ -173,7 +173,6 @@ export function CreateTree<
                   setIsTreeCreationStarted(false);
                   setTreeCreationTaskId(undefined);
                   setIsActive(0);
-                  globalThis.location.reload();
                 }}
                 onStopped={() => {
                   setIsTreeCreationStarted(false);
@@ -354,6 +353,7 @@ export function ImportTree<SCHEMA extends AnyTree>({
                   setIsTreeCreationStarted(false);
                   setTreeCreationTaskId(undefined);
                   setIsActive(0);
+                  globalThis.location.reload();
                 }}
                 onStopped={() => {
                   setIsTreeCreationStarted(false);


### PR DESCRIPTION
Fixes #7757

Prevents you from importing a default tree into an empty tree multiple times.

### Checklist

- [ ] Self-review the PR after opening it to make sure the changes look good and
      self-explanatory (or properly documented)
- [ ] Add relevant issue to release milestone
- [ ] Add pr to documentation list
- [ ] Add automated tests
- [ ] Add a reverse migration if a migration is present in the PR

### Testing instructions

- Create a new empty taxon tree
- Click the button to import a tree into it
- A loading dialog should appear. Close it.
- [ ] The page should refresh after closing the dialog, preventing you from importing again or creating a root.
- [ ] A tree loading message should appear.
