### PR TITLE
Date field edits should trigger save button highlight

### DIFF
--- a/specifyweb/frontend/js_src/lib/components/FormPlugins/DateInput.tsx
+++ b/specifyweb/frontend/js_src/lib/components/FormPlugins/DateInput.tsx
@@ -101,6 +101,22 @@ export function DateInput({
             value.length > 0 ? parseDate(precision, value) : undefined;
           setMoment(moment);
         }}
+        onChange={({ target }): void => {
+          const input = target as HTMLInputElement;
+          if (isReadOnly || input === null) return;
+          /*
+           * For native date/month pickers, update the resource immediately
+           * on change rather than waiting for blur. This ensures the form's
+           * dirty-tracking detects the change and highlights the Save button.
+           * See https://github.com/specify/specify7/issues/6699
+           */
+          if (input.type === 'date' || input.type === 'month') {
+            const value = input.value.trim();
+            const moment =
+              value.length > 0 ? parseDate(precision, value) : undefined;
+            setMoment(moment);
+          }
+        }}
         onValueChange={setInputValue}
         {...(localPrecision === 'year'
           ? {

--- a/specifyweb/frontend/js_src/lib/components/FormPlugins/__tests__/PartialDateUi.test.tsx
+++ b/specifyweb/frontend/js_src/lib/components/FormPlugins/__tests__/PartialDateUi.test.tsx
@@ -1,3 +1,7 @@
+import { describe, expect, test } from '@jest/globals';
+import { act, render } from '@testing-library/react';
+import React from 'react';
+
 import { mockTime, requireContext } from '../../../tests/helpers';
 import { snapshot } from '../../../tests/reactUtils';
 import { PartialDateUi } from '../PartialDateUi';
@@ -6,7 +10,7 @@ import { dateTestUtils } from './dateTestUtils';
 mockTime();
 requireContext();
 
-const { props, getBaseResource } = dateTestUtils;
+const { props, getBaseResource, getResource } = dateTestUtils;
 
 // Snapshot tests
 snapshot(PartialDateUi, () => props(getBaseResource()));
@@ -22,3 +26,33 @@ snapshot(PartialDateUi, () =>
     defaultPrecision: 'year',
   })
 );
+
+describe('date field change triggers save required (#6699)', () => {
+  test('changing date via native picker marks resource as modified', () => {
+    const resource = getResource();
+    resource.needsSaved = false;
+
+    const { container } = render(
+      <PartialDateUi {...props(resource)} />
+    );
+
+    const input = container.querySelector('input') as HTMLInputElement;
+    expect(input).not.toBeNull();
+
+    /*
+     * Simulate what a native date picker does: sets value and fires
+     * a change event, without a subsequent blur.
+     */
+    act(() => {
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      const nativeInputValueSetter = Object.getOwnPropertyDescriptor(
+        HTMLInputElement.prototype,
+        'value'
+      )!.set!;
+      nativeInputValueSetter.call(input, '2024-06-15');
+      input.dispatchEvent(new Event('change', { bubbles: true }));
+    });
+
+    expect(resource.needsSaved).toBe(true);
+  });
+});


### PR DESCRIPTION
Fixes #6699
Contributed by @foozleface

Editing a date field using a native date/month picker does not mark the record as modified, so the save button never highlights. This happens because native date pickers fire `change` events (not `blur`), and the `DateInput` component only updated the model on blur.

### Implementation
- Added an `onChange` handler to `DateInput` that, for native `date` and `month` input types, parses and applies the value immediately on change (the same logic already used in the `onBlur` handler). This ensures dirty-tracking detects the modification regardless of whether the browser fires blur.
- Added a test that renders `PartialDateUi`, simulates a native date picker change event (without blur), and asserts `resource.needsSaved` becomes `true`.

### Testing instructions
- [ ] Open a form with a date field (e.g. Cataloged Date on Collection Object)
- [ ] Use the native date picker to select a new date (click the calendar icon, pick a date)
- [ ] Verify the Save button highlights immediately after selection, without needing to click elsewhere
- [ ] Run `npx jest --testPathPattern=PartialDateUi`
