### PR TITLE
New efficient get_schema_localization implementation

### DIFF
--- a/specifyweb/backend/context/schema_localization.py
+++ b/specifyweb/backend/context/schema_localization.py
@@ -5,28 +5,59 @@ Provide the proper Schema Localization to the front-end
 import logging
 logger = logging.getLogger(__name__)
 
-from django.conf import settings
-from django.db import connection
+from django.db.models import F, OuterRef, Q, Subquery
+from django.db.models.functions import Coalesce, Lower
 
+from specifyweb.specify.models import (
+    Splocalecontainer,
+    Splocalecontaineritem,
+    Splocaleitemstr,
+)
+
+def _is_null_or_blank(field_name: str) -> Q:
+    return Q(**{f'{field_name}__isnull': True}) | Q(**{field_name: ''})
+
+def _localized_text_subquery(fk_field_name: str, language: str, country: str | None) -> Subquery:
+    filters = {
+        fk_field_name: OuterRef('id'),
+        'language': language,
+    }
+    query = Splocaleitemstr.objects.filter(**filters).filter(_is_null_or_blank('variant'))
+
+    if country is None:
+        query = query.filter(_is_null_or_blank('country'))
+    else:
+        query = query.filter(country=country)
+
+    return Subquery(query.order_by('id').values('text')[:1])
+
+def _localized_text_annotation(fk_field_name: str, language: str, country: str | None, fallback_field_name: str):
+    candidates = []
+
+    if country is not None:
+        candidates.append(_localized_text_subquery(fk_field_name, language, country))
+
+    candidates.append(_localized_text_subquery(fk_field_name, language, None))
+
+    if language != 'en':
+        candidates.append(_localized_text_subquery(fk_field_name, 'en', None))
+
+    return Coalesce(*candidates, F(fallback_field_name))
 
 def get_schema_languages():
-    cursor = connection.cursor()
-
-    cursor.execute("""
-    SELECT DISTINCT
-        lower(`language`),
-        lower(`country`),
-        lower(`variant`)
-    FROM splocaleitemstr;
-    """)
-
-    return list(cursor.fetchall())
+    return list(
+        Splocaleitemstr.objects.annotate(
+            language_lower=Lower('language'),
+            country_lower=Lower('country'),
+            variant_lower=Lower('variant'),
+        )
+        .values_list('language_lower', 'country_lower', 'variant_lower')
+        .distinct()
+    )
 
 def get_schema_localization(collection, schematype, lang):
     disc = collection.discipline
     language, country = lang.lower().split('-') if '-' in lang else (lang, None)
-
-    cursor = connection.cursor()
 
     # # It's possible to generate the json in the DB as follows:
 
@@ -70,109 +101,104 @@ def get_schema_localization(collection, schematype, lang):
 
     # return cursor.fetchone()[0]
 
