### PR TITLE
Correct date field component labels in batch edit headers

### DIFF
--- a/specifyweb/backend/stored_queries/batch_edit.py
+++ b/specifyweb/backend/stored_queries/batch_edit.py
@@ -720,17 +720,22 @@ class RowPlanCanonical(NamedTuple):
             ]  # Need to go off by 1, bc we added 1 to account for id fields
             # It could happen that the field we saw doesn't exist.
             # Plus, the default options get chosen in the cases of
-            table_name, field_name = _get_table_and_field(field)
+            table_name, _ = _get_table_and_field(field)
+            # Use date-part-aware field name for localization lookup so that
+            # different date components (Full Date, Day, Month, Year) are
+            # matched to their correct captions rather than consuming labels
+            # in insertion order.
+            date_part_field_name = _get_date_part_field_name(field)
             field_caption = query_field_caption_lookup.get(field, None)
             table_field_labels = batch_edit_meta_tables.get_table_field_labels(table_name)
             if (
                 table_field_labels is None
-                or not table_field_labels.has_field_label(field_name)
+                or not table_field_labels.has_field_label(date_part_field_name)
                 or field.fieldspec.contains_tree_rank()
             ):
                 localized_label = naive_field_format(field.fieldspec)
             else:
-                field_label = table_field_labels.use_field_label(field_name, field_caption)
+                field_label = table_field_labels.use_field_label(date_part_field_name, field_caption)
                 localized_label = (
                     field_label.caption if field_label is not None else naive_field_format(field.fieldspec)
                 )
@@ -857,7 +862,10 @@ def naive_field_format(fieldspec: QueryFieldSpec):
         return f"{prefix}{fieldspec.table.name} (formatted)"
     if field.is_relationship:
         return f"{prefix}{fieldspec.table.name} ({'formatted' if field.type.endswith('to-one') else 'aggregatd'})"
-    return f"{prefix}{fieldspec.table.name} {field.name}"
+    date_suffix = ""
+    if fieldspec.is_temporal() and fieldspec.date_part is not None and fieldspec.date_part != "Full Date":
+        date_suffix = f" ({fieldspec.date_part})"
+    return f"{prefix}{fieldspec.table.name} {field.name}{date_suffix}"
 
 
 # @transaction.atomic <--- we DONT do this because the query logic could take up possibly multiple minutes
@@ -895,6 +903,21 @@ def _get_table_and_field(field: QueryField):
     table_name = field.fieldspec.table.name
     field_name = None if field.fieldspec.get_field() is None else field.fieldspec.get_field().name
     return (table_name, field_name)
