### PR TITLE
Upgrade flatted version from 3.1.1 to 3.4.2

### DIFF
--- a/specifyweb/frontend/js_src/package-lock.json
+++ b/specifyweb/frontend/js_src/package-lock.json
@@ -9120,9 +9120,10 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.1.1",
-      "dev": true,
-      "license": "ISC"
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
+      "dev": true
     },
     "node_modules/for-each": {
       "version": "0.3.3",
@@ -23611,7 +23612,9 @@
       }
     },
     "flatted": {
-      "version": "3.1.1",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
       "dev": true
     },
     "for-each": {


### PR DESCRIPTION
Fixes #7889
Fixes https://github.com/specify/specify7/security/dependabot/202

Upgrade dependent flatted version from 3.1.1 to 3.4.2 in the package-lock.json file.  This will fix the packages that are dependent on the flatted package.


### Checklist

- [ ] Self-review the PR after opening it to make sure the changes look good and
      self-explanatory (or properly documented)
- [x] Add relevant issue to release milestone
- [ ] Add pr to documentation list


### Testing instructions

- [x] Light general testing.  The upgraded module affects handling json data, so sampling random pages to make sure that they load without errors is sufficient.

