### PR TITLE
Upgrade Django from 4.2.27 to 4.2.29

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ wheel
 kombu==5.5.2
 redis==6.4.0
 celery==5.5.1
-Django==4.2.27
+Django==4.2.29
 mysqlclient==2.1.1
 SQLAlchemy==1.4.54
 sqlalchemy2-stubs


### PR DESCRIPTION
Fixes #7885
Fixes https://github.com/specify/specify7/security/dependabot/159
Fixes https://github.com/specify/specify7/security/dependabot/160
Fixes https://github.com/specify/specify7/security/dependabot/161
Fixes https://github.com/specify/specify7/security/dependabot/191

Minor version upgrade for Django from 4.2.27 to 4.2.29 in order to fix an SQL injections issue.  This is just a minor change, no major changes in the Django changelog for the release, so no issue should arise.

Not sure why dependabot had so many duplicates of the same issue?

### Checklist

- [ ] Self-review the PR after opening it to make sure the changes look good and
      self-explanatory (or properly documented)
- [x] Add relevant issue to release milestone
- [ ] Add pr to documentation list


### Testing instructions
- [x] Startup Specify successfully without errors.
- [x] Light general checking of Specify features, nothing should be broken from this update.

