### PR TITLE
Ensure paleobotany is in geo disciplines

### DIFF
--- a/specifyweb/frontend/js_src/lib/components/WbPlanView/navigator.ts
+++ b/specifyweb/frontend/js_src/lib/components/WbPlanView/navigator.ts
@@ -46,12 +46,12 @@ import {
 import { getMaxToManyIndex, isCircularRelationship } from './modelHelpers';
 import type { NavigatorSpec } from './navigatorSpecs';
 
-const geoPaleoDisciplines = [
+const geoPaleoDisciplines: readonly string[] = [
   'geology',
   'invertpaleo',
   'vertpaleo',
   'paleobotany',
-] as const;
+];
 
 type NavigationCallbackPayload = {
   readonly table: SpecifyTable;


### PR DESCRIPTION
Fixes #7792

Ensure paleobotany is in geo disciplines.  There was an issue where the `geoPaleoDisciplines` was created in two places, where one didn't include paleobotany.  I created a single immutable instance of `geoPaleoDisciplines` at the top of the file and removed the other two defintions.

### Checklist

- [x] Self-review the PR after opening it to make sure the changes look good and
      self-explanatory (or properly documented)
- [x] Add relevant issue to release milestone
- [ ] Add pr to documentation list

### Testing instructions

- Go to any DB with a paleobotany discipline
- Query on CO base table
- [x] See Age does appear as an available field.

Working on test-panel https://blankdbsetup2elizabeth20260303-issue-7792.test.specifysystems.org/specify/query/new/collectionobject/
