### PR TITLE
fix: remove limit on record sets in search dialog

### DIFF
--- a/specifyweb/frontend/js_src/lib/components/SearchDialog/SelectRecordSet.tsx
+++ b/specifyweb/frontend/js_src/lib/components/SearchDialog/SelectRecordSet.tsx
@@ -18,7 +18,6 @@ import type { RecordSet } from '../DataModel/types';
 import { softError } from '../Errors/assert';
 import { userInformation } from '../InitialContext/userInformation';
 import { Dialog, LoadingScreen } from '../Molecules/Dialog';
-import { usePaginator } from '../Molecules/Paginator';
 import { TableIcon } from '../Molecules/TableIcon';
 
 export function SelectRecordSets<SCHEMA extends AnySchema>({
@@ -38,21 +37,19 @@ export function SelectRecordSets<SCHEMA extends AnySchema>({
     RA<number>
   >([]);
 
-  const { limit, offset } = usePaginator('recordSets');
-
   const [recordSets] = useAsyncState(
     React.useCallback(
       async () =>
         fetchCollection('RecordSet', {
           specifyUser: userInformation.id,
           type: 0,
-          limit,
+          limit: 0,
           domainFilter: true,
-          offset,
+          offset: 0,
           dbTableId: table?.tableId,
           collectionMemberId: schema.domainLevelIds.collection,
         }),
-      [table, limit, offset]
+      [table]
     ),
     false
   );

--- a/specifyweb/frontend/js_src/lib/components/SearchDialog/__tests__/SelectRecordSet.test.ts
+++ b/specifyweb/frontend/js_src/lib/components/SearchDialog/__tests__/SelectRecordSet.test.ts
@@ -1,0 +1,71 @@
+import { overrideAjax } from '../../../tests/ajax';
+import { requireContext } from '../../../tests/helpers';
+import { addMissingFields } from '../../DataModel/addMissingFields';
+import { fetchCollection } from '../../DataModel/collection';
+import { getResourceApiUrl } from '../../DataModel/resource';
+
+requireContext();
+
+/**
+ * Regression test for issue #6971:
+ * The Record Sets button in the Search Dialog previously used a paginated
+ * fetch with a default limit of 10, which meant users with more than 10
+ * record sets could only see a subset. The fix uses limit=0 (no limit)
+ * to fetch all record sets.
+ *
+ * This test verifies that a limit=0 fetch returns all record sets rather
+ * than being capped at 10.
+ */
+describe('SelectRecordSet record set fetch', () => {
+  const recordSetCount = 25;
+  const mockRecordSets = Array.from({ length: recordSetCount }, (_, index) => ({
+    resource_uri: getResourceApiUrl('RecordSet', index + 1),
+    name: `Record Set ${index + 1}`,
+    dbTableId: 1,
+    type: 0,
+  }));
+
+  overrideAjax(
+    '/api/specify/recordset/?specifyuser=1&type=0&limit=0&offset=0&dbtableid=1&collectionmemberid=4',
+    {
+      meta: {
+        total_count: recordSetCount,
+      },
+      objects: mockRecordSets,
+    }
+  );
+
+  test('fetches all record sets when limit is 0', async () => {
+    const result = await fetchCollection('RecordSet', {
+      specifyUser: 1,
+      type: 0,
+      limit: 0,
+      domainFilter: true,
+      offset: 0,
+      dbTableId: 1,
+      collectionMemberId: 4,
+    });
+
+    expect(result.totalCount).toBe(recordSetCount);
+    expect(result.records).toHaveLength(recordSetCount);
+    expect(result.records).toEqual(
+      mockRecordSets.map((recordSet) =>
+        addMissingFields('RecordSet', recordSet)
+      )
+    );
+  });
+
+  test('returns more than the old default limit of 10', async () => {
+    const result = await fetchCollection('RecordSet', {
+      specifyUser: 1,
+      type: 0,
+      limit: 0,
+      domainFilter: true,
+      offset: 0,
+      dbTableId: 1,
+      collectionMemberId: 4,
+    });
+
+    expect(result.records.length).toBeGreaterThan(10);
+  });
+});


### PR DESCRIPTION
Fixes #6971

Contributed by @foozleface 

The Record Sets button in the Search Dialog used `usePaginator` with a default limit of 10 (configurable in the record sets dialog) but _never rendered the paginator UI_, so users could only see the first 10 record sets. Replace with `limit: 0` to fetch all record sets for the current user.

**Left:** `issue-6971`, **Right:** `v7.12.0-prerelease`
<img width="2560" height="1413" alt="image" src="https://github.com/user-attachments/assets/d1c4ba7e-0471-4226-8950-768050a60538" />

### Checklist

- [X] Self-review the PR after opening it to make sure the changes look good and
      self-explanatory (or properly documented)
- [ ] Add relevant issue to release milestone
- [X] Add automated tests

### Testing instructions

Make sure you have a large number of record sets for the base table so you can exceed the limit set in the record sets dialog easily. I tested this in situations with hundreds of record sets, and it should become scrollable with that many.

- [ ] Set the limit on the number of record sets per page to `10` in the Record Sets dialog
- [ ] Go to a place where you can search or select a record set (e.g. by clicking the plus in the collection relationship plugin), and select record set, and verify that all record sets of the appropriate base table appear

     https://github.com/user-attachments/assets/449d280e-8409-4749-80e8-14796637a5da
