### PR TITLE
Add remote prefs to setup tool

### DIFF
--- a/specifyweb/backend/setup_tool/app_resource_defaults.py
+++ b/specifyweb/backend/setup_tool/app_resource_defaults.py
@@ -17,7 +17,7 @@ auditing.audit_field_updates=true
 
 def create_app_resource_defaults() -> None:
     """Adds initial app resource files to the database."""
-    create_global_prefs()
+    # create_global_prefs() # Replacing globabl prefs with remote to avoid user confusion
     create_remote_prefs()
 
 def create_global_prefs(user: Optional[Specifyuser] = None) -> None:


### PR DESCRIPTION
Fixes #7800

Create a `create_remote_prefs` function and add it to the setup tool process.  Also, don't create a "Globabl Preferences" anymore, it's not used in Specify 7 anymore and creates confusion with "Remote Preferences".  The desired setup is to just have "Remote Preferences" setup as default for a new database.  We also need to make sure that the new app resource is title 'preferences' so that it gets picked up and applied.

The default Remote Preferences is populated with:
```
ui.formatting.scrdateformat=yyyy-MM-dd
auditing.do_audits=true
auditing.audit_field_updates=true
```


### Checklist

- [ ] Self-review the PR after opening it to make sure the changes look good and
      self-explanatory (or properly documented)
- [x] Add relevant issue to release milestone
- [ ] Add pr to documentation list

### Testing instructions

- Open Specify on a new database and go through the setup process.
- After the setup processes is completed, login and go to the app resources page.
- [x] See at the top that their is a "Remote Preferences" app resource.
- [x] See that no "Global Preferences" app resource was created. 
- Click on the "Remote Preferences" app resource.
- [x] Verify that the title is "preferences" exactly.
- [x] Verify that the contents of the app resources is not blank.  It should have three lines of default prefs.
- Go to the forms and create some collection object records for testing.
- Go to the query builder, with collection objects as the base table, select the 'Cataloged Date' field and run the query.
- [x] In the query results, the date format should be 'YYYY-MM-DD', like it's set in the remote preferences. 


<img width="1131" height="833" alt="image" src="https://github.com/user-attachments/assets/dea0b066-7eae-4bdf-9efb-5d753572c80c" />


<img width="1296" height="642" alt="image" src="https://github.com/user-attachments/assets/d34a07c8-2dfe-41d2-8edd-65c36f850933" />
