### PR TITLE
Fix BatchIdentify readonly array mutations in frontend typecheck

### DIFF
--- a/specifyweb/frontend/js_src/lib/components/AppResources/__tests__/__snapshots__/AppResourceDownload.test.tsx.snap
+++ b/specifyweb/frontend/js_src/lib/components/AppResources/__tests__/__snapshots__/AppResourceDownload.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`AppResourceDownload simple render 1`] = `
 <DocumentFragment>

--- a/specifyweb/frontend/js_src/lib/components/AppResources/__tests__/__snapshots__/AppResourceEditButton.test.tsx.snap
+++ b/specifyweb/frontend/js_src/lib/components/AppResources/__tests__/__snapshots__/AppResourceEditButton.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`AppResourceEditButton simple render 1`] = `
 <DocumentFragment>

--- a/specifyweb/frontend/js_src/lib/components/AppResources/__tests__/__snapshots__/AppResourceLoad.test.tsx.snap
+++ b/specifyweb/frontend/js_src/lib/components/AppResources/__tests__/__snapshots__/AppResourceLoad.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`AppResourceLoad simple render 1`] = `
 <DocumentFragment>

--- a/specifyweb/frontend/js_src/lib/components/AppResources/__tests__/__snapshots__/AppResourcesAside.test.tsx.snap
+++ b/specifyweb/frontend/js_src/lib/components/AppResources/__tests__/__snapshots__/AppResourcesAside.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`AppResourcesAside (expanded case) expanded case 1`] = `
 <DocumentFragment>

--- a/specifyweb/frontend/js_src/lib/components/AppResources/__tests__/__snapshots__/AppResourcesFilters.test.tsx.snap
+++ b/specifyweb/frontend/js_src/lib/components/AppResources/__tests__/__snapshots__/AppResourcesFilters.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`AppResourcesFilters simple render 1`] = `
 <DocumentFragment>

--- a/specifyweb/frontend/js_src/lib/components/AppResources/__tests__/__snapshots__/AppResourcesTab.test.tsx.snap
+++ b/specifyweb/frontend/js_src/lib/components/AppResources/__tests__/__snapshots__/AppResourcesTab.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`AppResourcesTab dialog render 1`] = `
 <div

--- a/specifyweb/frontend/js_src/lib/components/AppResources/__tests__/__snapshots__/Tabs.test.tsx.snap
+++ b/specifyweb/frontend/js_src/lib/components/AppResources/__tests__/__snapshots__/Tabs.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Tabs first tab selected, and then second 1`] = `
 <DocumentFragment>