-    cursor.execute(f"""
-    select name, format, ishidden, isuiformatter, picklistname, type, aggregator, defaultui,
-           coalesce({'n1.text, ' if country is not None else ''} n2.text, n3.text, name),
-           coalesce({'d1.text, ' if country is not None else ''} d2.text, d3.text, name)
-    from splocalecontainer
-
-    {'''
-    left outer join splocaleitemstr n1 on n1.splocalecontainernameid = splocalecontainerid
-    and n1.language = %(language)s
-    and n1.country = %(country)s
-    and (n1.variant is null or n1.variant = '')
-    '''  if country is not None else ''}
-
-    left outer join splocaleitemstr n2 on n2.splocalecontainernameid = splocalecontainerid
-    and n2.language = %(language)s
-    and (n2.country is null or n2.country = '')
-    and (n2.variant is null or n2.variant = '')
-
-    left outer join splocaleitemstr n3 on n3.splocalecontainernameid = splocalecontainerid
-    and n3.language = 'en'
-    and (n3.country is null or n3.country = '')
-    and (n3.variant is null or n3.variant = '')
-
-    {'''
-    left outer join splocaleitemstr d1 on d1.splocalecontainerdescid = splocalecontainerid
-    and d1.language = %(language)s
-    and d1.country = %(country)s
-    and (d1.variant is null or d1.variant = '')
-    ''' if country is not None else ''}
-
-    left outer join splocaleitemstr d2 on d2.splocalecontainerdescid = splocalecontainerid
-    and d2.language = %(language)s
-    and (d2.country is null or d2.country = '')
-    and (d2.variant is null or d2.variant = '')
-
-    left outer join splocaleitemstr d3 on d3.splocalecontainerdescid = splocalecontainerid
-    and d3.language = 'en'
-    and (d3.country is null or d3.country = '')
-    and (d3.variant is null or d3.variant = '')
-
-    where schematype = %(schematype)s and disciplineid = %(disciplineid)s
-    order by name
-    """, {'language': language, 'country': country, 'schematype': schematype, 'disciplineid': disc.id})
-
-    cfields = ('format', 'ishidden', 'isuiformatter', 'picklistname', 'type', 'aggregator', 'defaultui', 'name', 'desc')
+    container_rows = (
+        Splocalecontainer.objects.filter(schematype=schematype, discipline_id=disc.id)
+        .annotate(
+            localized_name=_localized_text_annotation(
+                'containername_id',
+                language,
+                country,
+                'name',
+            ),
+            localized_desc=_localized_text_annotation(
+                'containerdesc_id',
+                language,
+                country,
+                'name',
+            ),
+        )
+        .order_by('name')
+        .values(
+            'name',
+            'format',
+            'ishidden',
+            'isuiformatter',
+            'picklistname',
+            'type',
+            'aggregator',
+            'defaultui',
+            'localized_name',
+            'localized_desc',
+        )
+    )
 
     containers = {
-        row[0].lower(): dict(items={}, **{field: row[i+1] for i, field in enumerate(cfields)})
-        for row in cursor.fetchall()
+        row['name'].lower(): dict(
+            items={},
+            format=row['format'],
+            ishidden=row['ishidden'],
+            isuiformatter=row['isuiformatter'],
+            picklistname=row['picklistname'],
+            type=row['type'],
+            aggregator=row['aggregator'],
+            defaultui=row['defaultui'],
+            name=row['localized_name'],
+            desc=row['localized_desc'],
+        )
+        for row in container_rows
     }
 
-    cursor.execute(f"""
-    select container.name, item.name,
-           item.format, item.ishidden, item.isuiformatter, item.picklistname,
-           item.type, item.isrequired, item.weblinkname,
-           coalesce({'n1.text, ' if country is not None else ''} n2.text, n3.text, item.name),
-           coalesce({'d1.text, ' if country is not None else ''} d2.text, d3.text, item.name)
-    from splocalecontainer container
-    inner join splocalecontaineritem item on item.splocalecontainerid = container.splocalecontainerid
+    item_rows = (
+        Splocalecontaineritem.objects.filter(
+            container__schematype=schematype,
+            container__discipline_id=disc.id,
+        )
+        .annotate(
+            container_name=F('container__name'),
+            localized_name=_localized_text_annotation(
+                'itemname_id',
+                language,
+                country,
+                'name',
+            ),
+            localized_desc=_localized_text_annotation(
+                'itemdesc_id',
+                language,
+                country,
+                'name',
+            ),
+        )
+        .order_by('name')
+        .values(
+            'container_name',
+            'name',
+            'format',
+            'ishidden',
+            'isuiformatter',
+            'picklistname',
+            'type',
+            'isrequired',
+            'weblinkname',
+            'localized_name',
+            'localized_desc',
+        )
+    )
 
-    {'''
-    left outer join splocaleitemstr n1 on n1.splocalecontaineritemnameid = splocalecontaineritemid
-    and n1.language = %(language)s
-    and n1.country = %(country)s
-    and (n1.variant is null or n1.variant = '')
-    '''  if country is not None else ''}
+    for row in item_rows:
+        container_key = row['container_name'].lower()
+        if container_key not in containers:
+            continue
 
-    left outer join splocaleitemstr n2 on n2.splocalecontaineritemnameid = splocalecontaineritemid
-    and n2.language = %(language)s
-    and (n2.country is null or n2.country = '')
-    and (n2.variant is null or n2.variant = '')
-
-    left outer join splocaleitemstr n3 on n3.splocalecontaineritemnameid = splocalecontaineritemid
-    and n3.language = 'en'
-    and (n3.country is null or n3.country = '')
-    and (n3.variant is null or n3.variant = '')
-
-    {'''
-    left outer join splocaleitemstr d1 on d1.splocalecontaineritemdescid = splocalecontaineritemid
-    and d1.language = %(language)s
-    and d1.country = %(country)s
-    and (d1.variant is null or d1.variant = '')
-    ''' if country is not None else ''}
-
-    left outer join splocaleitemstr d2 on d2.splocalecontaineritemdescid = splocalecontaineritemid
-    and d2.language = %(language)s
-    and (d2.country is null or d2.country = '')
-    and (d2.variant is null or d2.variant = '')
-
-    left outer join splocaleitemstr d3 on d3.splocalecontaineritemdescid = splocalecontaineritemid
-    and d3.language = 'en'
-    and (d3.country is null or d3.country = '')
-    and (d3.variant is null or d3.variant = '')
-
-    where schematype = %(schematype)s and disciplineid = %(disciplineid)s
-    order by item.name
-    """, {'language': language, 'country': country, 'schematype': schematype, 'disciplineid': disc.id})
-
-
-    ifields = ('format', 'ishidden', 'isuiformatter', 'picklistname', 'type', 'isrequired', 'weblinkname', 'name', 'desc')
-
-    for row in cursor.fetchall():
-        containers[row[0].lower()]['items'][row[1].lower()] = {field: row[i+2] for i, field in enumerate(ifields)}
+        containers[container_key]['items'][row['name'].lower()] = {
+            'format': row['format'],
+            'ishidden': row['ishidden'],
+            'isuiformatter': row['isuiformatter'],
+            'picklistname': row['picklistname'],
+            'type': row['type'],
+            'isrequired': row['isrequired'],
+            'weblinkname': row['weblinkname'],
+            'name': row['localized_name'],
+            'desc': row['localized_desc'],
+        }
 
     return containers
