### PR TITLE
Fix: Remove duplicate no prep warning

### DIFF
--- a/specifyweb/frontend/js_src/lib/components/Interactions/InteractionDialog.tsx
+++ b/specifyweb/frontend/js_src/lib/components/Interactions/InteractionDialog.tsx
@@ -574,33 +574,20 @@ export function InteractionDialog({
             {state.type === 'MissingState' && (
               <div className="mt-2 space-y-2">
                 {state.missing.length > 0 && (
-                  <div>
+                  <>
                     <H3>{interactionsText.preparationsNotFoundFor()}</H3>
                     {state.missing.map((problem, index) => (
                       <p key={index}>{problem}</p>
                     ))}
-                  </div>
+                  </>
                 )}
-                {state.type === 'MissingState' && (
+
+                {state.unavailableBis.length > 0 && (
                   <>
-                    {state.missing.length > 0 && (
-                      <>
-                        <H3>{interactionsText.preparationsNotFoundFor()}</H3>
-                        {state.missing.map((problem, index) => (
-                          <p key={index}>{problem}</p>
-                        ))}
-                      </>
-                    )}
-                    {state.unavailableBis.length > 0 && (
-                      <>
-                        <H3>
-                          {interactionsText.preparationsNotAvailableFor()}
-                        </H3>
-                        {state.unavailableBis.map((problem, index) => (
-                          <p key={index}>{problem}</p>
-                        ))}
-                      </>
-                    )}
+                    <H3>{interactionsText.preparationsNotAvailableFor()}</H3>
+                    {state.unavailableBis.map((problem, index) => (
+                      <p key={index}>{problem}</p>
+                    ))}
                   </>
                 )}
               </div>


### PR DESCRIPTION
Fixes #7900

### Checklist

- [ ] Self-review the PR after opening it to make sure the changes look good and
      self-explanatory (or properly documented)
- [ ] Add relevant issue to release milestone


### Testing instructions

- Go to interactions
- Select any interaction that opens up the dialog (i.e. loan, gift, disposal, etc.)
- Enter a record that has no preparations
- [ ] Verify warning appears only once
