### PR TITLE
Add Norwegian Bokmål to Specify

### DIFF
--- a/specifyweb/frontend/js_src/lib/localization/utils/config.ts
+++ b/specifyweb/frontend/js_src/lib/localization/utils/config.ts
@@ -24,6 +24,7 @@ export const languageCodeMapper = {
   'de-ch': 'de_CH',
   'pt-br': 'pt_BR',
   'hr-hr': 'hr',
+  'nb': 'nb_NO'
 } as const;
 
 export const languages = Object.keys(languageCodeMapper);

--- a/specifyweb/settings/__init__.py
+++ b/specifyweb/settings/__init__.py
@@ -141,6 +141,7 @@ LANGUAGES = [
     ('de-ch', 'deutsch (schweiz)'),
     ('pt-br', 'português (brasil)'),
     ('hr-hr', 'hrvatski'),
+    ('nb', 'Norsk Bokmål'),
 ]
 
 SITE_ID = 1


### PR DESCRIPTION
Fixes #7909 

Adds weblate translation configuration for Norwegian Bokmål

https://github.com/specify/specify7/tree/main/specifyweb/frontend/js_src/lib/localization#adding-new-language
> Push the changes to main branch (weblate is setup to only look at that branch).
> Weblate should do automatic translation for the language using Google Translate.

### Checklist

- [ ] Self-review the PR after opening it to make sure the changes look good and
      self-explanatory (or properly documented)
- [ ] Add relevant issue to release milestone
- [ ] Add pr to documentation list
- [ ] Add automated tests
- [ ] Add a reverse migration if a migration is present in the PR

### Testing instructions

- Translations should be updated after merging with main