-

--- a/specifyweb/backend/context/tests/test_schema_localization.py
+++ b/specifyweb/backend/context/tests/test_schema_localization.py
@@ -1,0 +1,346 @@
+from django.db import connection
+
+from specifyweb.backend.context.schema_localization import get_schema_localization
+from specifyweb.specify.models import Splocalecontainer, Splocalecontaineritem, Splocaleitemstr
+from specifyweb.specify.tests.test_api import ApiTests
+
+def _legacy_get_schema_localization_raw_sql(collection, schematype, lang):
+    disc = collection.discipline
+    language, country = lang.lower().split('-') if '-' in lang else (lang, None)
+
+    cursor = connection.cursor()
+
+    cursor.execute(f"""
+    select name, format, ishidden, isuiformatter, picklistname, type, aggregator, defaultui,
+           coalesce({'n1.text, ' if country is not None else ''} n2.text, n3.text, name),
+           coalesce({'d1.text, ' if country is not None else ''} d2.text, d3.text, name)
+    from splocalecontainer
+
+    {'''
+    left outer join splocaleitemstr n1 on n1.splocalecontainernameid = splocalecontainerid
+    and n1.language = %(language)s
+    and n1.country = %(country)s
+    and (n1.variant is null or n1.variant = '')
+    '''  if country is not None else ''}
+
+    left outer join splocaleitemstr n2 on n2.splocalecontainernameid = splocalecontainerid
+    and n2.language = %(language)s
+    and (n2.country is null or n2.country = '')
+    and (n2.variant is null or n2.variant = '')
+
+    left outer join splocaleitemstr n3 on n3.splocalecontainernameid = splocalecontainerid
+    and n3.language = 'en'
+    and (n3.country is null or n3.country = '')
+    and (n3.variant is null or n3.variant = '')
+
+    {'''
+    left outer join splocaleitemstr d1 on d1.splocalecontainerdescid = splocalecontainerid
+    and d1.language = %(language)s
+    and d1.country = %(country)s
+    and (d1.variant is null or d1.variant = '')
+    ''' if country is not None else ''}
+
+    left outer join splocaleitemstr d2 on d2.splocalecontainerdescid = splocalecontainerid
+    and d2.language = %(language)s
+    and (d2.country is null or d2.country = '')
+    and (d2.variant is null or d2.variant = '')
+
+    left outer join splocaleitemstr d3 on d3.splocalecontainerdescid = splocalecontainerid
+    and d3.language = 'en'
+    and (d3.country is null or d3.country = '')
+    and (d3.variant is null or d3.variant = '')
+
+    where schematype = %(schematype)s and disciplineid = %(disciplineid)s
+    order by name
+    """, {'language': language, 'country': country, 'schematype': schematype, 'disciplineid': disc.id})
+
+    cfields = (
+        'format',
+        'ishidden',
+        'isuiformatter',
+        'picklistname',
+        'type',
+        'aggregator',
+        'defaultui',
+        'name',
+        'desc',
+    )
+
+    containers = {
+        row[0].lower(): dict(items={}, **{field: row[i + 1] for i, field in enumerate(cfields)})
+        for row in cursor.fetchall()
+    }
+
+    cursor.execute(f"""
+    select container.name, item.name,
+           item.format, item.ishidden, item.isuiformatter, item.picklistname,
+           item.type, item.isrequired, item.weblinkname,
+           coalesce({'n1.text, ' if country is not None else ''} n2.text, n3.text, item.name),
+           coalesce({'d1.text, ' if country is not None else ''} d2.text, d3.text, item.name)
+    from splocalecontainer container
+    inner join splocalecontaineritem item on item.splocalecontainerid = container.splocalecontainerid
+
+    {'''
+    left outer join splocaleitemstr n1 on n1.splocalecontaineritemnameid = splocalecontaineritemid
+    and n1.language = %(language)s
+    and n1.country = %(country)s
+    and (n1.variant is null or n1.variant = '')
+    '''  if country is not None else ''}
+
+    left outer join splocaleitemstr n2 on n2.splocalecontaineritemnameid = splocalecontaineritemid
+    and n2.language = %(language)s
+    and (n2.country is null or n2.country = '')
+    and (n2.variant is null or n2.variant = '')
+
+    left outer join splocaleitemstr n3 on n3.splocalecontaineritemnameid = splocalecontaineritemid
+    and n3.language = 'en'
+    and (n3.country is null or n3.country = '')
+    and (n3.variant is null or n3.variant = '')
+
+    {'''
+    left outer join splocaleitemstr d1 on d1.splocalecontaineritemdescid = splocalecontaineritemid
+    and d1.language = %(language)s
+    and d1.country = %(country)s
+    and (d1.variant is null or d1.variant = '')
+    ''' if country is not None else ''}
+
+    left outer join splocaleitemstr d2 on d2.splocalecontaineritemdescid = splocalecontaineritemid
+    and d2.language = %(language)s
+    and (d2.country is null or d2.country = '')
+    and (d2.variant is null or d2.variant = '')
+
+    left outer join splocaleitemstr d3 on d3.splocalecontaineritemdescid = splocalecontaineritemid
+    and d3.language = 'en'
+    and (d3.country is null or d3.country = '')
+    and (d3.variant is null or d3.variant = '')
+
+    where schematype = %(schematype)s and disciplineid = %(disciplineid)s
+    order by item.name
+    """, {'language': language, 'country': country, 'schematype': schematype, 'disciplineid': disc.id})
+
+    ifields = (
+        'format',
+        'ishidden',
+        'isuiformatter',
+        'picklistname',
+        'type',
+        'isrequired',
+        'weblinkname',
+        'name',
+        'desc',
+    )
+
+    for row in cursor.fetchall():
+        containers[row[0].lower()]['items'][row[1].lower()] = {
+            field: row[i + 2] for i, field in enumerate(ifields)
+        }
+
+    return containers
+
+class TestSchemaLocalization(ApiTests):
+    def setUp(self):
+        super().setUp()
+        suffix = str(self.collection.id)
+        self.container_name = f'ormlocaletable_{suffix}'
+        self.item_name = f'ormlocalefield_{suffix}'
+
+        self.container = Splocalecontainer.objects.create(
+            name=self.container_name,
+            discipline=self.discipline,
+            schematype=0,
+            ishidden=False,
+            issystem=False,
+        )
+        self.item = Splocalecontaineritem.objects.create(
+            container=self.container,
+            name=self.item_name,
+            ishidden=False,
+            issystem=False,
+        )
+
+    def _create_itemstr(
+        self,
+        *,
+        text: str,
+        language: str,
+        target: str,
+        kind: str,
+        country: str | None = None,
+        variant: str | None = None,
+    ) -> None:
+        payload = {
+            'text': text,
+            'language': language,
+            'country': country,
+            'variant': variant,
+        }
+
+        if target == 'container' and kind == 'name':
+            payload['containername'] = self.container
+        elif target == 'container' and kind == 'desc':
+            payload['containerdesc'] = self.container
+        elif target == 'item' and kind == 'name':
+            payload['itemname'] = self.item
+        elif target == 'item' and kind == 'desc':
+            payload['itemdesc'] = self.item
+        else:
+            raise ValueError('Unexpected target/kind combination')
+
+        Splocaleitemstr.objects.create(**payload)
+
+    def test_prefers_country_then_language_then_english(self):
+        self._create_itemstr(
+            text='Container EN',
+            language='en',
+            target='container',
+            kind='name',
+        )
+        self._create_itemstr(
+            text='Container ES',
+            language='es',
+            target='container',
+            kind='name',
+        )
+        self._create_itemstr(
+            text='Container ES-MX',
+            language='es',
+            country='mx',
+            target='container',
+            kind='name',
+        )
+        self._create_itemstr(
+            text='Container Desc EN',
+            language='en',
+            target='container',
+            kind='desc',
+        )
+        self._create_itemstr(
+            text='Container Desc ES',
+            language='es',
+            target='container',
+            kind='desc',
+        )
+
+        self._create_itemstr(
+            text='Item EN',
+            language='en',
+            target='item',
+            kind='name',
+        )
+        self._create_itemstr(
+            text='Item ES',
+            language='es',
+            target='item',
+            kind='name',
+        )
+        self._create_itemstr(
+            text='Item ES-MX',
+            language='es',
+            country='mx',
+            target='item',
+            kind='name',
+        )
+        self._create_itemstr(
+            text='Item Desc EN',
+            language='en',
+            target='item',
+            kind='desc',
+        )
+        self._create_itemstr(
+            text='Item Desc ES',
+            language='es',
+            target='item',
+            kind='desc',
+        )
+
+        localized = get_schema_localization(self.collection, 0, 'es-mx')
+        table = localized[self.container_name]
+        field = table['items'][self.item_name]
+
+        self.assertEqual(table['name'], 'Container ES-MX')
+        self.assertEqual(table['desc'], 'Container Desc ES')
+        self.assertEqual(field['name'], 'Item ES-MX')
+        self.assertEqual(field['desc'], 'Item Desc ES')
+
+    def test_falls_back_to_name_when_no_locale_rows_exist(self):
+        localized = get_schema_localization(self.collection, 0, 'fr')
+        table = localized[self.container_name]
+        field = table['items'][self.item_name]
+
+        self.assertEqual(table['name'], self.container_name)
+        self.assertEqual(table['desc'], self.container_name)
+        self.assertEqual(field['name'], self.item_name)
+        self.assertEqual(field['desc'], self.item_name)
+
+    def test_executes_two_queries(self):
+        with self.assertNumQueries(2):
+            get_schema_localization(self.collection, 0, 'en')
+
+    def test_matches_legacy_raw_sql_behavior(self):
+        self._create_itemstr(
+            text='Container EN',
+            language='en',
+            target='container',
+            kind='name',
+        )
+        self._create_itemstr(
+            text='Container ES',
+            language='es',
+            target='container',
+            kind='name',
+        )
+        self._create_itemstr(
+            text='Container ES-MX',
+            language='es',
+            country='mx',
+            target='container',
+            kind='name',
+        )
+        self._create_itemstr(
+            text='Container Desc EN',
+            language='en',
+            target='container',
+            kind='desc',
+        )
+        self._create_itemstr(
+            text='Container Desc ES',
+            language='es',
+            target='container',
+            kind='desc',
+        )
+        self._create_itemstr(
+            text='Item EN',
+            language='en',
+            target='item',
+            kind='name',
+        )
+        self._create_itemstr(
+            text='Item ES',
+            language='es',
+            target='item',
+            kind='name',
+        )
+        self._create_itemstr(
+            text='Item ES-MX',
+            language='es',
+            country='mx',
+            target='item',
+            kind='name',
+        )
+        self._create_itemstr(
+            text='Item Desc EN',
+            language='en',
+            target='item',
+            kind='desc',
+        )
+        self._create_itemstr(
+            text='Item Desc ES',
+            language='es',
+            target='item',
+            kind='desc',
+        )
+
+        for lang in ('en', 'es', 'es-mx', 'fr'):
+            legacy = _legacy_get_schema_localization_raw_sql(self.collection, 0, lang)
+            orm = get_schema_localization(self.collection, 0, lang)
+            self.assertEqual(legacy, orm)


