### PR TITLE
Fix embedded record set multi-select

### DIFF
--- a/specifyweb/frontend/js_src/lib/components/FormSliders/RecordSelector.tsx
+++ b/specifyweb/frontend/js_src/lib/components/FormSliders/RecordSelector.tsx
@@ -84,7 +84,9 @@ export function useRecordSelector<SCHEMA extends AnySchema>({
     [index]
   );
 
-  const isToOne = !relationshipIsToMany(field) || shouldBeToOne(field);
+  const isToOne = field === undefined 
+    ? false
+    : !relationshipIsToMany(field) || shouldBeToOne(field);
 
   const handleResourcesSelected = React.useMemo(
     () =>


### PR DESCRIPTION
Fixes #7793

Handle undefined field for isToOne.  This fixed the issue of the embedded record set multi-select not working correctly.

### Checklist

- [x] Self-review the PR after opening it to make sure the changes look good and
      self-explanatory (or properly documented)
- [x] Add relevant issue to release milestone
- [ ] Add pr to documentation list

### Testing instructions

- Create a new record set on any table.
- Press the add button in the top left.
- Select query builder.
- Add any field.
- Press Query.
- Try to select multiple results .
- [x] See Select button is enabled and can be pressed.

Working on test-panel https://blankdbsetup2elizabeth20260302-issue-7793.test.specifysystems.org/specify/view/collectingevent/1/?recordsetid=7
