### PR TITLE
Add missing database indexes for tree tables

### DIFF
--- a/specifyweb/specify/migrations/0046_add_tectonicunit_indexes.py
+++ b/specifyweb/specify/migrations/0046_add_tectonicunit_indexes.py
@@ -1,0 +1,23 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('specify', '0045_add_missing_dwc_fields'),
+    ]
+
+    operations = [
+        migrations.AddIndex(
+            model_name='tectonicunit',
+            index=models.Index(fields=['name'], name='TectonicUnitNameIDX'),
+        ),
+        migrations.AddIndex(
+            model_name='tectonicunit',
+            index=models.Index(fields=['fullname'], name='TectonicUnitFullNameIDX'),
+        ),
+        migrations.AddIndex(
+            model_name='tectonicunit',
+            index=models.Index(fields=['guid'], name='TectonicUnitGuidIDX'),
+        ),
+    ]

--- a/specifyweb/specify/migrations/0048_add_tree_performance_indexes.py
+++ b/specifyweb/specify/migrations/0048_add_tree_performance_indexes.py
@@ -1,0 +1,110 @@
+"""
+Add ~20 missing performance indexes for tree operations and large table lookups.
+
+Addresses GitHub issue #7482. Without these indexes, queries like
+  SELECT ... FROM taxon WHERE NodeNumber BETWEEN X AND Y
+do full table scans (type: ALL) on tables with 200K+ rows.
+"""
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('specify', '0046_add_tectonicunit_indexes'),
+    ]
+
+    operations = [
+        # -- Taxon tree indexes --
+        migrations.AddIndex(
+            model_name='taxon',
+            index=models.Index(fields=['nodenumber'], name='TaxonNodeNumIDX'),
+        ),
+        migrations.AddIndex(
+            model_name='taxon',
+            index=models.Index(fields=['highestchildnodenumber'], name='TaxonHCNNumIDX'),
+        ),
+        migrations.AddIndex(
+            model_name='taxon',
+            index=models.Index(fields=['rankid'], name='TaxonRankIDIDX'),
+        ),
+
+        # -- Geography tree indexes --
+        migrations.AddIndex(
+            model_name='geography',
+            index=models.Index(fields=['nodenumber'], name='GeoNodeNumIDX'),
+        ),
+        migrations.AddIndex(
+            model_name='geography',
+            index=models.Index(fields=['highestchildnodenumber'], name='GeoHCNNumIDX'),
+        ),
+
+        # -- Storage tree indexes --
+        migrations.AddIndex(
+            model_name='storage',
+            index=models.Index(fields=['nodenumber'], name='StorNodeNumIDX'),
+        ),
+        migrations.AddIndex(
+            model_name='storage',
+            index=models.Index(fields=['highestchildnodenumber'], name='StorHCNNumIDX'),
+        ),
+
+        # -- Geologictimeperiod tree indexes --
+        migrations.AddIndex(
+            model_name='geologictimeperiod',
+            index=models.Index(fields=['nodenumber'], name='GTPNodeNumIDX'),
+        ),
+        migrations.AddIndex(
+            model_name='geologictimeperiod',
+            index=models.Index(fields=['highestchildnodenumber'], name='GTPHCNNumIDX'),
+        ),
+
+        # -- Lithostrat tree indexes --
+        migrations.AddIndex(
+            model_name='lithostrat',
+            index=models.Index(fields=['nodenumber'], name='LithoNodeNumIDX'),
+        ),
+        migrations.AddIndex(
+            model_name='lithostrat',
+            index=models.Index(fields=['highestchildnodenumber'], name='LithoHCNNumIDX'),
+        ),
+
+        # -- Tectonicunit tree indexes --
+        migrations.AddIndex(
+            model_name='tectonicunit',
+            index=models.Index(fields=['nodenumber'], name='TectNodeNumIDX'),
+        ),
+        migrations.AddIndex(
+            model_name='tectonicunit',
+            index=models.Index(fields=['highestchildnodenumber'], name='TectHCNNumIDX'),
+        ),
+
+        # -- GUID indexes for large tables --
+        migrations.AddIndex(
+            model_name='locality',
+            index=models.Index(fields=['guid'], name='LocalityGuidIDX'),
+        ),
+        migrations.AddIndex(
+            model_name='collectionobject',
+            index=models.Index(fields=['guid'], name='COGuidIDX'),
+        ),
+
+        # -- Compound index: determination lookups by collection + current --
+        migrations.AddIndex(
+            model_name='determination',
+            index=models.Index(
+                fields=['collectionmemberid', 'iscurrent'],
+                name='DetColMemCurrIDX',
+            ),
+        ),
+
+        # -- Compound index: CoJo lookups by parent COG + primary flag --
+        migrations.AddIndex(
+            model_name='collectionobjectgroupjoin',
+            index=models.Index(
+                fields=['parentcog', 'isprimary'],
+                name='CojoParentPrimaryIDX',
+            ),
+        ),
+    ]