### PR DESCRIPTION
Fixes #7771

The issue was that the existing implementation was using raw SQL and didn't scale well for large databases with larger amounts of collections and disciplines.

Refactored the schema localization loading in schema_localization.py from raw SQL to Django ORM, while preserving the existing fallback behavior and response shape.

The previous implementation used raw SQL with multiple `LEFT JOIN`s to `splocaleitemstr` for each localization fallback tier (`country-specific`, `language-only`, `english`) for both `name` and `desc`.

Here's the old query:
```sql
select container.name, item.name,
       item.format, item.ishidden, item.isuiformatter, item.picklistname,
       item.type, item.isrequired, item.weblinkname,
       coalesce(n1.text, n2.text, n3.text, item.name),
       coalesce(d1.text, d2.text, d3.text, item.name)
from splocalecontainer container
inner join splocalecontaineritem item on item.splocalecontainerid = container.splocalecontainerid
left outer join splocaleitemstr n1 on n1.splocalecontaineritemnameid = splocalecontaineritemid
  and n1.language = %(language)s
  and n1.country = %(country)s
  and (n1.variant is null or n1.variant = '')
left outer join splocaleitemstr n2 on n2.splocalecontaineritemnameid = splocalecontaineritemid
  and n2.language = %(language)s
  and (n2.country is null or n2.country = '')
  and (n2.variant is null or n2.variant = '')
left outer join splocaleitemstr n3 on n3.splocalecontaineritemnameid = splocalecontaineritemid
  and n3.language = 'en'
  and (n3.country is null or n3.country = '')
  and (n3.variant is null or n3.variant = '')
left outer join splocaleitemstr d1 on d1.splocalecontaineritemdescid = splocalecontaineritemid
  and d1.language = %(language)s
  and d1.country = %(country)s
  and (d1.variant is null or d1.variant = '')
left outer join splocaleitemstr d2 on d2.splocalecontaineritemdescid = splocalecontaineritemid
  and d2.language = %(language)s
  and (d2.country is null or d2.country = '')
  and (d2.variant is null or d2.variant = '')
left outer join splocaleitemstr d3 on d3.splocalecontaineritemdescid = splocalecontaineritemid
  and d3.language = 'en'
  and (d3.country is null or d3.country = '')
  and (d3.variant is null or d3.variant = '')
where schematype = %(schematype)s and disciplineid = %(disciplineid)s
order by item.name;
```