+
+def _get_date_part_field_name(field: QueryField) -> str | None:
+    """Return a field name that includes the date part suffix for temporal fields.
+
+    This ensures that different date components (e.g., catalogedDate Full Date,
+    catalogedDate Day, catalogedDate Month, catalogedDate Year) are treated as
+    distinct fields in the localization lookup, preventing mislabeled headers.
+    """
+    base_name = None if field.fieldspec.get_field() is None else field.fieldspec.get_field().name
+    if base_name is None:
+        return None
+    date_part = field.fieldspec.date_part
+    if date_part is not None:
+        return f"{base_name}__{date_part}"
+    return base_name
 
 def rewrite_coordinate_fields(row, _mapped_rows: dict[tuple[tuple[str, ...], ...], Any], join_paths: tuple[tuple[str, ...], ...]) -> tuple: 
     """
@@ -982,7 +1005,8 @@ def run_batch_edit_query(props: BatchEditProps):
 
     localization_dump: dict[str, list[tuple[str, str, bool]]] = {}
     for field, caption in field_caption_pairs:
-        table_name, field_name = _get_table_and_field(field)
+        table_name, _ = _get_table_and_field(field)
+        field_name = _get_date_part_field_name(field)
         field_labels = localization_dump.get(table_name, [])
         new_field_label = (field_name, caption, False)
         field_labels.append(new_field_label)

--- a/specifyweb/backend/stored_queries/relative_date_utils.py
+++ b/specifyweb/backend/stored_queries/relative_date_utils.py
@@ -8,6 +8,8 @@ def apply_absolute_date(query_field):
         return query_field
 
     field_value = query_field.value
+    if field_value is None:
+        return query_field
     new_field_value = ','.join([relative_to_absolute_date(value_split) for value_split in field_value.split(',')])
     return query_field._replace(value=new_field_value)
 

--- a/specifyweb/backend/stored_queries/tests/test_batch_edit.py
+++ b/specifyweb/backend/stored_queries/tests/test_batch_edit.py
@@ -6,6 +6,8 @@ from specifyweb.backend.stored_queries.batch_edit import (
     BatchEditProps,
     RowPlanMap,
     run_batch_edit_query,
+    naive_field_format,
+    _get_date_part_field_name,
 )
 
 from specifyweb.backend.stored_queries.queryfield import fields_from_json
@@ -2342,4 +2344,154 @@ class QueryConstructionTests(SQLAlchemySetup):
         (headers, rows, packs, plan, order) = run_batch_edit_query(props)
 
         self.assertEqual(headers, expected_captions)
-        
+
+
+class DateFieldLabelTests(SQLAlchemySetup):
+    """Tests for issue #6808: date field components must get distinct labels."""
+
+    def test_naive_field_format_includes_date_part(self):
+        """naive_field_format must include (Day), (Month), (Year) for date parts."""
+        base_table = "collectionobject"
+
+        full_date = QueryFieldSpec.from_path([base_table, "catalogedDate"])
+        day = full_date._replace(date_part="Day")
+        month = full_date._replace(date_part="Month")
+        year = full_date._replace(date_part="Year")
+
+        self.assertEqual(
+            naive_field_format(full_date),
+            "CollectionObject catalogedDate",
+        )
+        self.assertEqual(
+            naive_field_format(day),
+            "CollectionObject catalogedDate (Day)",
+        )
+        self.assertEqual(
+            naive_field_format(month),
+            "CollectionObject catalogedDate (Month)",
+        )
+        self.assertEqual(
+            naive_field_format(year),
+            "CollectionObject catalogedDate (Year)",
+        )
+
+    def test_get_date_part_field_name_distinguishes_parts(self):
+        """_get_date_part_field_name returns distinct keys per date component."""
+        base_table = "collectionobject"
+
+        full_date_spec = QueryFieldSpec.from_path([base_table, "catalogedDate"])
+        day_spec = full_date_spec._replace(date_part="Day")
+        month_spec = full_date_spec._replace(date_part="Month")
+        year_spec = full_date_spec._replace(date_part="Year")
+
+        full_date = BatchEditPack._query_field(full_date_spec, 0)
+        day = BatchEditPack._query_field(day_spec, 0)
+        month = BatchEditPack._query_field(month_spec, 0)
+        year = BatchEditPack._query_field(year_spec, 0)
+
+        names = [
+            _get_date_part_field_name(full_date),
+            _get_date_part_field_name(day),
+            _get_date_part_field_name(month),
+            _get_date_part_field_name(year),
+        ]
+
+        self.assertEqual(names[0], "catalogedDate__Full Date")
+        self.assertEqual(names[1], "catalogedDate__Day")
+        self.assertEqual(names[2], "catalogedDate__Month")
+        self.assertEqual(names[3], "catalogedDate__Year")
+
+        # All names must be distinct
+        self.assertEqual(len(set(names)), 4)
+
+    @patch(OBJ_FORMATTER_PATH, new=fake_obj_formatter)
+    def test_date_field_headers_without_captions(self):
+        """Without captions, date field headers must include part suffix (#6808)."""
+        base_table = "collectionobject"
+
+        full_date_spec = QueryFieldSpec.from_path([base_table, "catalogedDate"])
+        day_spec = full_date_spec._replace(date_part="Day")
+        month_spec = full_date_spec._replace(date_part="Month")
+        year_spec = full_date_spec._replace(date_part="Year")
+
+        query_fields = [
+            BatchEditPack._query_field(full_date_spec, 0),
+            BatchEditPack._query_field(day_spec, 0),
+            BatchEditPack._query_field(month_spec, 0),
+            BatchEditPack._query_field(year_spec, 0),
+        ]
+
+        props = BatchEditProps(
+            collection=self.collection,
+            user=self.specifyuser,
+            contexttableid=datamodel.get_table_strict(base_table).tableId,
+            fields=query_fields,
+            session_maker=DateFieldLabelTests.test_session_context,
+            captions=None,
+            limit=None,
+            recordsetid=None,
+            omit_relationships=False,
+            treedefsfilter=None,
+        )
+
+        (headers, rows, packs, plan, order) = run_batch_edit_query(props)
+
+        # Each date component must have a distinct header with the correct suffix
+        self.assertIn("CollectionObject catalogedDate", headers)
+        self.assertIn("CollectionObject catalogedDate (Day)", headers)
+        self.assertIn("CollectionObject catalogedDate (Month)", headers)
+        self.assertIn("CollectionObject catalogedDate (Year)", headers)
+
+        # No duplicate headers
+        date_headers = [h for h in headers if "catalogedDate" in h]
+        self.assertEqual(len(date_headers), len(set(date_headers)))
+
+    @patch(OBJ_FORMATTER_PATH, new=fake_obj_formatter)
+    def test_date_field_headers_with_captions(self):
+        """With captions, date field headers must use the correct caption per component (#6808)."""
+        base_table = "collectionobject"
+
+        full_date_spec = QueryFieldSpec.from_path([base_table, "catalogedDate"])
+        day_spec = full_date_spec._replace(date_part="Day")
+        month_spec = full_date_spec._replace(date_part="Month")
+        year_spec = full_date_spec._replace(date_part="Year")
+
+        query_fields = [
+            BatchEditPack._query_field(full_date_spec, 0),
+            BatchEditPack._query_field(day_spec, 0),
+            BatchEditPack._query_field(month_spec, 0),
+            BatchEditPack._query_field(year_spec, 0),
+        ]
+
+        captions = [
+            "Cataloged Date",
+            "Cataloged Date (Day)",
+            "Cataloged Date (Month)",
+            "Cataloged Date (Year)",
+        ]
+
+        props = BatchEditProps(
+            collection=self.collection,
+            user=self.specifyuser,
+            contexttableid=datamodel.get_table_strict(base_table).tableId,
+            fields=query_fields,
+            session_maker=DateFieldLabelTests.test_session_context,
+            captions=captions,
+            limit=None,
+            recordsetid=None,
+            omit_relationships=False,
+            treedefsfilter=None,
+        )
+
+        (headers, rows, packs, plan, order) = run_batch_edit_query(props)
+
+        # Each date component must use its caption, not all showing "(Year)"
+        self.assertIn("Cataloged Date", headers)
+        self.assertIn("Cataloged Date (Day)", headers)
+        self.assertIn("Cataloged Date (Month)", headers)
+        self.assertIn("Cataloged Date (Year)", headers)
+
+        # No duplicate headers
+        date_headers = [h for h in headers if "Cataloged Date" in h]
+        self.assertEqual(len(date_headers), len(set(date_headers)))
+