--- a/specifyweb/frontend/js_src/lib/components/AppResources/__tests__/__snapshots__/buildAppResourceConformation.test.ts.snap
+++ b/specifyweb/frontend/js_src/lib/components/AppResources/__tests__/__snapshots__/buildAppResourceConformation.test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`buildAppResourceConformation multi-level completely empty tree 1`] = `
 [

--- a/specifyweb/frontend/js_src/lib/components/AppResources/__tests__/__snapshots__/useResourcesTree.test.ts.snap
+++ b/specifyweb/frontend/js_src/lib/components/AppResources/__tests__/__snapshots__/useResourcesTree.test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`useResourcesTree all appresource dir 1`] = `
 [

--- a/specifyweb/frontend/js_src/lib/components/Atoms/__tests__/__snapshots__/Button.test.tsx.snap
+++ b/specifyweb/frontend/js_src/lib/components/Atoms/__tests__/__snapshots__/Button.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Button.BorderedGray renders without errors 1`] = `
 <DocumentFragment>

--- a/specifyweb/frontend/js_src/lib/components/Atoms/__tests__/__snapshots__/DataEntry.test.ts.snap
+++ b/specifyweb/frontend/js_src/lib/components/Atoms/__tests__/__snapshots__/DataEntry.test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[` renders without errors 1`] = `
 <DocumentFragment>

--- a/specifyweb/frontend/js_src/lib/components/Atoms/__tests__/__snapshots__/Form.test.tsx.snap
+++ b/specifyweb/frontend/js_src/lib/components/Atoms/__tests__/__snapshots__/Form.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<Form> removes notSubmitted class name on submit 1`] = `
 <DocumentFragment>

--- a/specifyweb/frontend/js_src/lib/components/Atoms/__tests__/__snapshots__/Link.test.ts.snap
+++ b/specifyweb/frontend/js_src/lib/components/Atoms/__tests__/__snapshots__/Link.test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Link.BorderedGray renders without errors 1`] = `
 <DocumentFragment>

--- a/specifyweb/frontend/js_src/lib/components/Atoms/__tests__/__snapshots__/Submit.test.ts.snap
+++ b/specifyweb/frontend/js_src/lib/components/Atoms/__tests__/__snapshots__/Submit.test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Submit.Danger renders without errors 1`] = `
 <DocumentFragment>

--- a/specifyweb/frontend/js_src/lib/components/Atoms/__tests__/__snapshots__/index.test.tsx.snap
+++ b/specifyweb/frontend/js_src/lib/components/Atoms/__tests__/__snapshots__/index.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Can use <summary> as a controlled component 1`] = `
 <DocumentFragment>

--- a/specifyweb/frontend/js_src/lib/components/Attachments/__tests__/__snapshots__/AttachmentCell.test.tsx.snap
+++ b/specifyweb/frontend/js_src/lib/components/Attachments/__tests__/__snapshots__/AttachmentCell.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`AttachmentCell simple render 1`] = `
 <DocumentFragment>

--- a/specifyweb/frontend/js_src/lib/components/Attachments/__tests__/__snapshots__/ChronoChart.test.tsx.snap
+++ b/specifyweb/frontend/js_src/lib/components/Attachments/__tests__/__snapshots__/ChronoChart.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`ChronoChart dialog open and close 1`] = `
 <div

--- a/specifyweb/frontend/js_src/lib/components/Attachments/__tests__/__snapshots__/UploadAttachment.test.tsx.snap
+++ b/specifyweb/frontend/js_src/lib/components/Attachments/__tests__/__snapshots__/UploadAttachment.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`UploadAttachment simple render 1`] = `
 <DocumentFragment>