This didn't scale well for the following reasons:
- Multiple joins to the same large table (`splocaleitemstr`) per row increased planner and join work.
- Join cardinality could balloon when duplicate locale rows existed for a key.
- For `lang=en`, fallback joins became redundant, language-only and english-fallback predicates are equivalent, causing extra unnecessary work.
- As schema localization rows grow across disciplines, repeated multi-join scans become more expensive.

For `lang=en`, Django now emits two queries at the container-level and at the item-level, each using `COALESCE` with scalar subqueries `LIMIT 1` instead of multiple join aliases.

Container-level
```sql
SELECT
    `splocalecontainer`.`Name`,
    `splocalecontainer`.`Format`,
    `splocalecontainer`.`IsHidden`,
    `splocalecontainer`.`IsUIFormatter`,
    `splocalecontainer`.`PickListName`,
    `splocalecontainer`.`Type`,
    `splocalecontainer`.`Aggregator`,
    `splocalecontainer`.`DefaultUI`,
    COALESCE(
        (
            SELECT U0.`Text`
            FROM `splocaleitemstr` U0
            WHERE
                U0.`SpLocaleContainerNameID` = (`splocalecontainer`.`splocalecontainerid`)
                AND U0.`Language` = 'en'
                AND (U0.`Variant` IS NULL OR U0.`Variant` = '')
                AND (U0.`Country` IS NULL OR U0.`Country` = '')
            ORDER BY U0.`splocaleitemstrid` ASC
            LIMIT 1
        ),
        `splocalecontainer`.`Name`
    ) AS `localized_name`,
    COALESCE(
        (
            SELECT U0.`Text`
            FROM `splocaleitemstr` U0
            WHERE
                U0.`SpLocaleContainerDescID` = (`splocalecontainer`.`splocalecontainerid`)
                AND U0.`Language` = 'en'
                AND (U0.`Variant` IS NULL OR U0.`Variant` = '')
                AND (U0.`Country` IS NULL OR U0.`Country` = '')
            ORDER BY U0.`splocaleitemstrid` ASC
            LIMIT 1
        ),
        `splocalecontainer`.`Name`
    ) AS `localized_desc`
FROM `splocalecontainer`
WHERE
    `splocalecontainer`.`DisciplineID` = 1
    AND `splocalecontainer`.`SchemaType` = 0
ORDER BY `splocalecontainer`.`Name` ASC;
```

