### PR TITLE
Fix resolved loans blocking preparation count updates

### DIFF
--- a/specifyweb/frontend/js_src/lib/components/DataModel/businessRuleDefs.ts
+++ b/specifyweb/frontend/js_src/lib/components/DataModel/businessRuleDefs.ts
@@ -751,11 +751,15 @@ export const businessRuleDefs: MappedBusinessRuleDefs = {
       countAmt: async (prep): Promise<BusinessRuleResult | undefined> => {
         const loanPrep = await prep.rgetCollection('loanPreparations');
         const totalPrep = prep.get('countAmt') ?? 0;
-        let totalPrepLoaned = 0;
+        let totalPrepOnLoan = 0;
 
         loanPrep.models.forEach((loan) => {
           const quantity = loan.get('quantity') ?? 0;
-          totalPrepLoaned += quantity;
+          const quantityResolved = loan.get('quantityResolved') ?? 0;
+          const unresolvedQuantity = loan.get('isResolved')
+            ? 0
+            : Math.max(quantity - quantityResolved, 0);
+          totalPrepOnLoan += unresolvedQuantity;
         });
 
         if (totalPrep < 0) {
@@ -765,7 +769,7 @@ export const businessRuleDefs: MappedBusinessRuleDefs = {
             [resourcesText.preparationIsNegative()],
             PREPARATION_NEGATIVE_KEY
           );
-        } else if (totalPrep < totalPrepLoaned) {
+        } else if (totalPrep < totalPrepOnLoan) {
           setSaveBlockers(
             prep,
             prep.specifyTable.field.countAmt,


### PR DESCRIPTION
Fixes #7625

The preparation count validator was counting historical resolved loans as if they were still active. This change updates the front-end check to only block decreases when there is unresolved quantity still on loan.

### Checklist

- [ ] Self-review the PR after opening it to make sure the changes look good and
      self-explanatory (or properly documented)
- [x] Add relevant issue to release milestone
- [ ] Add pr to documentation list

### Testing instructions

- Create a preparation with count `3`.
- Add that preparation to a loan with quantity `3`.
- Return and resolve all `3` items on the loan.
- Open the preparation again.
- Change the preparation count from `3` to `1`.
- Save the record.
- [ ] Confirm the save succeeds and the "The preparation is used in a loan." error does not appear.
- [ ] Reopen the same preparation and confirm the new count is still `1`.