--- a/specifyweb/frontend/js_src/lib/components/Attachments/__tests__/__snapshots__/utils.test.ts.snap
+++ b/specifyweb/frontend/js_src/lib/components/Attachments/__tests__/__snapshots__/utils.test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`allTablesWithAttachments 1`] = `
 [

--- a/specifyweb/frontend/js_src/lib/components/AttachmentsBulkImport/__tests__/__snapshots__/utils.test.ts.snap
+++ b/specifyweb/frontend/js_src/lib/components/AttachmentsBulkImport/__tests__/__snapshots__/utils.test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`reconstruct deleting attachment spec 1`] = `
 [

--- a/specifyweb/frontend/js_src/lib/components/BatchIdentify/index.tsx
+++ b/specifyweb/frontend/js_src/lib/components/BatchIdentify/index.tsx
@@ -170,7 +170,7 @@ const fetchRecordSetCollectionObjectIds = async (
   const limit = 2000;
   let offset = 0;
   let totalCount = 0;
-  const collectionObjectIds: number[] = [];
+  const collectionObjectIds: readonly number[] = [];
 
   do {
     const { records, totalCount: fetchedTotalCount } = await fetchCollection(

--- a/specifyweb/frontend/js_src/lib/components/BatchIdentify/index.tsx
+++ b/specifyweb/frontend/js_src/lib/components/BatchIdentify/index.tsx
@@ -170,7 +170,7 @@ const fetchRecordSetCollectionObjectIds = async (
   const limit = 2000;
   let offset = 0;
   let totalCount = 0;
-  const collectionObjectIds: readonly number[] = [];
+  const collectionObjectIds: number[] = [];
 
   do {
     const { records, totalCount: fetchedTotalCount } = await fetchCollection(

--- a/specifyweb/frontend/js_src/lib/components/BatchIdentify/parseCatalogNumbers.ts
+++ b/specifyweb/frontend/js_src/lib/components/BatchIdentify/parseCatalogNumbers.ts
@@ -20,7 +20,7 @@ export const parseCatalogNumberEntries = (rawEntries: string): RA<string> =>
     .filter((entry) => entry.length > 0);
 
 export const tokenizeCatalogEntry = (entry: string): RA<CatalogToken> => {
-  const tokens: CatalogToken[] = [];
+  const tokens: readonly CatalogToken[] = [];
   let currentNumber = '';
 
   for (const character of entry) {
@@ -62,7 +62,7 @@ export const parseCatalogNumberRanges = (
   entries: RA<string>
 ): RA<readonly [number, number]> =>
   entries.flatMap((entry) => {
-    const ranges: Array<readonly [number, number]> = [];
+    const ranges: readonly (readonly [number, number])[] = [];
     const yearMatches = Array.from(
       entry.matchAll(entryYearCatalogNumberRe)
     ).filter((match) =>

--- a/specifyweb/frontend/js_src/lib/components/BatchIdentify/parseCatalogNumbers.ts
+++ b/specifyweb/frontend/js_src/lib/components/BatchIdentify/parseCatalogNumbers.ts
@@ -20,7 +20,7 @@ export const parseCatalogNumberEntries = (rawEntries: string): RA<string> =>
     .filter((entry) => entry.length > 0);
 
 export const tokenizeCatalogEntry = (entry: string): RA<CatalogToken> => {
-  const tokens: readonly CatalogToken[] = [];
+  const tokens: CatalogToken[] = [];
   let currentNumber = '';
 
   for (const character of entry) {
@@ -62,7 +62,7 @@ export const parseCatalogNumberRanges = (
   entries: RA<string>
 ): RA<readonly [number, number]> =>
   entries.flatMap((entry) => {
-    const ranges: readonly (readonly [number, number])[] = [];
+    const ranges: Array<readonly [number, number]> = [];
     const yearMatches = Array.from(
       entry.matchAll(entryYearCatalogNumberRe)
     ).filter((match) =>

--- a/specifyweb/frontend/js_src/lib/components/DataModel/__tests__/__snapshots__/specifyTable.test.ts.snap
+++ b/specifyweb/frontend/js_src/lib/components/DataModel/__tests__/__snapshots__/specifyTable.test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`fields are loaded 1`] = `
 [

--- a/specifyweb/frontend/js_src/lib/components/FieldFormatters/__tests__/__snapshots__/index.test.ts.snap
+++ b/specifyweb/frontend/js_src/lib/components/FieldFormatters/__tests__/__snapshots__/index.test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`field formatters are fetched and parsed correctly 1`] = `
 {

--- a/specifyweb/frontend/js_src/lib/components/FormEditor/__tests__/__snapshots__/createView.test.ts.snap
+++ b/specifyweb/frontend/js_src/lib/components/FormEditor/__tests__/__snapshots__/createView.test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Tables with form tables computed correctly 1`] = `
 [

--- a/specifyweb/frontend/js_src/lib/components/FormEditor/__tests__/__snapshots__/fetchAllViews.test.tsx.snap
+++ b/specifyweb/frontend/js_src/lib/components/FormEditor/__tests__/__snapshots__/fetchAllViews.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`fetchAllViews 1`] = `
 {

--- a/specifyweb/frontend/js_src/lib/components/FormEditor/__tests__/__snapshots__/index.test.ts.snap
+++ b/specifyweb/frontend/js_src/lib/components/FormEditor/__tests__/__snapshots__/index.test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Can edit a form definition 1`] = `
 {

--- a/specifyweb/frontend/js_src/lib/components/FormEditor/__tests__/__snapshots__/viewSpec.test.ts.snap
+++ b/specifyweb/frontend/js_src/lib/components/FormEditor/__tests__/__snapshots__/viewSpec.test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Can edit form definition 1`] = `
 "<?xml version='1.0' encoding='UTF-8'?>

--- a/specifyweb/frontend/js_src/lib/components/FormMeta/__tests__/__snapshots__/CarryForward.test.ts.snap
+++ b/specifyweb/frontend/js_src/lib/components/FormMeta/__tests__/__snapshots__/CarryForward.test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`dependentFields 1`] = `
 {

--- a/specifyweb/frontend/js_src/lib/components/FormPlugins/__tests__/__snapshots__/PartialDateUi.test.tsx.snap
+++ b/specifyweb/frontend/js_src/lib/components/FormPlugins/__tests__/__snapshots__/PartialDateUi.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`PartialDateUi renders without errors 1`] = `
 <DocumentFragment>

--- a/specifyweb/frontend/js_src/lib/components/Formatters/__tests__/__snapshots__/formatters.test.ts.snap
+++ b/specifyweb/frontend/js_src/lib/components/Formatters/__tests__/__snapshots__/formatters.test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Formatters are fetched and parsed correctly 1`] = `
 {

--- a/specifyweb/frontend/js_src/lib/components/InitialContext/__tests__/__snapshots__/remotePrefs.test.ts.snap
+++ b/specifyweb/frontend/js_src/lib/components/InitialContext/__tests__/__snapshots__/remotePrefs.test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`fetches and parses remotePrefs correctly 1`] = `
 {

--- a/specifyweb/frontend/js_src/lib/components/InitialContext/__tests__/__snapshots__/treeRanks.test.ts.snap
+++ b/specifyweb/frontend/js_src/lib/components/InitialContext/__tests__/__snapshots__/treeRanks.test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Get tree definition for the Geography tree 1`] = `
 [

--- a/specifyweb/frontend/js_src/lib/components/Merging/__tests__/__snapshots__/autoMerge.test.ts.snap
+++ b/specifyweb/frontend/js_src/lib/components/Merging/__tests__/__snapshots__/autoMerge.test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`autoMerge cautious 1`] = `
 {

--- a/specifyweb/frontend/js_src/lib/components/QueryBuilder/__tests__/__snapshots__/fromTree.test.ts.snap
+++ b/specifyweb/frontend/js_src/lib/components/QueryBuilder/__tests__/__snapshots__/fromTree.test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`queryFromTree 1`] = `
 [

--- a/specifyweb/frontend/js_src/lib/components/QueryComboBox/__tests__/__snapshots__/useTypeSearch.test.ts.snap
+++ b/specifyweb/frontend/js_src/lib/components/QueryComboBox/__tests__/__snapshots__/useTypeSearch.test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`type searches are fetched and parsed correctly 1`] = `
 [

--- a/specifyweb/frontend/js_src/lib/components/WebLinks/__tests__/__snapshots__/index.test.ts.snap
+++ b/specifyweb/frontend/js_src/lib/components/WebLinks/__tests__/__snapshots__/index.test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`weblinks are fetched and parsed correctly 1`] = `
 {

--- a/specifyweb/frontend/js_src/lib/utils/__tests__/__snapshots__/fonts.test.ts.snap
+++ b/specifyweb/frontend/js_src/lib/utils/__tests__/__snapshots__/fonts.test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Unavailable fonts are filterd out 1`] = `
 [


### PR DESCRIPTION
Fixes #7952

Did a few things to fix the errors occurring in GitHub Actions:
- Fixed the `BatchIdentify` GitHub Actions typecheck failure caused by calling `push()` on arrays typed as readonly.
- Kept the internal accumulator arrays mutable while preserving readonly return types.
- Updated the affected BatchIdentify helpers in the catalog number parser and record set collection object ID loader.

### Checklist

- [x] Self-review the PR after opening it to make sure the changes look good and
      self-explanatory (or properly documented)
- [x] Add relevant issue to release milestone
- [ ] Add pr to documentation list


### Testing instructions

- [x] Just need to make sure that all the front-end github actions complete successfully.