Item-level
```sql
SELECT
    `splocalecontaineritem`.`Name`,
    `splocalecontaineritem`.`Format`,
    `splocalecontaineritem`.`IsHidden`,
    `splocalecontaineritem`.`IsUIFormatter`,
    `splocalecontaineritem`.`PickListName`,
    `splocalecontaineritem`.`Type`,
    `splocalecontaineritem`.`IsRequired`,
    `splocalecontaineritem`.`WebLinkName`,
    `splocalecontainer`.`Name` AS `container_name`,
    COALESCE(
        (
            SELECT U0.`Text`
            FROM `splocaleitemstr` U0
            WHERE
                U0.`SpLocaleContainerItemNameID` = (`splocalecontaineritem`.`splocalecontaineritemid`)
                AND U0.`Language` = 'en'
                AND (U0.`Variant` IS NULL OR U0.`Variant` = '')
                AND (U0.`Country` IS NULL OR U0.`Country` = '')
            ORDER BY U0.`splocaleitemstrid` ASC
            LIMIT 1
        ),
        `splocalecontaineritem`.`Name`
    ) AS `localized_name`,
    COALESCE(
        (
            SELECT U0.`Text`
            FROM `splocaleitemstr` U0
            WHERE
                U0.`SpLocaleContainerItemDescID` = (`splocalecontaineritem`.`splocalecontaineritemid`)
                AND U0.`Language` = 'en'
                AND (U0.`Variant` IS NULL OR U0.`Variant` = '')
                AND (U0.`Country` IS NULL OR U0.`Country` = '')
            ORDER BY U0.`splocaleitemstrid` ASC
            LIMIT 1
        ),
        `splocalecontaineritem`.`Name`
    ) AS `localized_desc`
FROM `splocalecontaineritem`
INNER JOIN `splocalecontainer`
    ON (`splocalecontaineritem`.`SpLocaleContainerID` = `splocalecontainer`.`splocalecontainerid`)
WHERE
    `splocalecontainer`.`DisciplineID` = 1
    AND `splocalecontainer`.`SchemaType` = 0
ORDER BY `splocalecontaineritem`.`Name` ASC;
```

