### PR TITLE
Upgrade fast-xml-parser version from 4.2.2 to 5.5.7

### DIFF
--- a/specifyweb/frontend/js_src/lib/localization/schema-localization/xml.ts
+++ b/specifyweb/frontend/js_src/lib/localization/schema-localization/xml.ts
@@ -1,7 +1,3 @@
-import type {
-  X2jOptionsOptional,
-  XmlBuilderOptionsOptional,
-} from 'fast-xml-parser';
 import { XMLBuilder, XMLParser } from 'fast-xml-parser';
 
 import { postProcessXml } from '../../components/Syncer/xmlToString';
@@ -79,14 +75,11 @@ export const toUnparsedNode = (node: ParsedNode): ParsedDom[number] =>
 /**
  * It's important to use the same setting for parser and builder
  */
-const parserBuilderSettings: Pick<
-  XmlBuilderOptionsOptional,
-  keyof X2jOptionsOptional & keyof XmlBuilderOptionsOptional
-> = {
+const parserBuilderSettings = {
   ignoreAttributes: false,
   preserveOrder: true,
   commentPropName: '#comment',
-};
+} as const;
 
 /**
  * XML parser to use when running in Node.js

--- a/specifyweb/frontend/js_src/lib/localization/schema-localization/xml.ts
+++ b/specifyweb/frontend/js_src/lib/localization/schema-localization/xml.ts
@@ -100,5 +100,5 @@ export function nodeUnparseXml(dom: ParsedDom): string {
     format: true,
     suppressUnpairedNode: true,
   });
-  return postProcessXml(parser.build(dom) as string);
+  return postProcessXml(parser.build(dom) );
 }

--- a/specifyweb/frontend/js_src/package-lock.json
+++ b/specifyweb/frontend/js_src/package-lock.json
@@ -83,7 +83,7 @@
         "core-js": "^3.23.4",
         "css-loader": "^6.10.0",
         "eslint": "^8.31.0",
-        "fast-xml-parser": "^4.2.2",
+        "fast-xml-parser": "^5.5.7",
         "gettext-parser": "^6.0.0",
         "jest": "^28.1.3",
         "jest-environment-jsdom": "^28.1.3",
@@ -9027,23 +9027,36 @@
       ],
       "license": "BSD-3-Clause"
     },
-    "node_modules/fast-xml-parser": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.2.2.tgz",
-      "integrity": "sha512-DLzIPtQqmvmdq3VUKR7T6omPK/VCRNqgFlGtbESfyhcH2R4I8EzK1/K6E8PkRCK2EabWrUHK32NjYRbEFnnz0Q==",
+    "node_modules/fast-xml-builder": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.4.tgz",
+      "integrity": "sha512-f2jhpN4Eccy0/Uz9csxh3Nu6q4ErKxf0XIsasomfOihuSUa3/xw6w8dnOtCDgEItQFJG8KyXPzQXzcODDrrbOg==",
       "dev": true,
       "funding": [
-        {
-          "type": "paypal",
-          "url": "https://paypal.me/naturalintelligence"
-        },
         {
           "type": "github",
           "url": "https://github.com/sponsors/NaturalIntelligence"
         }
       ],
       "dependencies": {
-        "strnum": "^1.0.5"
+        "path-expression-matcher": "^1.1.3"
+      }
+    },
+    "node_modules/fast-xml-parser": {
+      "version": "5.5.7",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.5.7.tgz",
+      "integrity": "sha512-LteOsISQ2GEiDHZch6L9hB0+MLoYVLToR7xotrzU0opCICBkxOPgHAy1HxAvtxfJNXDJpgAsQN30mkrfpO2Prg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "dependencies": {
+        "fast-xml-builder": "^1.1.4",
+        "path-expression-matcher": "^1.1.3",
+        "strnum": "^2.2.0"
       },
       "bin": {
         "fxparser": "src/cli/cli.js"
@@ -12893,6 +12906,21 @@
         "node": ">=8"
       }
     },
+    "node_modules/path-expression-matcher": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.1.3.tgz",
+      "integrity": "sha512-qdVgY8KXmVdJZRSS1JdEPOKPdTiEK/pi0RkcT2sw1RhXxohdujUlJFPuS1TSkevZ9vzd3ZlL7ULl1MHGTApKzQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/path-is-absolute": {
       "version": "1.0.1",
       "dev": true,
@@ -15482,10 +15510,16 @@
       }
     },
     "node_modules/strnum": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.0.5.tgz",
-      "integrity": "sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA==",
-      "dev": true
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.2.1.tgz",
+      "integrity": "sha512-BwRvNd5/QoAtyW1na1y1LsJGQNvRlkde6Q/ipqqEaivoMdV+B1OMOTVdwR+N/cwVUcIt9PYyHmV8HyexCZSupg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ]
     },
     "node_modules/style-loader": {
       "version": "3.3.4",
@@ -23549,13 +23583,24 @@
       "integrity": "sha512-Atfo14OibSv5wAp4VWNsFYE1AchQRTv9cBGWET4pZWHzYshFSS9NQI6I57rdKn9croWVMbYFbLhJ+yJvmZIIHw==",
       "dev": true
     },
-    "fast-xml-parser": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.2.2.tgz",
-      "integrity": "sha512-DLzIPtQqmvmdq3VUKR7T6omPK/VCRNqgFlGtbESfyhcH2R4I8EzK1/K6E8PkRCK2EabWrUHK32NjYRbEFnnz0Q==",
+    "fast-xml-builder": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.4.tgz",
+      "integrity": "sha512-f2jhpN4Eccy0/Uz9csxh3Nu6q4ErKxf0XIsasomfOihuSUa3/xw6w8dnOtCDgEItQFJG8KyXPzQXzcODDrrbOg==",
       "dev": true,
       "requires": {
-        "strnum": "^1.0.5"
+        "path-expression-matcher": "^1.1.3"
+      }
+    },
+    "fast-xml-parser": {
+      "version": "5.5.7",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.5.7.tgz",
+      "integrity": "sha512-LteOsISQ2GEiDHZch6L9hB0+MLoYVLToR7xotrzU0opCICBkxOPgHAy1HxAvtxfJNXDJpgAsQN30mkrfpO2Prg==",
+      "dev": true,
+      "requires": {
+        "fast-xml-builder": "^1.1.4",
+        "path-expression-matcher": "^1.1.3",
+        "strnum": "^2.2.0"
       }
     },
     "fastest-levenshtein": {
@@ -26314,6 +26359,12 @@
       "version": "4.0.0",
       "dev": true
     },
+    "path-expression-matcher": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.1.3.tgz",
+      "integrity": "sha512-qdVgY8KXmVdJZRSS1JdEPOKPdTiEK/pi0RkcT2sw1RhXxohdujUlJFPuS1TSkevZ9vzd3ZlL7ULl1MHGTApKzQ==",
+      "dev": true
+    },
     "path-is-absolute": {
       "version": "1.0.1",
       "dev": true
@@ -27952,9 +28003,9 @@
       "dev": true
     },
     "strnum": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.0.5.tgz",
-      "integrity": "sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.2.1.tgz",
+      "integrity": "sha512-BwRvNd5/QoAtyW1na1y1LsJGQNvRlkde6Q/ipqqEaivoMdV+B1OMOTVdwR+N/cwVUcIt9PYyHmV8HyexCZSupg==",
       "dev": true
     },
     "style-loader": {

--- a/specifyweb/frontend/js_src/package.json
+++ b/specifyweb/frontend/js_src/package.json
@@ -103,7 +103,7 @@
     "core-js": "^3.23.4",
     "css-loader": "^6.10.0",
     "eslint": "^8.31.0",
-    "fast-xml-parser": "^4.2.2",
+    "fast-xml-parser": "^5.5.7",
     "gettext-parser": "^6.0.0",
     "jest": "^28.1.3",
     "jest-environment-jsdom": "^28.1.3",


### PR DESCRIPTION
Fixes #7896
Fixes https://github.com/specify/specify7/security/dependabot/203
Fixes https://github.com/specify/specify7/security/dependabot/184

Upgrade fast-xml-parser version from 4.2.2 to 5.5.7.  This upgrade solves the dependabot issue of numeric entity expansion bypassing all entity expansion limits.  This is a major version upgrade, so we need to confirm nothing is broken when testing. Also needed to fix an issue with X2jOptionsOptional and XmlBuilderOptionsOptional in the xml.ts file in order to accommodate the version upgrade.

### Checklist

- [x] Self-review the PR after opening it to make sure the changes look good and
      self-explanatory (or properly documented)
- [x] Add relevant issue to release milestone
- [ ] Add pr to documentation list


### Testing instructions

- [x] Light general testing.  This package upgrade effects code the deals with xml.  Try testing out components that user xml, like forms and user preferences for example.
