### PR TITLE
Fix lithostrat/tectonic tree def assignment in setup tool

### DIFF
--- a/specifyweb/backend/setup_tool/setup_tasks.py
+++ b/specifyweb/backend/setup_tool/setup_tasks.py
@@ -80,9 +80,17 @@ DEFAULT_TREE = {
     'ranks': {}
 }
 
+
+def _required_treedef_id(tree_result: dict, tree_name: str) -> int:
+    treedef_id = tree_result.get('treedef_id')
+    if treedef_id is None:
+        raise ValueError(f'{tree_name} tree creation did not return treedef_id')
+    return treedef_id
+
 @app.task(bind=True)
 def setup_database_task(self, data: dict):
     """Execute all database setup steps in order."""
+    from specifyweb.specify.models import Discipline
     self.update_state(state='STARTED', meta={'progress': api.get_setup_resource_progress()})
     def update_progress():
         self.update_state(state='STARTED', meta={'progress': api.get_setup_resource_progress()})
@@ -114,12 +122,12 @@ def setup_database_task(self, data: dict):
             default_chronostrat_tree = default_tree.copy()
             default_chronostrat_tree['fullnamedirection'] = -1
             chronostrat_result = api.create_geologictimeperiod_tree(default_chronostrat_tree)
-            chronostrat_treedef_id = chronostrat_result.get('treedef_id')
+            chronostrat_treedef_id = _required_treedef_id(chronostrat_result, 'Geologictimeperiod')
 
             logger.info('Creating geography tree')
             uses_global_geography_tree = data['institution'].get('issinglegeographytree', False)
             geography_result = api.create_geography_tree(data['geographytreedef'].copy(), global_tree=uses_global_geography_tree)
-            geography_treedef_id = geography_result.get('treedef_id')
+            geography_treedef_id = _required_treedef_id(geography_result, 'Geography')
 
             logger.info('Creating discipline')
             discipline_result = api.create_discipline(data['discipline'])
@@ -127,18 +135,30 @@ def setup_database_task(self, data: dict):
             default_tree['discipline_id'] = discipline_id
             update_progress()
 
+            lithostrat_treedef_id = None
+            tectonicunit_treedef_id = None
             if is_paleo_geo:
                 logger.info('Creating Lithostratigraphy tree')
-                api.create_lithostrat_tree(default_tree.copy())
+                lithostrat_result = api.create_lithostrat_tree(default_tree.copy())
+                lithostrat_treedef_id = _required_treedef_id(lithostrat_result, 'Lithostrat')
 
                 logger.info('Creating Tectonic Unit tree')
-                api.create_tectonicunit_tree(default_tree.copy())
+                tectonicunit_result = api.create_tectonicunit_tree(default_tree.copy())
+                tectonicunit_treedef_id = _required_treedef_id(tectonicunit_result, 'Tectonicunit')
 
             logger.info('Creating taxon tree')
             if data['taxontreedef'].get('discipline_id') is None:
                 data['taxontreedef']['discipline_id'] = discipline_id
             taxon_result = api.create_taxon_tree(data['taxontreedef'].copy())
-            taxon_treedef_id = taxon_result.get('treedef_id')
+            taxon_treedef_id = _required_treedef_id(taxon_result, 'Taxon')
+
+            Discipline.objects.filter(id=discipline_id).update(
+                geographytreedef_id=geography_treedef_id,
+                taxontreedef_id=taxon_treedef_id,
+                geologictimeperiodtreedef_id=chronostrat_treedef_id,
+                lithostrattreedef_id=lithostrat_treedef_id,
+                tectonicunittreedef_id=tectonicunit_treedef_id,
+            )
             update_progress()
 
             logger.info('Creating collection')
@@ -211,7 +231,7 @@ def create_discipline_and_trees_task(data: dict):
             default_chronostrat_tree = default_tree.copy()
             default_chronostrat_tree['fullnamedirection'] = -1
             chronostrat_result = api.create_geologictimeperiod_tree(default_chronostrat_tree)
-            chronostrat_treedef_id = chronostrat_result.get('treedef_id')
+            chronostrat_treedef_id = _required_treedef_id(chronostrat_result, 'Geologictimeperiod')
             data['discipline']['geologictimeperiodtreedef_id'] = chronostrat_treedef_id
 
             logger.info('Creating discipline')
@@ -228,22 +248,22 @@ def create_discipline_and_trees_task(data: dict):
 
             logger.info('Creating geography tree')
             geography_result = api.create_geography_tree(data['geographytreedef'].copy(), global_tree=False)
-            geography_treedef_id = geography_result.get('treedef_id')
+            geography_treedef_id = _required_treedef_id(geography_result, 'Geography')
 
             logger.info('Creating taxon tree')
             taxon_result = api.create_taxon_tree(data['taxontreedef'].copy())
-            taxon_treedef_id = taxon_result.get('treedef_id')
+            taxon_treedef_id = _required_treedef_id(taxon_result, 'Taxon')
 
             lithostrat_id = None
             tectonicunit_id = None
             if is_paleo_geo:
                 logger.info('Creating Lithostratigraphy tree')
                 lithostrat_result = api.create_lithostrat_tree(default_tree.copy())
-                lithostrat_id = lithostrat_result.get('lithostrattreedef_id')
+                lithostrat_id = _required_treedef_id(lithostrat_result, 'Lithostrat')
 
                 logger.info('Creating Tectonic Unit tree')
                 tectonicunit_result = api.create_tectonicunit_tree(default_tree.copy())
-                tectonicunit_id = tectonicunit_result.get('tectonicunittreedef_id')
+                tectonicunit_id = _required_treedef_id(tectonicunit_result, 'Tectonicunit')
 
             Discipline.objects.filter(id=discipline_id).update(
                 geographytreedef_id=geography_treedef_id,


### PR DESCRIPTION
Fixes #7804

In setup-tool tree creation, we were assuming tree API responses included type-specific keys like lithostrattreedef_id and tectonicunittreedef_id.  The API actually returns a generic treedef_id for all tree types. That mismatch caused Lithostrat/Tectonic discipline links to be saved as None in some setup flows, which then broke scoped querying in new DBs.

Fixed this issue by standardizing and hardening tree ID handling in setup tasks.  So, making sure we use treedef_id consistently for all tree creation responses.  Made a helper function to ensure this for each tree type.

### Checklist

- [x] Self-review the PR after opening it to make sure the changes look good and
      self-explanatory (or properly documented)
- [x] Add relevant issue to release milestone
- [ ] Add pr to documentation list

### Testing instructions

- Create a new DB with a paleo/geo discipline
- Verify there are records in the lithostrat tree, or create some if needed
- Go to queries
- Select lithostrat as base table
- Add any rank -> name
- [x] See that records appear in the query results.
- [x] Repeat for the tectonic unit table.
