### PR TITLE
fix(queries): restrict simple search

### DIFF
--- a/specifyweb/backend/express_search/related.py
+++ b/specifyweb/backend/express_search/related.py
@@ -181,7 +181,7 @@ class RelatedSearch(metaclass=RelatedSearchMeta):
             user,
             self.root.tableId,
             queryfields,
-            props=BuildQueryProps(implicit_or=True),
+            props=BuildQueryProps(implicit_or=False),
         )
 
         if self.distinct:

--- a/specifyweb/backend/express_search/tests.py
+++ b/specifyweb/backend/express_search/tests.py
@@ -1,16 +1,90 @@
 """
-This file demonstrates writing tests using the unittest module. These will pass
-when you run "manage.py test".
+Tests for express search, focusing on synonymy-related searches.
 
-Replace this with more appropriate tests for your application.
+These tests verify the fix for issue #6783: Simple Search Returns All
+Synonymized Taxon Records.
+
+Root cause: When a related search (e.g., SynonymCollObjs) has an exclude
+filter whose QueryFieldSpec matches the primary field's QueryFieldSpec,
+using implicit_or=True in build_query causes those predicates to be OR'd
+instead of AND'd. This means the WHERE clause becomes:
+
+    WHERE (taxon.id IN (matching_ids) OR NOT (taxon.id = preferred.id))
+
+instead of the correct:
+
+    WHERE taxon.id IN (matching_ids) AND NOT (taxon.id = preferred.id)
+
+The OR version returns ALL synonymized records regardless of the search
+term, because NOT (taxon.id = preferred.id) is true for every synonymized
+record.
+
+Fix: Use implicit_or=False in build_related_query so all predicates are
+AND'd together.
 """
 
 from django.test import TestCase
 
+from specifyweb.backend.express_search.related import RelatedSearch
+from specifyweb.backend.stored_queries.queryfieldspec import QueryFieldSpec
 
-class SimpleTest(TestCase):
-    def test_basic_addition(self):
+
+class TestSynonymyPredicateGrouping(TestCase):
+    """Regression test for issue #6783."""
+
+    def test_synonym_collobj_fieldspec_collision(self):
+        """SynonymCollObjs' exclude filter and primary field share the same
+        fieldspec for the 'Collectionobject.determinations.taxon' definition.
+
+        This collision causes predicates to be OR'd under implicit_or=True,
+        which is the root cause of returning all synonymized records.
         """
-        Tests that 1 + 1 always equals 2.
-        """
-        self.assertEqual(1 + 1, 2)
+        from specifyweb.backend.express_search.related_searches import SynonymCollObjs
+
+        # The exclude filter's fieldspec: determinations.taxon.taxonid
+        exclude_field = SynonymCollObjs.filter_fields[0]
+        exclude_fs = exclude_field.fieldspec
+
+        # The primary field for definition 'Collectionobject.determinations.taxon'
+        # produces fieldspec: Collectionobject.determinations.taxon + add_id (taxonid)
+        primary_fs = QueryFieldSpec.from_path(
+            'Collectionobject.determinations.taxon'.split('.'), add_id=True
+        )
+
+        # These fieldspecs are equal, which means their predicates would
+        # be grouped together under implicit_or=True
+        self.assertEqual(
+            primary_fs, exclude_fs,
+            "The primary field and exclude filter share the same "
+            "QueryFieldSpec. With implicit_or=True, their predicates "
+            "would be incorrectly OR'd instead of AND'd."
+        )
+
+    def test_other_syns_collobj_fieldspec_collision(self):
+        """OtherSynsCollObjs has the same fieldspec collision."""
+        from specifyweb.backend.express_search.related_searches import OtherSynsCollObjs
+
+        exclude_field = OtherSynsCollObjs.filter_fields[0]
+        exclude_fs = exclude_field.fieldspec
+
+        primary_fs = QueryFieldSpec.from_path(
+            'Collectionobject.determinations.preferredtaxon.acceptedchildren'.split('.'),
+            add_id=True
+        )
+
+        self.assertEqual(
+            primary_fs, exclude_fs,
+            "OtherSynsCollObjs has the same fieldspec collision."
+        )
+
+    def test_build_related_query_uses_implicit_or_false(self):
+        """Verify that build_related_query passes implicit_or=False to
+        build_query, preventing predicate OR-grouping."""
+        import inspect
+        source = inspect.getsource(RelatedSearch.build_related_query)
+        self.assertIn(
+            'implicit_or=False',
+            source,
+            "build_related_query must use implicit_or=False to prevent "
+            "OR-grouping of primary field with exclude filter predicates"
+        )


### PR DESCRIPTION
Fixes #6783

Contributed by @foozleface 

Related searches like `SynonymCollObjs` and `OtherSynsCollObjs` have exclude filters whose field spec collides with the primary field QueryFieldSpec built from the definition path. When build_query uses implicit_or=True, predicates sharing the same fieldspec are ORd:

  ```sql
   WHERE (taxon.id IN (matching) OR NOT (taxon.id = preferred.id))
  ```

This returns **ALL synonymized** records regardless of the search term. This PR changes `build_related_query` to use `implicit_or=False`, ensuring all predicates are ANDd:

  ```sql
  WHERE taxon.id IN (matching) AND NOT (taxon.id = preferred.id)
  ```

This removes the 'Taxon Preferred Taxon' results that have been present anytime synonyms are included in the database while preserving valid results:

**Left:** `v7.12.0-prerelease`, **Right:** `issue-6783`
<img width="2560" height="1411" alt="image" src="https://github.com/user-attachments/assets/44373210-48e8-4993-83ba-6a4e6efd5314" />

<img width="2542" height="821" alt="image" src="https://github.com/user-attachments/assets/cf789926-0d9a-4195-a0db-4a64ca417217" />


### Checklist

- [X] Self-review the PR after opening it to make sure the changes look good and
      self-explanatory (or properly documented)
- [X] Add automated tests

### Testing instructions
- [ ] Verify that simple search no longer returns all synonymized taxon records
- [ ] Verify that explicitly searching for a synonym returns the appropriate results