### PR TITLE
Upgrade lodash version from 4.17.21 to 4.18.1

### DIFF
--- a/specifyweb/frontend/js_src/package-lock.json
+++ b/specifyweb/frontend/js_src/package-lock.json
@@ -11957,9 +11957,10 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.21",
-      "dev": true,
-      "license": "MIT"
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+      "dev": true
     },
     "node_modules/lodash.debounce": {
       "version": "4.0.8",
@@ -25658,7 +25659,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.21",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "dev": true
     },
     "lodash.debounce": {


### PR DESCRIPTION
Fixes #7891
Fixes https://github.com/specify/specify7/security/dependabot/214

Upgrade lodash version from 4.17.21 to 4.18.1.  This solve the code injection vulnerability via _.template imports key names.  Packages dependent on lodash will no longer have this vulnerability issue.

### Checklist

- [ ] Self-review the PR after opening it to make sure the changes look good and
      self-explanatory (or properly documented)
- [x] Add relevant issue to release milestone
- [ ] Add pr to documentation list


### Testing instructions

- [ ] Light general testing.  This upgraded package is a helper function to many operations and functionalities in our javascript and typescript codebase.