--- a/specifyweb/frontend/js_src/lib/components/WbPlanView/__tests__/mappingPreview.test.ts
+++ b/specifyweb/frontend/js_src/lib/components/WbPlanView/__tests__/mappingPreview.test.ts
@@ -126,4 +126,21 @@ theories(generateMappingPathPreview, [
     'Exsiccata - Reference Work - Title',
   ],
   [['TaxonAttribute', ['taxons', '$Family', 'taxonId']], 'Family - ID'],
+  // Issue #6808: Date field components must get distinct labels
+  [
+    ['CollectionObject', ['catalogedDate-fullDate']],
+    'Cataloged Date',
+  ],
+  [
+    ['CollectionObject', ['catalogedDate-day']],
+    'Cataloged Date (Day)',
+  ],
+  [
+    ['CollectionObject', ['catalogedDate-month']],
+    'Cataloged Date (Month)',
+  ],
+  [
+    ['CollectionObject', ['catalogedDate-year']],
+    'Cataloged Date (Year)',
+  ],
 ]);


### PR DESCRIPTION
Fixes #6808
Contributed by @foozleface

Batch edit column headers for date fields show wrong component labels. When multiple date components of the same field are present (e.g. catalogedDate Full Date, Day, Month, Year), all columns get the same label because the localization lookup key is just the base field name, so each component consumes labels in insertion order rather than matching by date part.

### Implementation
- Introduced `_get_date_part_field_name()` which returns a distinct key per date component (e.g. `catalogedDate__Full Date`, `catalogedDate__Day`) for localization lookups.
- Updated `RowPlanCanonical._create_row_plan()` and `run_batch_edit_query()` to use the date-part-aware key instead of the bare field name when looking up and registering field labels.
- Updated `naive_field_format()` to append the date part suffix (e.g. "(Day)", "(Month)", "(Year)") for non-"Full Date" components.
- Added a null guard in `apply_absolute_date()` for `query_field.value` being `None`.
- Added frontend test cases for `generateMappingPathPreview` to verify date component labels.
- Added backend tests for `naive_field_format`, `_get_date_part_field_name`, and end-to-end batch edit header generation with and without captions.

### Testing instructions
- [ ] Open the query builder, add multiple date components of the same field (e.g. Cataloged Date Full Date, Day, Month, Year)
- [ ] Run a batch edit and verify each column header shows the correct component label
- [ ] Run `python manage.py test specifyweb.backend.stored_queries.tests.test_batch_edit`
- [ ] Run `npx jest --testPathPattern=mappingPreview`
