### PR TITLE
Sync column headers with data on query field reorder

### DIFF
--- a/specifyweb/frontend/js_src/lib/components/QueryBuilder/ResultsWrapper.tsx
+++ b/specifyweb/frontend/js_src/lib/components/QueryBuilder/ResultsWrapper.tsx
@@ -22,11 +22,49 @@ import {
   queryFieldsToFieldSpecs,
   unParseQueryFields,
 } from './helpers';
+import type { QueryFieldSpec } from './fieldSpec';
 import type { QueryResultRow } from './Results';
 import { QueryResults } from './Results';
 
 // TODO: [FEATURE] allow customizing this and other constants as make sense
 const fetchSize = 40;
+
+/**
+ * When series mode (smushed) is active, the backend skips the catalog number
+ * column from its normal position in the SQL SELECT and instead inserts a
+ * catalog number series range at position 1 (right after the ID column).
+ *
+ * This function reorders the frontend fieldSpecs/queryFields arrays so that
+ * the catalog number entry is at index 0 (matching position 1 in the result
+ * data, since position 0 is the ID which is stripped before rendering).
+ *
+ * Without this reordering, column headers become mismatched with data columns.
+ * See: https://github.com/specify/specify7/issues/7086
+ */
+export function reorderFieldSpecsForSeries<
+  T extends { readonly fieldSpec: QueryFieldSpec; readonly field: QueryField },
+>(
+  items: RA<T>,
+  isSeries: boolean,
+  tableName: string
+): RA<T> {
+  if (!isSeries || tableName !== 'CollectionObject') return items;
+
+  const catNumIndex = items.findIndex(
+    (item) =>
+      item.field.mappingPath.length === 1 &&
+      item.field.mappingPath[0] === 'catalogNumber'
+  );
+
+  if (catNumIndex <= 0) return items;
+
+  const catNumItem = items[catNumIndex];
+  return [
+    catNumItem,
+    ...items.slice(0, catNumIndex),
+    ...items.slice(catNumIndex + 1),
+  ];
+}
 
 export function QueryResultsWrapper({
   createRecordSet,
@@ -185,14 +223,21 @@ export function useQueryResultsWrapper({
     const initialData = isCountOnly
       ? Promise.resolve(undefined)
       : runQuery(query, { offset: 0, ...fetchPayload });
-    const fieldSpecsAndFields = queryFieldsToFieldSpecs(
+    const isSeries = queryResource.get('smushed') === true;
+    const rawFieldSpecsAndFields = queryFieldsToFieldSpecs(
       table.name,
       displayedFields
     );
-    const fieldSpecs = fieldSpecsAndFields.map(
-      ([_field, fieldSpec]) => fieldSpec
+    const reordered = reorderFieldSpecsForSeries(
+      rawFieldSpecsAndFields.map(([field, fieldSpec]) => ({
+        field,
+        fieldSpec,
+      })),
+      isSeries,
+      table.name
     );
-    const queryFields = fieldSpecsAndFields.map(([field]) => field);
+    const fieldSpecs = reordered.map(({ fieldSpec }) => fieldSpec);
+    const queryFields = reordered.map(({ field }) => field);
 
     initialData
       .then((initialData) =>
@@ -218,7 +263,7 @@ export function useQueryResultsWrapper({
                    * index differ. Also needs to skip phantom fields (added by locality)
                    */
                   const index = fieldSpecs.indexOf(fieldSpec);
-                  const displayField = displayedFields[index];
+                  const displayField = queryFields[index];
                   const lineIndex = allFields.indexOf(displayField);
                   handleSortChange(
                     replaceItem(

--- a/specifyweb/frontend/js_src/lib/components/QueryBuilder/__tests__/ResultsWrapper.test.ts
+++ b/specifyweb/frontend/js_src/lib/components/QueryBuilder/__tests__/ResultsWrapper.test.ts
@@ -1,0 +1,100 @@
+import { requireContext } from '../../../tests/helpers';
+import type { QueryField } from '../helpers';
+import { QueryFieldSpec } from '../fieldSpec';
+import { reorderFieldSpecsForSeries } from '../ResultsWrapper';
+
+requireContext();
+
+function makeItem(mappingPath: readonly string[], baseTable = 'CollectionObject') {
+  const field: QueryField = {
+    id: 0,
+    mappingPath,
+    sortType: undefined,
+    isDisplay: true,
+    filters: [{ type: 'any', startValue: '', isNot: false, isStrict: false }],
+  };
+  const fieldSpec = QueryFieldSpec.fromPath(
+    baseTable as 'CollectionObject',
+    mappingPath
+  );
+  return { field, fieldSpec };
+}
+
+describe('reorderFieldSpecsForSeries', () => {
+  test('no-op when series is off', () => {
+    const items = [
+      makeItem(['timestampCreated']),
+      makeItem(['catalogNumber']),
+      makeItem(['determinations', 'taxon', '-formatted']),
+    ];
+    const result = reorderFieldSpecsForSeries(items, false, 'CollectionObject');
+    expect(result).toBe(items);
+  });
+
+  test('no-op when table is not CollectionObject', () => {
+    const items = [
+      makeItem(['timestampCreated'], 'Accession'),
+      makeItem(['accessionNumber'], 'Accession'),
+    ];
+    const result = reorderFieldSpecsForSeries(
+      items as ReturnType<typeof makeItem>[],
+      true,
+      'Accession'
+    );
+    expect(result).toBe(items);
+  });
+
+  test('no-op when catalogNumber is already first', () => {
+    const items = [
+      makeItem(['catalogNumber']),
+      makeItem(['timestampCreated']),
+    ];
+    const result = reorderFieldSpecsForSeries(items, true, 'CollectionObject');
+    expect(result).toBe(items);
+  });
+
+  test('no-op when catalogNumber is absent', () => {
+    const items = [
+      makeItem(['timestampCreated']),
+      makeItem(['determinations', 'taxon', '-formatted']),
+    ];
+    const result = reorderFieldSpecsForSeries(items, true, 'CollectionObject');
+    expect(result).toBe(items);
+  });
+
+  test('moves catalogNumber to front when series is on', () => {
+    const items = [
+      makeItem(['timestampCreated']),
+      makeItem(['catalogNumber']),
+      makeItem(['determinations', 'taxon', '-formatted']),
+    ];
+    const result = reorderFieldSpecsForSeries(items, true, 'CollectionObject');
+
+    expect(result).toHaveLength(3);
+    expect(result[0].field.mappingPath).toEqual(['catalogNumber']);
+    expect(result[1].field.mappingPath).toEqual(['timestampCreated']);
+    expect(result[2].field.mappingPath).toEqual([
+      'determinations',
+      'taxon',
+      '-formatted',
+    ]);
+  });
+
+  test('moves catalogNumber from last position to front', () => {
+    const items = [
+      makeItem(['timestampCreated']),
+      makeItem(['determinations', 'taxon', '-formatted']),
+      makeItem(['catalogNumber']),
+    ];
+    const result = reorderFieldSpecsForSeries(items, true, 'CollectionObject');
+
+    expect(result).toHaveLength(3);
+    expect(result[0].field.mappingPath).toEqual(['catalogNumber']);
+    expect(result[1].field.mappingPath).toEqual(['timestampCreated']);
+    expect(result[2].field.mappingPath).toEqual([
+      'determinations',
+      'taxon',
+      '-formatted',
+    ]);
+  });
+});


### PR DESCRIPTION
Fixes #7086
Contributed by @foozleface

When reordering fields in the query builder, the column headers in the results table get out of sync with the actual data columns. This happens specifically in "series" (smushed) mode, where the backend moves the catalog number column to position 1 in the SQL SELECT but the frontend field specs remain in the user-defined order.

### Implementation
- Added `reorderFieldSpecsForSeries()` which, when series mode is active on a CollectionObject query, moves the catalog number entry to the front of the fieldSpecs/queryFields arrays to match the backend column order.
- Applied the reordering in `useQueryResultsWrapper()` after building field specs but before rendering results.
- Fixed the sort handler to use `queryFields` (the reordered array) instead of `displayedFields` (the original order) when resolving field indices.
- Added unit tests covering no-op cases (series off, wrong table, catNum already first, catNum absent) and the actual reorder case.

### Testing instructions
- [ ] Create a CollectionObject query with catalog number and other fields
- [ ] Reorder the fields so catalog number is not first
- [ ] Enable "series" (smushed) mode and run the query
- [ ] Verify column headers match their data columns
- [ ] Run `npx jest --testPathPattern=ResultsWrapper`
