### PR TITLE
Validate formatter compatibility with field type in schema config

### DIFF
--- a/specifyweb/frontend/js_src/lib/components/SchemaConfig/Format.tsx
+++ b/specifyweb/frontend/js_src/lib/components/SchemaConfig/Format.tsx
@@ -24,7 +24,7 @@ import { ResourceLink } from '../Molecules/ResourceLink';
 import { hasToolPermission } from '../Permissions/helpers';
 import type { WithFetchedStrings } from '../Toolbar/SchemaConfig';
 import { PickList } from './Components';
-import { getItemType } from './helpers';
+import { filterCompatibleFormatters, getItemType } from './helpers';
 import type { ItemType } from './index';
 import type { SchemaData } from './schemaData';
 import { fetchSchemaPickLists } from './schemaData';
@@ -53,7 +53,7 @@ export function SchemaConfigFormat({
   const [otherFormatters, formattersForField] = React.useMemo(
     () =>
       split(
-        schemaData.uiFormatters,
+        filterCompatibleFormatters(schemaData.uiFormatters, field.type),
         ({ field: formatterField }) => formatterField === field
       ),
     [field, schemaData.uiFormatters]
@@ -400,3 +400,4 @@ function FieldFormatterEditing({
     </>
   );
 }
+

--- a/specifyweb/frontend/js_src/lib/components/SchemaConfig/__tests__/Format.test.ts
+++ b/specifyweb/frontend/js_src/lib/components/SchemaConfig/__tests__/Format.test.ts
@@ -1,0 +1,108 @@
+import {
+  filterCompatibleFormatters,
+  numericJavaTypes,
+} from '../helpers';
+import type { SimpleFieldFormatter } from '../schemaData';
+
+const makeFormatter = (
+  overrides: Partial<SimpleFieldFormatter> = {}
+): SimpleFieldFormatter => ({
+  name: 'TestFormatter',
+  isSystem: false,
+  value: '###',
+  field: undefined,
+  tableName: undefined,
+  index: 0,
+  isNumericOnly: false,
+  ...overrides,
+});
+
+describe('filterCompatibleFormatters', () => {
+  const numericFormatter = makeFormatter({
+    name: 'NumericOnly',
+    isNumericOnly: true,
+  });
+  const alphaFormatter = makeFormatter({
+    name: 'WithAlpha',
+    isNumericOnly: false,
+  });
+  const allFormatters = [numericFormatter, alphaFormatter];
+
+  test('returns all formatters for string fields', () => {
+    const result = filterCompatibleFormatters(
+      allFormatters,
+      'java.lang.String'
+    );
+    expect(result).toHaveLength(2);
+    expect(result).toEqual(allFormatters);
+  });
+
+  test('returns all formatters for text fields', () => {
+    const result = filterCompatibleFormatters(allFormatters, 'text');
+    expect(result).toHaveLength(2);
+  });
+
+  test('returns all formatters when field type is null', () => {
+    const result = filterCompatibleFormatters(allFormatters, null);
+    expect(result).toHaveLength(2);
+  });
+
+  test('filters out non-numeric formatters for Integer fields', () => {
+    const result = filterCompatibleFormatters(
+      allFormatters,
+      'java.lang.Integer'
+    );
+    expect(result).toHaveLength(1);
+    expect(result[0].name).toBe('NumericOnly');
+  });
+
+  test('filters out non-numeric formatters for Float fields', () => {
+    const result = filterCompatibleFormatters(
+      allFormatters,
+      'java.lang.Float'
+    );
+    expect(result).toHaveLength(1);
+    expect(result[0].name).toBe('NumericOnly');
+  });
+
+  test('filters out non-numeric formatters for BigDecimal fields', () => {
+    const result = filterCompatibleFormatters(
+      allFormatters,
+      'java.math.BigDecimal'
+    );
+    expect(result).toHaveLength(1);
+    expect(result[0].name).toBe('NumericOnly');
+  });
+
+  test('filters for all numeric Java types', () => {
+    for (const javaType of numericJavaTypes) {
+      const result = filterCompatibleFormatters(allFormatters, javaType);
+      expect(result).toHaveLength(1);
+      expect(result[0].name).toBe('NumericOnly');
+    }
+  });
+
+  test('returns empty array when no formatters are numeric-compatible', () => {
+    const result = filterCompatibleFormatters(
+      [alphaFormatter],
+      'java.lang.Integer'
+    );
+    expect(result).toHaveLength(0);
+  });
+
+  test('does not filter for date fields', () => {
+    const result = filterCompatibleFormatters(
+      allFormatters,
+      'java.util.Calendar'
+    );
+    expect(result).toHaveLength(2);
+  });
+
+  test('does not filter for boolean fields', () => {
+    const result = filterCompatibleFormatters(
+      allFormatters,
+      'java.lang.Boolean'
+    );
+    expect(result).toHaveLength(2);
+  });
+});

--- a/specifyweb/frontend/js_src/lib/components/SchemaConfig/helpers.ts
+++ b/specifyweb/frontend/js_src/lib/components/SchemaConfig/helpers.ts
@@ -3,6 +3,7 @@ import type { IR, RA } from '../../utils/types';
 import { localized } from '../../utils/types';
 import { addMissingFields } from '../DataModel/addMissingFields';
 import type { SerializedResource } from '../DataModel/helperTypes';
+import type { JavaType } from '../DataModel/specifyField';
 import type { SpLocaleContainerItem } from '../DataModel/types';
 import type { Aggregator, Formatter } from '../Formatters/spec';
 import type {
@@ -10,7 +11,7 @@ import type {
   NewSpLocaleItemString,
   SpLocaleItemString,
 } from './index';
-import type { SchemaFormatter } from './schemaData';
+import type { SchemaFormatter, SimpleFieldFormatter } from './schemaData';
 
 let newStringId = 1;
 const defaultLanguage = 'en';
@@ -87,6 +88,29 @@ export const localizedRelationshipTypes: IR<string> = {
   'many-to-one': schemaText.manyToOne(),
   'many-to-many': schemaText.manyToMany(),
 };
+
+export const numericJavaTypes = new Set<JavaType>([
+  'java.lang.Byte',
+  'java.lang.Short',
+  'java.lang.Integer',
+  'java.lang.Float',
+  'java.lang.Double',
+  'java.lang.Long',
+  'java.math.BigDecimal',
+]);
+
+/**
+ * Filter out formatters that are incompatible with the field type.
+ * Numeric fields can only use formatters whose parts produce numeric output.
+ */
+export function filterCompatibleFormatters(
+  formatters: RA<SimpleFieldFormatter>,
+  fieldType: string | null
+): RA<SimpleFieldFormatter> {
+  if (fieldType === null || !numericJavaTypes.has(fieldType as JavaType))
+    return formatters;
+  return formatters.filter(({ isNumericOnly }) => isNumericOnly);
+}
 
 /**
  * Localize Java type name for presenting in the UI

--- a/specifyweb/frontend/js_src/lib/components/SchemaConfig/schemaData.ts
+++ b/specifyweb/frontend/js_src/lib/components/SchemaConfig/schemaData.ts
@@ -41,14 +41,21 @@ export type SchemaFormatter = {
   readonly index: number;
 };
 
-type SimpleFieldFormatter = {
+export type SimpleFieldFormatter = {
   readonly name: string;
   readonly isSystem: boolean;
   readonly value: string;
   readonly field: LiteralField | undefined;
   readonly tableName: keyof Tables | undefined;
   readonly index: number;
+  readonly isNumericOnly: boolean;
 };
+
+/**
+ * Formatter part types that produce only numeric characters in their output.
+ * Used to determine if a formatter is safe to assign to numeric fields.
+ */
+const numericSafePartTypes = new Set(['numeric', 'year']);
 
 export const fetchSchemaData = async (): Promise<RawSchemaData> =>
   f.all({
@@ -73,6 +80,10 @@ export const fetchSchemaData = async (): Promise<RawSchemaData> =>
           field: formatter.field,
           tableName: formatter.table?.name,
           index: formatter.originalIndex,
+          isNumericOnly: formatter.parts.every(
+            (part) =>
+              part.type !== undefined && numericSafePartTypes.has(part.type)
+          ),
         }))
         .filter(({ value }) => value)
     ),


### PR DESCRIPTION
Fixes #7585
Contributed by @foozleface

Schema Config allows selecting formatters that are incompatible with the field's data type (e.g., assigning a formatter containing alpha characters to an integer field), which causes runtime errors. This change filters the formatter dropdown to only show formatters whose output is compatible with the target field's Java type.

### Implementation
- Add `isNumericOnly` flag to `SimpleFieldFormatter`, computed by checking whether all formatter parts are of numeric-safe types (`numeric`, `year`)
- Add `filterCompatibleFormatters()` in `helpers.ts` that filters out non-numeric formatters when the field type is a numeric Java type (`Byte`, `Short`, `Integer`, `Float`, `Double`, `Long`, `BigDecimal`)
- Apply the filter in `Format.tsx` before splitting formatters into field-specific vs. other groups
- Export `SimpleFieldFormatter` type from `schemaData.ts` so it can be referenced by the filter function
- Add unit tests covering all numeric Java types, string/text/null passthrough, date and boolean non-filtering, and the empty-result edge case

### Testing instructions
- [ ] Open Schema Config and navigate to a table with numeric fields (e.g., `CollectionObject.catalogNumber` if configured as integer)
- [ ] Verify that only numeric-compatible formatters appear in the formatter dropdown for numeric fields
- [ ] Verify that string fields still show all available formatters
- [ ] Confirm no runtime errors when selecting a formatter from the filtered list