### PR TITLE
Escape quotes in locality name for GEOLocate integration

### DIFF
--- a/specifyweb/frontend/js_src/lib/components/Molecules/GeoLocate.tsx
+++ b/specifyweb/frontend/js_src/lib/components/Molecules/GeoLocate.tsx
@@ -19,6 +19,24 @@ const baseData = {
   georef: 'run',
 };
 
+/**
+ * Sanitize data values for GEOLocate by removing quote characters.
+ *
+ * GEOLocate's web page fails to render the map when locality names or other
+ * parameters contain `"` or `'` characters because its internal page scripts
+ * do not handle embedded quotes safely. Stripping them is the simplest fix
+ * that preserves the useful content of the string.
+ *
+ * See: https://github.com/specify/specify7/issues/7664
+ */
+export const sanitizeGeoLocateData = (data: IR<string>): IR<string> =>
+  Object.fromEntries(
+    Object.entries(data).map(([key, value]) => [
+      key,
+      value.replaceAll(/["']/gu, ''),
+    ])
+  );
+
 export function GenericGeoLocate({
   data,
   onClose: handleClose,
@@ -54,7 +72,7 @@ export function GenericGeoLocate({
     () =>
       formatUrl('https://www.geo-locate.org/web/webgeoreflight.aspx', {
         ...baseData,
-        ...data,
+        ...sanitizeGeoLocateData(data),
       }).replaceAll(/%7c/giu, '|'),
     [data]
   );

--- a/specifyweb/frontend/js_src/lib/components/Molecules/__tests__/GeoLocate.test.ts
+++ b/specifyweb/frontend/js_src/lib/components/Molecules/__tests__/GeoLocate.test.ts
@@ -1,0 +1,45 @@
+import { sanitizeGeoLocateData } from '../GeoLocate';
+
+describe('sanitizeGeoLocateData', () => {
+  test('removes double quotes from locality name', () => {
+    const data = { locality: 'Near "Big Rock" Creek', country: 'US' };
+    const result = sanitizeGeoLocateData(data);
+    expect(result.locality).toBe('Near Big Rock Creek');
+    expect(result.country).toBe('US');
+  });
+
+  test('removes single quotes from locality name', () => {
+    const data = { locality: "O'Brien's Landing", state: 'California' };
+    const result = sanitizeGeoLocateData(data);
+    expect(result.locality).toBe('OBriens Landing');
+    expect(result.state).toBe('California');
+  });
+
+  test('removes mixed quotes from locality name', () => {
+    const data = { locality: `He said "it's here"`, county: 'Marin' };
+    const result = sanitizeGeoLocateData(data);
+    expect(result.locality).toBe('He said its here');
+    expect(result.county).toBe('Marin');
+  });
+
+  test('passes through values without quotes unchanged', () => {
+    const data = {
+      locality: 'Normal Locality Name',
+      country: 'United States',
+      state: 'California',
+      points: '37.7749|-122.4194|Normal Locality Name|',
+    };
+    const result = sanitizeGeoLocateData(data);
+    expect(result).toStrictEqual(data);
+  });
+
+  test('sanitizes quotes in all fields including points', () => {
+    const data = {
+      locality: "Lake O'Neill",
+      points: "33.2|-117.3|Lake O'Neill|",
+    };
+    const result = sanitizeGeoLocateData(data);
+    expect(result.locality).toBe('Lake ONeill');
+    expect(result.points).toBe('33.2|-117.3|Lake ONeill|');
+  });
+});


### PR DESCRIPTION
Fixes #7664
Contributed by @foozleface

Locality names containing single or double quotes break the GEOLocate plugin because its internal page scripts cannot handle embedded quote characters in URL parameters, causing the map to fail to render.

### Implementation
- Add `sanitizeGeoLocateData()` helper that strips `"` and `'` characters from all data values before they are passed to the GEOLocate URL builder
- Apply the sanitizer in `GenericGeoLocate` when constructing the URL, replacing the direct `...data` spread with `...sanitizeGeoLocateData(data)`
- Add unit tests covering double quotes, single quotes, mixed quotes, passthrough of clean values, and sanitization across all fields including the `points` parameter

### Testing instructions
- [ ] Create or find a locality record with quotes in the name (e.g., `Near "Big Rock" Creek` or `O'Brien's Landing`)
- [ ] Open the GEOLocate plugin from that locality record
- [ ] Verify the GEOLocate map renders correctly without JavaScript errors
- [ ] Verify that locality names without quotes continue to work normally