### PR TITLE
Fix: Allow non admin to have access to discipline resource

### DIFF
--- a/specifyweb/backend/delete_blockers/views.py
+++ b/specifyweb/backend/delete_blockers/views.py
@@ -22,9 +22,6 @@ def delete_blockers(request, model, id):
     using = router.db_for_write(obj.__class__, instance=obj)
 
     if obj._meta.model_name == 'discipline': # Special case for discipline
-        # commented out to allow non admin to access discipline resource
-        # if not request.specify_user.is_admin():
-        #     return http.HttpResponseForbidden('Specifyuser must be an institution admin')
         guard_blockers = get_discipline_delete_guard_blockers(obj)
         if guard_blockers:
             result = guard_blockers


### PR DESCRIPTION
Fixes #7848


### Checklist

- [ ] Self-review the PR after opening it to make sure the changes look good and
      self-explanatory (or properly documented)
- [ ] Add relevant issue to release milestone
- [ ] Add pr to documentation list


### Testing instructions

- Log into a db as a non admin user 
- Verify that you can open a discipline resource
