### PR TITLE
Suppress separators for null fields in table formatters

### DIFF
--- a/specifyweb/backend/stored_queries/format.py
+++ b/specifyweb/backend/stored_queries/format.py
@@ -200,6 +200,13 @@ class ObjectFormatter:
                 formatter,
                 aggregator, previous_tables)
 
+            # Unwrap blank_nulls so that apply_stringish sees the raw
+            # expression.  This lets concat(sep, expr) return NULL when the
+            # nested formatter produced NULL, so the outer blank_nulls
+            # correctly suppresses both the value and its separator.
+            # See issue #6406.
+            if isinstance(new_expr, blank_nulls):
+                new_expr = new_expr.clauses.clauses[0]
             raw_expr = new_expr
         else:
             new_query, table, model, specify_field = query.build_join(

--- a/specifyweb/backend/stored_queries/tests/test_format/test_format_query.py
+++ b/specifyweb/backend/stored_queries/tests/test_format/test_format_query.py
@@ -304,3 +304,68 @@ class FormatterAggregatorTests(SQLAlchemySetup):
             query, expr = object_formatter.objformat(query, models.AccessionAgent, None)
             query = query.query.add_columns(expr)
             self.assertCountEqual(list(query), [('text 1 value for this accession',), (' text 2 value for this accession role2',)])
+
+    def test_null_formatted_field_suppresses_separator(self):
+        """Separator on a formatted (relationship) field must be suppressed
+        when the relationship is null.  Regression test for issue #6406."""
+        formatter_def = """
+        <formatters>
+          <format
+            name="Accession"
+            title="Accession"
+            class="edu.ku.brc.specify.datamodel.Accession"
+            default="true"
+          >
+            <switch single="true">
+              <fields>
+                <field>accessionNumber</field>
+              </fields>
+            </switch>
+          </format>
+          <format
+            name="AccessionAgent"
+            title="AccessionAgent"
+            class="edu.ku.brc.specify.datamodel.AccessionAgent"
+            default="true"
+          >
+            <switch single="true">
+              <fields>
+                <field>role</field>
+                <field sep=" -Acc: " formatter="Accession">accession</field>
+              </fields>
+            </switch>
+          </format>
+        </formatters>
+        """
+        object_formatter = self.get_formatter(formatter_def)
+
+        accession_1 = spmodels.Accession.objects.create(
+            accessionnumber='ACC-001',
+            division=self.division,
+        )
+
+        # AccessionAgent WITH an accession -- separator should appear
+        spmodels.Accessionagent.objects.create(
+            agent=self.agent,
+            role='roleA',
+            accession=accession_1,
+        )
+        # AccessionAgent WITHOUT an accession -- separator must NOT appear
+        spmodels.Accessionagent.objects.create(
+            agent=self.agent,
+            role='roleB',
+            accession=None,
+        )
+
+        with FormatterAggregatorTests.test_session_context() as session:
+            query = QueryConstruct(
+                collection=self.collection,
+                objectformatter=object_formatter,
+                query=session.query()
+            )
+            query, expr = object_formatter.objformat(query, models.AccessionAgent, None)
+            query = query.query.add_columns(expr)
+            results = sorted([row[0] for row in query])
+            # With accession: "roleA -Acc: ACC-001"
+            # Without accession: "roleB" (no separator leaking)
+            self.assertEqual(results, ['roleA -Acc: ACC-001', 'roleB'])


### PR DESCRIPTION
Fixes #6406
Contributed by @foozleface

When an object formatter has fields with a `sep` attribute and the related record is NULL, the separator still renders (e.g. a stray " - " with no value after it). The root cause is that `blank_nulls` wrapping around the nested formatter result prevents `concat(sep, expr)` from seeing the NULL, so the separator is unconditionally emitted.

### Implementation
- In `ObjectFormatter.objformat()`, unwrap `blank_nulls` from the nested formatter result before assigning `raw_expr`, so that `apply_stringish` sees the raw expression and `concat(sep, expr)` correctly returns NULL when the nested formatter produced NULL. The outer `blank_nulls` still handles final display.
- Added a regression test that creates two `AccessionAgent` records (one with and one without an `Accession`) and verifies the separator only appears when the related record exists.

### Testing instructions
- [ ] Create a formatter that references a relationship field with a `sep` attribute (e.g. AccessionAgent formatter with `<field sep=" -Acc: " formatter="Accession">accession</field>`)
- [ ] Create records where the relationship is NULL
- [ ] Verify the formatted output does not include the stray separator for NULL relationships
- [ ] Run `python manage.py test specifyweb.backend.stored_queries.tests.test_format.test_format_query`