--- a/specifyweb/specify/migrations/0049_fix_index_definitions.py
+++ b/specifyweb/specify/migrations/0049_fix_index_definitions.py
@@ -1,0 +1,38 @@
+"""
+Fix index definitions created in 0048:
+- DetCurrColMemIDX → DetColMemCurrIDX: reorder columns for better selectivity
+- CojoIsPrimaryIDX → CojoParentPrimaryIDX: compound index matching query pattern
+
+For databases that ran the original 0048, this drops the old indexes.
+For fresh databases (running revised 0048 directly), the drops are no-ops.
+"""
+
+from django.db import migrations
+
+
+def drop_old_indexes(apps, schema_editor):
+    """Drop indexes from the original 0048 if they exist."""
+    with schema_editor.connection.cursor() as cursor:
+        for index_name, table_name in [
+            ('DetCurrColMemIDX', 'determination'),
+            ('CojoIsPrimaryIDX', 'collectionobjectgroupjoin'),
+        ]:
+            cursor.execute(
+                "SELECT COUNT(*) FROM information_schema.statistics "
+                "WHERE table_schema = DATABASE() AND table_name = %s "
+                "AND index_name = %s",
+                [table_name, index_name],
+            )
+            if cursor.fetchone()[0] > 0:
+                cursor.execute(f"DROP INDEX `{index_name}` ON `{table_name}`")
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('specify', '0048_add_tree_performance_indexes'),
+    ]
+
+    operations = [
+        migrations.RunPython(drop_old_indexes, migrations.RunPython.noop),
+    ]

