### PR TITLE
Apply date formatting to temporal fields in object formatters

### DIFF
--- a/specifyweb/backend/stored_queries/format.py
+++ b/specifyweb/backend/stored_queries/format.py
@@ -432,6 +432,8 @@ class ObjectFormatter:
 
     def _fieldformat(self, table: Table, specify_field: Field,
                      field: InstrumentedAttribute | Extract):
+        if self.format_types and specify_field.is_temporal():
+            return self._dateformat(specify_field, field)
         
         if self.format_agent_type and specify_field is Agent_model.get_field("agenttype"):
             # cases = [(field == _id, name) for (_id, name) in enumerate(agent_types)]


### PR DESCRIPTION
Fixes #7805

Fix formatted query dates showing timestamps, by applying date formatting to temporal fields in object formatters.

### Checklist

- [x] Self-review the PR after opening it to make sure the changes look good and
      self-explanatory (or properly documented)
- [x] Add relevant issue to release milestone
- [ ] Add pr to documentation list

### Testing instructions

- Go to any new DB
- Create a new table format on any table with a date field (i.e. CO)
- Add a date field and save
- Query with the same base table as the table format
- Select formatted
- [x] See that the dates are formatted correctly in the query results
