### PR TITLE
Upgrade minimatch transitive dependency versions

### DIFF
--- a/specifyweb/frontend/js_src/package-lock.json
+++ b/specifyweb/frontend/js_src/package-lock.json
@@ -12237,7 +12237,9 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "3.1.2",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.4.tgz",
+      "integrity": "sha512-twmL+S8+7yIsE9wsqgzU3E8/LumN3M3QELrBZ20OdmQ9jB2JvW5oZtBEmft84k/Gs5CG9mqtWc6Y9vW+JEzGxw==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -15584,9 +15586,9 @@
       }
     },
     "node_modules/sucrase/node_modules/minimatch": {
-      "version": "9.0.3",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
-      "integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
       "dev": true,
       "dependencies": {
         "brace-expansion": "^2.0.1"
@@ -16278,7 +16280,7 @@
       "dependencies": {
         "lunr": "^2.3.9",
         "marked": "^4.2.4",
-        "minimatch": "^5.1.1",
+        "minimatch": "5.1.8",
         "shiki": "^0.11.1"
       },
       "bin": {
@@ -16301,9 +16303,9 @@
       }
     },
     "node_modules/typedoc/node_modules/minimatch": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.2.tgz",
-      "integrity": "sha512-bNH9mmM9qsJ2X4r2Nat1B//1dJVcn3+iBLa3IgqJ7EbGaDNepL9QSHOxN4ng33s52VMMhhIfgCYDk3C4ZmlDAg==",
+      "version": "5.1.8",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.8.tgz",
+      "integrity": "sha512-7RN35vit8DeBclkofOVmBY0eDAZZQd1HzmukRdSyz95CRh8FT54eqnbj0krQr3mrHR6sfRyYkyhwBWjoV5uqlQ==",
       "dev": true,
       "dependencies": {
         "brace-expansion": "^2.0.1"
@@ -18935,7 +18937,7 @@
         "ignore": "^5.2.0",
         "import-fresh": "^3.2.1",
         "js-yaml": "^4.1.0",
-        "minimatch": "^3.1.2",
+        "minimatch": "3.1.4",
         "strip-json-comments": "^3.1.1"
       }
     },
@@ -25848,7 +25850,9 @@
       "dev": true
     },
     "minimatch": {
-      "version": "3.1.2",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.4.tgz",
+      "integrity": "sha512-twmL+S8+7yIsE9wsqgzU3E8/LumN3M3QELrBZ20OdmQ9jB2JvW5oZtBEmft84k/Gs5CG9mqtWc6Y9vW+JEzGxw==",
       "dev": true,
       "requires": {
         "brace-expansion": "^1.1.7"
@@ -28016,15 +28020,15 @@
           "requires": {
             "foreground-child": "^3.1.0",
             "jackspeak": "^2.3.5",
-            "minimatch": "^9.0.1",
+            "minimatch": "9.0.9",
             "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0",
             "path-scurry": "^1.10.1"
           }
         },
         "minimatch": {
-          "version": "9.0.3",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
-          "integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
+          "version": "9.0.9",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+          "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
           "dev": true,
           "requires": {
             "brace-expansion": "^2.0.1"
@@ -28521,7 +28525,7 @@
       "requires": {
         "lunr": "^2.3.9",
         "marked": "^4.2.4",
-        "minimatch": "^5.1.1",
+        "minimatch": "5.1.8",
         "shiki": "^0.11.1"
       },
       "dependencies": {
@@ -28535,9 +28539,9 @@
           }
         },
         "minimatch": {
-          "version": "5.1.2",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.2.tgz",
-          "integrity": "sha512-bNH9mmM9qsJ2X4r2Nat1B//1dJVcn3+iBLa3IgqJ7EbGaDNepL9QSHOxN4ng33s52VMMhhIfgCYDk3C4ZmlDAg==",
+          "version": "5.1.8",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.8.tgz",
+          "integrity": "sha512-7RN35vit8DeBclkofOVmBY0eDAZZQd1HzmukRdSyz95CRh8FT54eqnbj0krQr3mrHR6sfRyYkyhwBWjoV5uqlQ==",
           "dev": true,
           "requires": {
             "brace-expansion": "^2.0.1"

--- a/specifyweb/frontend/js_src/package.json
+++ b/specifyweb/frontend/js_src/package.json
@@ -130,8 +130,17 @@
     "worker-loader": "^3.0.8"
   },
   "overrides": {
+    "@eslint/eslintrc": {
+      "minimatch": "3.1.4"
+    },
+    "glob@10.3.10": {
+      "minimatch": "9.0.9"
+    },
     "worker-loader": {
       "loader-utils": "2.0.3"
+    },
+    "typedoc": {
+      "minimatch": "5.1.8"
     },
     "form-data": ">=4.0.4",
     "braces": "^3.0.3"


### PR DESCRIPTION
Fixes #7915
Fixes https://github.com/specify/specify7/security/dependabot/183
Fixes https://github.com/specify/specify7/security/dependabot/181
Fixes https://github.com/specify/specify7/security/dependabot/177

Needed to upgrade the minimatch transitive dependencies in order to solve the dependabot issue.  The vulnerabilities were coming from dev-tooling dependency paths rather than app runtime code, specifically through the ESLint/Jest-era tree, `typedoc`, and the `sucrase -> glob` branch used by Tailwind tooling.

### Checklist

- [ ] Self-review the PR after opening it to make sure the changes look good and
      self-explanatory (or properly documented)
- [x] Add relevant issue to release milestone
- [ ] Add pr to documentation list


### Testing instructions

- [x] Light general testing.  This upgrade mostly just affects dev tools, so the front-end code for running Specify shouldn't have any new issues from the upgrade.
