### PR TITLE
Feat: Prevent user with non UTF-8 encoding to create geo tree

### DIFF
--- a/specifyweb/backend/trees/urls.py
+++ b/specifyweb/backend/trees/urls.py
@@ -26,4 +26,5 @@ urlpatterns = [
     re_path(r'^create_default_tree/status/(?P<task_id>[^/]+)/$', views.default_tree_upload_status),
     re_path(r'^create_default_tree/abort/(?P<task_id>[^/]+)/$', views.abort_default_tree_creation),
     path('default_tree_mapping/', views.default_tree_mapping),
+    path('db_encoding/', views.get_db_encoding),
 ]

--- a/specifyweb/backend/trees/views.py
+++ b/specifyweb/backend/trees/views.py
@@ -928,3 +928,17 @@ def default_tree_mapping(request) -> http.HttpResponse:
         return http.JsonResponse({'error': f'Default tree mapping is invalid: {e}'}, status=400)
 
     return http.JsonResponse(tree_cfg)
+
+@login_maybe_required
+def get_db_encoding(request):
+    cursor = connection.cursor()
+
+    cursor.execute("SELECT @@character_set_database;")
+    row = cursor.fetchone()
+
+    encoding = row[0] if row else None
+
+    return http.HttpResponse(
+        json.dumps({"encoding": encoding}),
+        content_type='application/json'
+    )

--- a/specifyweb/backend/trees/views.py
+++ b/specifyweb/backend/trees/views.py
@@ -929,7 +929,6 @@ def default_tree_mapping(request) -> http.HttpResponse:
 
     return http.JsonResponse(tree_cfg)
 
-@login_maybe_required
 def get_db_encoding(request):
     cursor = connection.cursor()
 

--- a/specifyweb/frontend/js_src/lib/components/TreeView/CreateTree.tsx
+++ b/specifyweb/frontend/js_src/lib/components/TreeView/CreateTree.tsx
@@ -31,6 +31,7 @@ import type { TreeInformation } from '../InitialContext/treeRanks';
 import { userInformation } from '../InitialContext/userInformation';
 import { Dialog } from '../Molecules/Dialog';
 import { defaultTreeDefs } from './defaults';
+import { Link } from '../Atoms/Link';
 
 export type TaxonFileDefaultDefinition = {
   readonly discipline: string;
@@ -459,24 +460,71 @@ export function PopulatedTreeList({
         ? treeOptions.filter((r) => r.discipline === discipline)
         : treeOptions;
 
+  const fetchDatabaseEncoding = async () =>
+      ajax<{ readonly encoding: string }>(`/trees/db_encoding/`, {
+        headers: { Accept: 'application/json' },
+        method: 'GET',
+      }).then(({ data }) => data.encoding);
+
+  const [encoding, setEncoding] = React.useState<string | null>(null)
+
+  React.useEffect(() => {
+    fetchDatabaseEncoding().then((encoding) => {
+      setEncoding(encoding)
+    })
+  }, [])
+
+  const isUTF8 =
+    encoding !== null &&
+    ['utf8', 'utf8mb4'].includes(encoding.toLowerCase())
+
   return (
     <Ul className="flex flex-col gap-2">
       <H2>{treeText.populatedTrees()}</H2>
       {displayedOptions === undefined
         ? undefined
-        : displayedOptions.map((resource, index) => (
-            <li key={index}>
-              <Button.LikeLink onClick={(): void => handleClick(resource)}>
-                {localized(resource.title)}
-              </Button.LikeLink>
-              <div className="text-xs text-gray-500">
-                {resource.description}
-              </div>
-              <div className="text-xs text-gray-400 italic">
-                {`${treeText.source()}: ${resource.src}`}
-              </div>
-            </li>
-          ))}
+        : displayedOptions.map((resource, index) => 
+          {
+            const isBlockedGeoTree =
+              resource.title === 'Geology (Minerals)' && !isUTF8
+
+            const encodingFormat = typeof encoding === 'string' ? encoding : ''
+
+            if (isBlockedGeoTree) {
+              return (
+                <li key={index}>
+                  <Button.LikeLink onClick={undefined}>
+                    {localized(resource.title)}
+                  </Button.LikeLink>
+
+                  <div className="text-xs text-gray-500 break-words">
+                    {treeText.utf8EncodingWarning({ encoding: encodingFormat})}
+                  </div>
+
+                  <Link.NewTab href="https://discourse.specifysoftware.org/t/convert-a-specify-database-to-utf-8/3467">
+                    {treeText.resolveEncoding()}
+                  </Link.NewTab>
+                </li>
+              )
+            }
+
+            return (
+              <li key={index}>
+                <Button.LikeLink onClick={(): void => handleClick(resource)}>
+                  {localized(resource.title)}
+                </Button.LikeLink>
+
+                <div className="text-xs text-gray-500">
+                  {resource.description}
+                </div>
+
+                <div className="text-xs text-gray-400 italic">
+                  {`${treeText.source()}: ${resource.src}`}
+                </div>
+              </li>
+            )
+          }
+          )}
     </Ul>
   );
 }

--- a/specifyweb/frontend/js_src/lib/components/TreeView/CreateTree.tsx
+++ b/specifyweb/frontend/js_src/lib/components/TreeView/CreateTree.tsx
@@ -15,6 +15,7 @@ import { Progress } from '../Atoms';
 import { Button } from '../Atoms/Button';
 import { className } from '../Atoms/className';
 import { icons } from '../Atoms/Icons';
+import { Link } from '../Atoms/Link';
 import { LoadingContext } from '../Core/Contexts';
 import type {
   AnySchema,
@@ -31,7 +32,6 @@ import type { TreeInformation } from '../InitialContext/treeRanks';
 import { userInformation } from '../InitialContext/userInformation';
 import { Dialog } from '../Molecules/Dialog';
 import { defaultTreeDefs } from './defaults';
-import { Link } from '../Atoms/Link';
 
 export type TaxonFileDefaultDefinition = {
   readonly discipline: string;

--- a/specifyweb/frontend/js_src/lib/localization/tree.ts
+++ b/specifyweb/frontend/js_src/lib/localization/tree.ts
@@ -771,4 +771,11 @@ export const treeText = createDictionary({
     'uk-ua':
       'Якщо це ввімкнено, користувачі можуть додавати дочірні елементи до синонімізованих батьківських елементів та синонімізувати вузол з дочірніми елементами.',
   },
+  utf8EncodingWarning: {
+    'en-us':
+      'This tree data cannot be imported in your database because it contains UTF-8 characters and this database uses {encoding:string}',
+  },
+  resolveEncoding: {
+    'en-us': 'How to resolve:',
+  },
 } as const);


### PR DESCRIPTION
Fuxes #7842


### Checklist

- [ ] Self-review the PR after opening it to make sure the changes look good and
      self-explanatory (or properly documented)
- [ ] Add relevant issue to release milestone
- [ ] Add pr to documentation list


### Testing instructions


- Open the tree viewer with a db that do not use UTF-8 encoding 
- Click on create new tree (+) 
- [ ] Verify that the Geo tree cannot be clicked and that the warning "'This tree data cannot be imported in your database because it contains UTF-8 characters and this database uses {encoding:string}'" is displayed as well as a link to our documentation on how to fix it. (Doc to be created) 