--- a/specifyweb/specify/tests/test_performance_indexes.py
+++ b/specifyweb/specify/tests/test_performance_indexes.py
@@ -1,0 +1,176 @@
+"""
+Tests that performance-critical indexes exist on tree tables and large lookup tables.
+
+These indexes are added by migration 0048_add_tree_performance_indexes.
+The tests query information_schema.statistics to verify index existence,
+so they work against any MySQL/MariaDB backend (including the test DB).
+"""
+
+from django.db import connection
+from django.test import TransactionTestCase
+
+
+def index_exists(table_name: str, column_names: list[str]) -> bool:
+    """Check if an index exists covering the given column(s) on a table.
+
+    For compound indexes, verifies all columns are part of the same index
+    in the correct positional order.
+    """
+    db_name = connection.settings_dict['NAME']
+    with connection.cursor() as cursor:
+        cursor.execute(
+            """
+            SELECT INDEX_NAME, SEQ_IN_INDEX, COLUMN_NAME
+            FROM information_schema.statistics
+            WHERE TABLE_SCHEMA = %s
+              AND LOWER(TABLE_NAME) = LOWER(%s)
+              AND LOWER(COLUMN_NAME) IN ({})
+            ORDER BY INDEX_NAME, SEQ_IN_INDEX
+            """.format(','.join(['LOWER(%s)'] * len(column_names))),
+            [db_name, table_name] + column_names,
+        )
+        rows = cursor.fetchall()
+
+    if len(column_names) == 1:
+        return len(rows) > 0
+
+    # For compound indexes, group by index name and check column order
+    from collections import defaultdict
+    indexes = defaultdict(list)
+    for idx_name, seq, col in rows:
+        indexes[idx_name].append((seq, col.lower()))
+
+    target = [c.lower() for c in column_names]
+    for cols in indexes.values():
+        cols_sorted = [c for _, c in sorted(cols)]
+        if cols_sorted[:len(target)] == target:
+            return True
+    return False
+
+
+# -- Tree node indexes (NodeNumber, HighestChildNodeNumber) --
+
+class TestTaxonIndexes(TransactionTestCase):
+    def test_nodenumber_index(self):
+        self.assertTrue(
+            index_exists('taxon', ['NodeNumber']),
+            "Missing index on taxon.NodeNumber",
+        )
+
+    def test_highestchildnodenumber_index(self):
+        self.assertTrue(
+            index_exists('taxon', ['HighestChildNodeNumber']),
+            "Missing index on taxon.HighestChildNodeNumber",
+        )
+
+    def test_rankid_index(self):
+        self.assertTrue(
+            index_exists('taxon', ['RankID']),
+            "Missing index on taxon.RankID",
+        )
+
+
+class TestGeographyIndexes(TransactionTestCase):
+    def test_nodenumber_index(self):
+        self.assertTrue(
+            index_exists('geography', ['NodeNumber']),
+            "Missing index on geography.NodeNumber",
+        )
+
+    def test_highestchildnodenumber_index(self):
+        self.assertTrue(
+            index_exists('geography', ['HighestChildNodeNumber']),
+            "Missing index on geography.HighestChildNodeNumber",
+        )
+
+
+class TestStorageIndexes(TransactionTestCase):
+    def test_nodenumber_index(self):
+        self.assertTrue(
+            index_exists('storage', ['NodeNumber']),
+            "Missing index on storage.NodeNumber",
+        )
+
+    def test_highestchildnodenumber_index(self):
+        self.assertTrue(
+            index_exists('storage', ['HighestChildNodeNumber']),
+            "Missing index on storage.HighestChildNodeNumber",
+        )
+
+
+class TestGeologictimeperiodIndexes(TransactionTestCase):
+    def test_nodenumber_index(self):
+        self.assertTrue(
+            index_exists('geologictimeperiod', ['NodeNumber']),
+            "Missing index on geologictimeperiod.NodeNumber",
+        )
+
+    def test_highestchildnodenumber_index(self):
+        self.assertTrue(
+            index_exists('geologictimeperiod', ['HighestChildNodeNumber']),
+            "Missing index on geologictimeperiod.HighestChildNodeNumber",
+        )
+
+
+class TestLithostratIndexes(TransactionTestCase):
+    def test_nodenumber_index(self):
+        self.assertTrue(
+            index_exists('lithostrat', ['NodeNumber']),
+            "Missing index on lithostrat.NodeNumber",
+        )
+
+    def test_highestchildnodenumber_index(self):
+        self.assertTrue(
+            index_exists('lithostrat', ['HighestChildNodeNumber']),
+            "Missing index on lithostrat.HighestChildNodeNumber",
+        )
+
+
+class TestTectonicunitIndexes(TransactionTestCase):
+    def test_nodenumber_index(self):
+        self.assertTrue(
+            index_exists('tectonicunit', ['NodeNumber']),
+            "Missing index on tectonicunit.NodeNumber",
+        )
+
+    def test_highestchildnodenumber_index(self):
+        self.assertTrue(
+            index_exists('tectonicunit', ['HighestChildNodeNumber']),
+            "Missing index on tectonicunit.HighestChildNodeNumber",
+        )
+
+
+# -- GUID indexes --
+
+class TestLocalityGuidIndex(TransactionTestCase):
+    def test_guid_index(self):
+        self.assertTrue(
+            index_exists('locality', ['GUID']),
+            "Missing index on locality.GUID",
+        )
+
+
+class TestCollectionobjectGuidIndex(TransactionTestCase):
+    def test_guid_index(self):
+        self.assertTrue(
+            index_exists('collectionobject', ['GUID']),
+            "Missing index on collectionobject.GUID",
+        )
+
+
+# -- Compound and boolean indexes --
+
+class TestDeterminationCompoundIndex(TransactionTestCase):
+    def test_iscurrent_collectionmemberid_index(self):
+        self.assertTrue(
+            index_exists('determination', ['IsCurrent', 'CollectionMemberID']),
+            "Missing compound index on determination(IsCurrent, CollectionMemberID)",
+        )
+
+
+class TestCollectionobjectgroupjoinIsPrimaryIndex(TransactionTestCase):
+    def test_isprimary_index(self):
+        self.assertTrue(
+            index_exists('collectionobjectgroupjoin', ['IsPrimary']),
+            "Missing index on collectionobjectgroupjoin.IsPrimary",
+        )

