### PR TITLE
Handle bad broker request gracefully

### DIFF
--- a/specifyweb/frontend/js_src/lib/components/SpecifyNetwork/Overlay.tsx
+++ b/specifyweb/frontend/js_src/lib/components/SpecifyNetwork/Overlay.tsx
@@ -17,7 +17,9 @@ import { SpecifyNetworkOccurrence, SpecifyNetworkSpecies } from './Table';
 
 export type BrokerData = {
   readonly occurrence: RA<BrokerRecord> | undefined;
+  readonly occurrenceUnavailable: boolean;
   readonly species: RA<BrokerRecord> | undefined;
+  readonly speciesUnavailable: boolean;
   readonly taxonId: number | false | undefined;
   readonly speciesName: LocalizedString | undefined;
 };
@@ -55,7 +57,8 @@ export function useBrokerData(
   guid: string | undefined,
   taxonId: number | false | undefined
 ): BrokerData {
-  const occurrence = useOccurrence(guid);
+  const occurrenceResult = useOccurrence(guid);
+  const occurrence = occurrenceResult?.records;
   const occurrenceSpeciesName = React.useMemo(
     () =>
       // Prefer the species name from an aggregator over local as it is more trustworthy
@@ -66,7 +69,8 @@ export function useBrokerData(
           localSpecies,
     [occurrence, localSpecies]
   );
-  const species = useSpecies(occurrenceSpeciesName);
+  const speciesResult = useSpecies(occurrenceSpeciesName);
+  const species = speciesResult?.records;
   const speciesName = React.useMemo(
     () =>
       (typeof species === 'object'
@@ -78,12 +82,22 @@ export function useBrokerData(
   return React.useMemo(
     () => ({
       occurrence,
+      occurrenceUnavailable: occurrenceResult?.isUnavailable ?? false,
       species,
+      speciesUnavailable: speciesResult?.isUnavailable ?? false,
       speciesName,
       taxonId,
       guid,
     }),
-    [occurrence, species, speciesName, taxonId, guid]
+    [
+      occurrence,
+      occurrenceResult?.isUnavailable,
+      species,
+      speciesResult?.isUnavailable,
+      speciesName,
+      taxonId,
+      guid,
+    ]
   );
 }
 
@@ -120,6 +134,22 @@ export function NoBrokerData({
       onClose={handleClose}
     >
       {specifyNetworkText.noDataErrorDescription()}
+    </Dialog>
+  );
+}
+
+export function UnavailableBrokerData({
+  onClose: handleClose,
+}: {
+  readonly onClose: () => void;
+}): JSX.Element {
+  return (
+    <Dialog
+      buttons={commonText.close()}
+      header={specifyNetworkText.brokerUnavailable()}
+      onClose={handleClose}
+    >
+      {specifyNetworkText.brokerUnavailableDescription()}
     </Dialog>
   );
 }

--- a/specifyweb/frontend/js_src/lib/components/SpecifyNetwork/Table.tsx
+++ b/specifyweb/frontend/js_src/lib/components/SpecifyNetwork/Table.tsx
@@ -10,17 +10,20 @@ import type { BrokerRecord } from './fetchers';
 import { extractBrokerField } from './fetchers';
 import type { BrokerData } from './Overlay';
 import { NoBrokerData } from './Overlay';
+import { UnavailableBrokerData } from './Overlay';
 import { SpecifyNetworkResponse } from './Response';
 
 export function SpecifyNetworkOccurrence({
-  data: { occurrence },
+  data: { occurrence, occurrenceUnavailable },
   onClose: handleClose,
 }: {
   readonly data: BrokerData;
   readonly onClose: () => void;
 }): JSX.Element {
   return typeof occurrence === 'object' ? (
-    occurrence.length === 0 ? (
+    occurrenceUnavailable ? (
+      <UnavailableBrokerData onClose={handleClose} />
+    ) : occurrence.length === 0 ? (
       <NoBrokerData onClose={handleClose} />
     ) : (
       <Dialog
@@ -98,7 +101,7 @@ function OccurrenceTable({
 }
 
 export function SpecifyNetworkSpecies({
-  data: { species, speciesName },
+  data: { species, speciesName, speciesUnavailable },
   onClose: handleClose,
 }: {
   readonly data: BrokerData;
@@ -106,6 +109,8 @@ export function SpecifyNetworkSpecies({
 }): JSX.Element {
   return species === undefined ? (
     <LoadingScreen />
+  ) : speciesUnavailable ? (
+    <UnavailableBrokerData onClose={handleClose} />
   ) : species.length === 0 ? (
     <NoBrokerData onClose={handleClose} />
   ) : (

--- a/specifyweb/frontend/js_src/lib/components/SpecifyNetwork/fetchers.ts
+++ b/specifyweb/frontend/js_src/lib/components/SpecifyNetwork/fetchers.ts
@@ -12,7 +12,7 @@ import {
 
 export const fetchOccurrence = async (
   guid: string
-): Promise<RA<BrokerRecord> | undefined> =>
+): Promise<BrokerFetchResult> =>
   fetchFromEndpoint(
     `${brokerUrl}/api/v1/occ/?occid=${guid}`,
     occurrenceDataProviders
@@ -21,25 +21,36 @@ export const fetchOccurrence = async (
 const fetchFromEndpoint = async (
   url: string,
   providers: RA<string>
-): Promise<RA<BrokerRecord>> =>
+): Promise<BrokerFetchResult> =>
   Promise.all(
     providers.map(async (provider) =>
       fetchFromBroker(`${url}&provider=${provider}`)
     )
-  ).then((responses) =>
-    Array.from(filterArray(responses)).sort(
-      sortFunction(({ provider }) => providers.indexOf(provider.code))
-    )
-  );
+  ).then((responses) => ({
+    records: Array.from(
+      filterArray(responses.map(({ record }) => record))
+    ).sort(sortFunction(({ provider }) => providers.indexOf(provider.code))),
+    isUnavailable:
+      providers.length > 0 && responses.every(({ failed }) => failed),
+  }));
 
 const fetchFromBroker = async (
   requestUrl: string
-): Promise<BrokerRecord | undefined> =>
+): Promise<{
+  readonly record: BrokerRecord | undefined;
+  readonly failed: boolean;
+}> =>
   ajax<RawBrokerResponse>(requestUrl, {
+    errorMode: 'silent',
     headers: {
       Accept: 'application/json',
     },
-  }).then(({ data }) => extractResponseRecord(data));
+  })
+    .then(({ data }) => ({
+      record: extractResponseRecord(data),
+      failed: false,
+    }))
+    .catch(() => ({ record: undefined, failed: true }));
 
 const extractResponseRecord = (
   response: RawBrokerResponse
@@ -67,11 +78,16 @@ export function validateBrokerResponse(response: {
 
 export const fetchName = async (
   speciesName: string
-): Promise<RA<BrokerRecord>> =>
+): Promise<BrokerFetchResult> =>
   fetchFromEndpoint(
     `${brokerUrl}/api/v1/name/?namestr=${speciesName}`,
     speciesDataProviders
   );
+
+export type BrokerFetchResult = {
+  readonly records: RA<BrokerRecord>;
+  readonly isUnavailable: boolean;
+};
 
 export type BrokerRecord = {
   readonly provider: BrokerProvider;

--- a/specifyweb/frontend/js_src/lib/components/SpecifyNetwork/hooks.tsx
+++ b/specifyweb/frontend/js_src/lib/components/SpecifyNetwork/hooks.tsx
@@ -12,7 +12,8 @@ const emptyBrokerFetchResult: BrokerFetchResult = {
 export function useOccurrence(guid = ''): BrokerFetchResult | undefined {
   return useAsyncState(
     React.useCallback(
-      async () => (guid === '' ? emptyBrokerFetchResult : fetchOccurrence(guid)),
+      async () =>
+        guid === '' ? emptyBrokerFetchResult : fetchOccurrence(guid),
       [guid]
     ),
     false

--- a/specifyweb/frontend/js_src/lib/components/SpecifyNetwork/hooks.tsx
+++ b/specifyweb/frontend/js_src/lib/components/SpecifyNetwork/hooks.tsx
@@ -1,24 +1,29 @@
 import React from 'react';
 
 import { useAsyncState } from '../../hooks/useAsyncState';
-import type { RA } from '../../utils/types';
-import type { BrokerRecord } from './fetchers';
+import type { BrokerFetchResult } from './fetchers';
 import { fetchName, fetchOccurrence } from './fetchers';
 
-export function useOccurrence(guid = ''): RA<BrokerRecord> | undefined {
+const emptyBrokerFetchResult: BrokerFetchResult = {
+  records: [],
+  isUnavailable: false,
+};
+
+export function useOccurrence(guid = ''): BrokerFetchResult | undefined {
   return useAsyncState(
     React.useCallback(
-      async () => (guid === '' ? [] : fetchOccurrence(guid)),
+      async () => (guid === '' ? emptyBrokerFetchResult : fetchOccurrence(guid)),
       [guid]
     ),
     false
   )[0];
 }
 
-export function useSpecies(speciesName = ''): RA<BrokerRecord> | undefined {
+export function useSpecies(speciesName = ''): BrokerFetchResult | undefined {
   return useAsyncState(
     React.useCallback(
-      async () => (speciesName === '' ? [] : fetchName(speciesName)),
+      async () =>
+        speciesName === '' ? emptyBrokerFetchResult : fetchName(speciesName),
       [speciesName]
     ),
     false

--- a/specifyweb/frontend/js_src/lib/localization/specifyNetwork.ts
+++ b/specifyweb/frontend/js_src/lib/localization/specifyNetwork.ts
@@ -54,6 +54,13 @@ export const specifyNetworkText = createDictionary({
     'pt-br': 'Por favor, tente pesquisar um registro diferente.',
     'hr-hr': 'Pokušajte pretražiti drugi zapis',
   },
+  brokerUnavailable: {
+    'en-us': 'Specify Network unavailable',
+  },
+  brokerUnavailableDescription: {
+    'en-us':
+      'Specify could not connect to Specify Network. Please try again later.',
+  },
   dataQuality: {
     'en-us': 'Data Quality',
     'de-ch': 'Datenqualität',


### PR DESCRIPTION
Fixes #7946

Make sure the Specify Network front-end broker outages do not crash the app.

When requests to `https://broker.spcoco.org` fail, Specify now degrades gracefully instead of surfacing an application error. If a user explicitly opens a Specify Network occurrence or taxon view while the broker is unavailable, they now see a dialog box explaining that Specify Network is unavailable.  No error toasts!

### Checklist

- [x] Self-review the PR after opening it to make sure the changes look good and
      self-explanatory (or properly documented)
- [x] Add relevant issue to release milestone
- [ ] Add pr to documentation list

### Testing instructions

- Open an existing collection object form page.
- [x] See that the page loads without any error toasts.
- Click on the Specify Network CO button at the top of the page.
- [x] See that the pop up window either loads with the information, or the pop gives a message that it cannot connect.  Either way, there should be no error toasts.
- [x] Repeat with the Specify Network Taxon button.

<img width="769" height="524" alt="image" src="https://github.com/user-attachments/assets/24be301e-8380-49cf-98cd-e5b9b1ed01e3" />

