### PR TITLE
Respect date precision in formatted fields

### DIFF
--- a/specifyweb/backend/stored_queries/format.py
+++ b/specifyweb/backend/stored_queries/format.py
@@ -214,6 +214,15 @@ class ObjectFormatter:
                     formatter_field_spec.get_field(),
                     new_expr
                 )
+            elif specify_field.is_temporal():
+                # When full field formatting is disabled, still apply
+                # precision-aware date formatting for temporal fields.
+                # Without this, date fields in object formatters ignore
+                # precision and display the raw date (e.g. "2024-01-01"
+                # instead of "2024" for year-only precision).
+                # See: https://github.com/specify/specify7/issues/7376
+                new_expr = self._dateformat(specify_field, new_expr)
+                raw_expr = new_expr
 
         # Helper function to apply only string-ish transforms with no numeric casts
         def apply_stringish(expr):
@@ -418,7 +427,8 @@ class ObjectFormatter:
         if specify_field.type == "java.sql.Timestamp":
             return func.date_format(field, "%Y-%m-%dT%H:%i:%s")
 
-        prec_fld = getattr(field.class_, specify_field.name + 'Precision', None)
+        field_class = getattr(field, 'class_', None)
+        prec_fld = getattr(field_class, specify_field.name + 'Precision', None) if field_class is not None else None
 
         # format_expr = (
         #     case(

--- a/specifyweb/backend/stored_queries/tests/test_format/test_format_query.py
+++ b/specifyweb/backend/stored_queries/tests/test_format/test_format_query.py
@@ -237,6 +237,75 @@ class FormatterAggregatorTests(SQLAlchemySetup):
                                    "roleASome_number",)]
                                   )
 
+    def test_date_precision_in_formatted_fields(self):
+        """Date fields in object formatters should respect precision.
+
+        When a date has year-only precision (3), the formatted output
+        should show just the year, not the full date.
+        See: https://github.com/specify/specify7/issues/7376
+        """
+        from datetime import date
+
+        formatter_def = """
+        <formatters>
+          <format
+            name="Accession"
+            title="Accession"
+            class="edu.ku.brc.specify.datamodel.Accession"
+            default="true"
+          >
+            <switch single="true">
+              <fields>
+                <field>accessionNumber</field>
+                <field sep=" - ">dateAccessioned</field>
+              </fields>
+            </switch>
+          </format>
+        </formatters>
+        """
+        object_formatter = self.get_formatter(formatter_def)
+
+        # Year-only precision (3): should display as just "2024"
+        accession_year = spmodels.Accession.objects.create(
+            accessionnumber='YEAR-ONLY',
+            division=self.division,
+            dateaccessioned=date(2024, 1, 1),
+            dateaccessionedprecision=3,
+        )
+
+        # Month precision (2): should display as "2024-06" (or locale equivalent)
+        accession_month = spmodels.Accession.objects.create(
+            accessionnumber='MONTH-ONLY',
+            division=self.division,
+            dateaccessioned=date(2024, 6, 1),
+            dateaccessionedprecision=2,
+        )
+
+        # Full precision (1): should display as "2024-03-15"
+        accession_full = spmodels.Accession.objects.create(
+            accessionnumber='FULL-DATE',
+            division=self.division,
+            dateaccessioned=date(2024, 3, 15),
+            dateaccessionedprecision=1,
+        )
+
+        with FormatterAggregatorTests.test_session_context() as session:
+            query = QueryConstruct(
+                collection=self.collection,
+                objectformatter=object_formatter,
+                query=session.query()
+            )
+            query, expr = object_formatter.objformat(query, models.Accession, None)
+            query = query.query.add_columns(models.Accession.accessionNumber, expr)
+            results = {row[0]: row[1] for row in query}
+
+            # Year-only precision: must NOT include month/day
+            self.assertEqual(results['YEAR-ONLY'], 'YEAR-ONLY - 2024')
+            # Month precision: must include month but NOT day
+            self.assertEqual(results['MONTH-ONLY'], 'MONTH-ONLY - 2024-06')
+            # Full precision: must include full date
+            self.assertEqual(results['FULL-DATE'], 'FULL-DATE - 2024-03-15')
+
     def test_relationships_in_switch_fields(self):
         formatter_def = """
         <formatters>


### PR DESCRIPTION
Fixes #7376
Contributed by @foozleface

Dates with reduced precision (year-only or month-only) display the raw full date in query results instead of the trimmed value when they appear via object formatters. For example, a year-only accession date shows "2024-01-01" instead of "2024".

**Note:** This PR covers the object-formatter path (`format_expr=False`). The upstream v7.12.0-prerelease has a complementary fix inside `_fieldformat()` for the query-result-column path (`format_expr=True`). Both are needed for complete coverage.

### Implementation
- In `ObjectFormatter.objformat()`, when `format_expr` is False and the field is temporal, apply `_dateformat()` to get precision-aware date formatting. Previously this code path skipped date formatting entirely.
- Added a null guard in `_dateformat()`: check that `field.class_` exists before accessing the precision attribute, preventing an `AttributeError` when the field expression lacks a `class_` attribute.
- Added a regression test with three accessions at different precisions (year-only, month-only, full) verifying correct formatted output.

### Testing instructions
- [ ] Create records with date fields at different precisions (year-only, month-only, full)
- [ ] View those records through a formatter that includes the date field (e.g. Accession formatter with dateAccessioned)
- [ ] Verify year-only shows just "2024", month-only shows "2024-06", full shows "2024-03-15"
- [ ] Run `python manage.py test specifyweb.backend.stored_queries.tests.test_format.test_format_query`