--- a/specifyweb/specify/tests/test_tectonicunit_indexes.py
+++ b/specifyweb/specify/tests/test_tectonicunit_indexes.py
@@ -1,0 +1,27 @@
+from django.test import TestCase
+from django.db import connection
+
+
+class TectonicUnitIndexTests(TestCase):
+    """Verify that TectonicUnit has BTREE indexes on Name, FullName, and GUID."""
+
+    def _get_index_names(self, table: str) -> set[str]:
+        with connection.cursor() as cursor:
+            cursor.execute(
+                "SELECT index_name FROM information_schema.statistics "
+                "WHERE table_schema = DATABASE() AND table_name = %s",
+                [table],
+            )
+            return {row[0] for row in cursor.fetchall()}
+
+    def test_name_index_exists(self):
+        indexes = self._get_index_names('tectonicunit')
+        self.assertIn('TectonicUnitNameIDX', indexes)
+
+    def test_fullname_index_exists(self):
+        indexes = self._get_index_names('tectonicunit')
+        self.assertIn('TectonicUnitFullNameIDX', indexes)
+
+    def test_guid_index_exists(self):
+        indexes = self._get_index_names('tectonicunit')
+        self.assertIn('TectonicUnitGuidIDX', indexes)


### PR DESCRIPTION
Fixes #7482
Contributed by @foozleface

All six tree tables (Taxon, Geography, Storage, GeologicTimePeriod, LithoStrat, TectonicUnit) lack indexes on `NodeNumber` and `HighestChildNodeNumber`. Tree operations use `BETWEEN` queries on these columns, causing full table scans on tables with 200K+ rows. This PR adds the missing indexes via Django migrations, along with GUID indexes on Locality and CollectionObject, compound indexes on Determination, and indexes on CollectionObjectGroupJoin.

> **Note:** Migration numbering (0046/0048/0049) assumes upstream PR #7878 merges first. May need renumbering depending on merge order.

### Implementation
- Add migration `0046_add_tectonicunit_indexes` for TectonicUnit name, fullname, and GUID indexes
- Add migration `0048_add_tree_performance_indexes` with ~20 indexes: NodeNumber and HighestChildNodeNumber on all six tree tables, RankID on Taxon, GUID on Locality and CollectionObject, compound indexes on Determination (collectionobject + iscurrent, taxon + iscurrent), and CollectionObjectGroupJoin (parentcog + isprimary)
- Add migration `0049_fix_index_definitions` to correct any index definition issues
- Include tests verifying the indexes exist after migration

### Testing instructions
- [ ] Run `python manage.py migrate` and verify all three migrations apply without errors
- [ ] Confirm indexes exist: `SHOW INDEX FROM taxon WHERE Key_name LIKE '%NodeNum%'`
- [ ] Run `EXPLAIN SELECT * FROM taxon WHERE NodeNumber BETWEEN 1 AND 1000` and verify it uses the new index (type: range, not ALL)
- [ ] Run the test suite: `python manage.py test specifyweb.specify.tests.test_performance_indexes specifyweb.specify.tests.test_tectonicunit_indexes`