This new approach Is better for the following reasons:
- Replaces multi-alias join fanout with deterministic scalar subqueries `LIMIT 1`.
- Avoids row multiplication from duplicate locale rows.
- Keeps fallback behavior identical:
  - `lang-country` → `lang` → `en` → base field/table name.
- Keeps response schema unchanged for frontend consumers.
- Moves logic into maintainable ORM code instead of long raw SQL strings.

Unit tests were added to make sure that the functionality from the old query implementation was preserved in the new more efficient solution.

### Checklist

- [x] Self-review the PR after opening it to make sure the changes look good and
      self-explanatory (or properly documented)
- [x] Add relevant issue to release milestone
- [ ] Add pr to documentation list
- [x] Add automated tests

### Testing instructions

- Open Specify on an existing database and login.
- [x] See that the main Specify page loads fully without any timeout errors.
- [x] Open the network tab in the browser and see that the request to 'http://localhost/context/schema_localization.json?lang=en` was successful.
- Open Specify and login with this large collection and discipline database https://drive.google.com/file/d/1B8PkaV3Se9Gtu3QwNJHPC1xxxLujEAkm/view?usp=sharing
- [x] See that the main Specify page loads fully without any timeout errors.
- [x] Open the network tab in the browser and see that the request to 'http://localhost/context/schema_localization.json?lang=en` was successful.
