### PR TITLE
Avoid MariaDB join explosion for disambiguated taxon QB results

### DIFF
--- a/specifyweb/backend/stored_queries/query_construct.py
+++ b/specifyweb/backend/stored_queries/query_construct.py
@@ -45,36 +45,30 @@ class QueryConstruct(namedtuple('QueryConstruct', 'collection objectformatter qu
         table,
         next_join_path,
         treedefitem_params,
-        max_depth,
     ):
         field = next_join_path[0]
         treedefitem_column = table.name + 'TreeDefItemID'
+        treedef_column = table.name + 'TreeDefID'
         correlation_target = sa_inspect(start_alias).selectable
+        start_node_number = getattr(start_alias, "nodeNumber")
 
-        ancestors = [orm.aliased(mapped_cls)]
-        for _ in range(max_depth - 1):
-            ancestors.append(orm.aliased(mapped_cls))
-
-        cases = []
-        for ancestor in ancestors:
-            orm_field = getattr(ancestor, field.name)
-            for treedefitem_param in treedefitem_params:
-                cases.append(
-                    (
-                        getattr(ancestor, treedefitem_column) == treedefitem_param,
-                        orm_field,
-                    )
-                )
-
-        subquery = sql.select(sql.case(cases)).select_from(ancestors[0])
-        for parent, ancestor in zip(ancestors, ancestors[1:]):
-            subquery = subquery.outerjoin(ancestor, parent.ParentID == ancestor._id)
-
-        column = (
-            subquery.where(ancestors[0]._id == start_alias._id)
-            .correlate(correlation_target)
-            .scalar_subquery()
+        ancestor = orm.aliased(mapped_cls)
+        subquery = (
+            sql.select(getattr(ancestor, field.name))
+            .select_from(ancestor)
+            .where(
+                getattr(ancestor, treedefitem_column).in_(tuple(treedefitem_params)),
+                getattr(ancestor, treedef_column) == getattr(start_alias, treedef_column),
+                start_node_number.between(
+                    getattr(ancestor, "nodeNumber"),
+                    getattr(ancestor, "highestChildNodeNumber"),
+                ),
+            )
+            .order_by(getattr(ancestor, "nodeNumber").desc())
+            .limit(1)
         )
+
+        column = subquery.correlate(correlation_target).scalar_subquery()
         return column, field, table
 
     def handle_tree_field(self, node, table, tree_rank: TreeRankQuery, next_join_path, current_field_spec: QueryFieldSpec):
@@ -121,7 +115,6 @@ class QueryConstruct(namedtuple('QueryConstruct', 'collection objectformatter qu
                 table,
                 next_join_path,
                 treedefitem_params,
-                max_depth,
             )
         else:
             # Use the specific start anchor in the cache key, so each branch has its own chain

--- a/specifyweb/backend/stored_queries/query_construct.py
+++ b/specifyweb/backend/stored_queries/query_construct.py
@@ -19,24 +19,52 @@ def _safe_filter(query):
         return query.first()
     raise Exception(f"Got more than one matching: {list(query)}")
 
+def _taxon_tree_rank_lookup_supported(table, next_join_path):
+    return (
+        table.name == "Taxon"
+        and len(next_join_path) == 1
+        and not next_join_path[0].is_relationship
+        and not isinstance(next_join_path[0], TreeRankQuery)
+    )
+
+def _resolve_tree_rank_items(collection, table, tree_rank: TreeRankQuery):
+    treedefs = get_treedefs(collection, table.name)
+    item_model = getattr(spmodels, table.django_name + "treedefitem")
+
+    treedefs_with_ranks = [
+        (treedef_id, treedefitem_id)
+        for treedef_id, treedefitem_id in (
+            (
+                treedef_id,
+                _safe_filter(
+                    item_model.objects.filter(
+                        treedef_id=treedef_id, name=tree_rank.name
+                    ).values_list("id", flat=True)
+                ),
+            )
+            for treedef_id, _ in treedefs
+            if tree_rank.treedef_id is None or tree_rank.treedef_id == treedef_id
+        )
+        if treedefitem_id is not None
+    ]
+    assert len(treedefs_with_ranks) >= 1, "Didn't find the tree rank across any tree"
+    return treedefs_with_ranks
+
 class QueryConstruct(namedtuple('QueryConstruct', 'collection objectformatter query join_cache tree_rank_count internal_filters')):
 
     def __new__(cls, *args, **kwargs):
-        kwargs['join_cache'] = dict()
+        if 'join_cache' not in kwargs:
+            kwargs['join_cache'] = dict()
         # TODO: Use tree_rank_count to implement cases where formatter of taxon is defined with fields from the parent.
         # In that case, the cycle will end (unlike other cyclical cases).
-        kwargs['tree_rank_count'] = 0
-        kwargs['internal_filters'] = []
+        if 'tree_rank_count' not in kwargs:
+            kwargs['tree_rank_count'] = 0
+        if 'internal_filters' not in kwargs:
+            kwargs['internal_filters'] = []
         return super().__new__(cls, *args, **kwargs)
 
-    def _tree_rank_can_use_subquery(self, table, next_join_path):
-        return (
-            table.name == "Taxon"
-            and
-            len(next_join_path) == 1
-            and not next_join_path[0].is_relationship
-            and not isinstance(next_join_path[0], TreeRankQuery)
-        )
+    def _tree_rank_can_use_taxon_lookup(self, table, next_join_path):
+        return _taxon_tree_rank_lookup_supported(table, next_join_path)
 
     def _build_tree_rank_scalar_subquery(
         self,
@@ -71,6 +99,54 @@ class QueryConstruct(namedtuple('QueryConstruct', 'collection objectformatter qu
         column = subquery.correlate(correlation_target).scalar_subquery()
         return column, field, table
 
+    def _build_taxon_tree_rank_scalar_subquery(
+        self,
+        start_alias,
+        mapped_cls,
+        table,
+        next_join_path,
+        treedefitem_params,
+        max_depth,
+    ):
+        treedefitem_column = table.name + 'TreeDefItemID'
+        correlation_target = sa_inspect(start_alias).selectable
+        root = orm.aliased(mapped_cls)
+        field = next_join_path[0]
+        ancestors = [root]
+        subquery = sql.select(
+            sql.case(
+                [
+                    (
+                        getattr(ancestor, treedefitem_column).in_(tuple(treedefitem_params)),
+                        getattr(ancestor, field.name),
+                    )
+                    for ancestor in ancestors
+                ],
+                else_=None,
+            )
+        ).select_from(root)
+
+        for _ in range(max_depth - 1):
+            ancestor = orm.aliased(mapped_cls)
+            subquery = subquery.outerjoin(ancestor, ancestors[-1].ParentID == ancestor._id)
+            ancestors.append(ancestor)
+
+        subquery = subquery.with_only_columns(
+            sql.case(
+                [
+                    (
+                        getattr(ancestor, treedefitem_column).in_(tuple(treedefitem_params)),
+                        getattr(ancestor, field.name),
+                    )
+                    for ancestor in ancestors
+                ],
+                else_=None,
+            )
+        ).where(root._id == start_alias._id)
+
+        column = subquery.correlate(correlation_target).scalar_subquery()
+        return column, field, table
+
     def handle_tree_field(self, node, table, tree_rank: TreeRankQuery, next_join_path, current_field_spec: QueryFieldSpec):
         query = self
         if query.collection is None:
@@ -92,29 +168,18 @@ class QueryConstruct(namedtuple('QueryConstruct', 'collection objectformatter qu
 
         treedefs = get_treedefs(query.collection, table.name)
         max_depth = max(depth for _, depth in treedefs)
-
-        item_model = getattr(spmodels, table.django_name + "treedefitem")
-
-        # TODO: optimize out the ranks that appear? cache them
-        treedefs_with_ranks: list[tuple[int, int]] = [
-            (treedef_id, _safe_filter(item_model.objects.filter(treedef_id=treedef_id, name=tree_rank.name).values_list("id", flat=True)))
-            for treedef_id, _ in treedefs
-            # For constructing tree queries for batch edit
-            if (tree_rank.treedef_id is None or tree_rank.treedef_id == treedef_id)
-        ]
-        assert len(treedefs_with_ranks) >= 1, "Didn't find the tree rank across any tree"
+        treedefs_with_ranks = _resolve_tree_rank_items(query.collection, table, tree_rank)
 
         treedefitem_params = [treedefitem_id for (_, treedefitem_id) in treedefs_with_ranks]
 
-        if self._tree_rank_can_use_subquery(table, next_join_path):
-            # Restrict the subquery strategy to Taxon, so that the alias disambiguation issue from paths like
-            # PreferredTaxon/HostTaxon are solved without changing SQL shape for other trees like Geography or Storage.
-            column, field, table = self._build_tree_rank_scalar_subquery(
+        if self._tree_rank_can_use_taxon_lookup(table, next_join_path):
+            column, field, table = self._build_taxon_tree_rank_scalar_subquery(
                 start_alias,
                 mapped_cls,
                 table,
                 next_join_path,
                 treedefitem_params,
+                max_depth,
             )
         else:
             # Use the specific start anchor in the cache key, so each branch has its own chain

--- a/specifyweb/backend/stored_queries/query_construct.py
+++ b/specifyweb/backend/stored_queries/query_construct.py
@@ -2,7 +2,6 @@ import logging
 from collections import namedtuple, deque
 
 from sqlalchemy import orm, sql, or_
-from sqlalchemy import inspect
 from sqlalchemy.orm.util import AliasedClass
 from sqlalchemy.inspection import inspect as sa_inspect
 
@@ -30,6 +29,54 @@ class QueryConstruct(namedtuple('QueryConstruct', 'collection objectformatter qu
         kwargs['internal_filters'] = []
         return super().__new__(cls, *args, **kwargs)
 
+    def _tree_rank_can_use_subquery(self, table, next_join_path):
+        return (
+            table.name == "Taxon"
+            and
+            len(next_join_path) == 1
+            and not next_join_path[0].is_relationship
+            and not isinstance(next_join_path[0], TreeRankQuery)
+        )
+
+    def _build_tree_rank_scalar_subquery(
+        self,
+        start_alias,
+        mapped_cls,
+        table,
+        next_join_path,
+        treedefitem_params,
+        max_depth,
+    ):
+        field = next_join_path[0]
+        treedefitem_column = table.name + 'TreeDefItemID'
+        correlation_target = sa_inspect(start_alias).selectable
+
+        ancestors = [orm.aliased(mapped_cls)]
+        for _ in range(max_depth - 1):
+            ancestors.append(orm.aliased(mapped_cls))
+
+        cases = []
+        for ancestor in ancestors:
+            orm_field = getattr(ancestor, field.name)
+            for treedefitem_param in treedefitem_params:
+                cases.append(
+                    (
+                        getattr(ancestor, treedefitem_column) == treedefitem_param,
+                        orm_field,
+                    )
+                )
+
+        subquery = sql.select(sql.case(cases)).select_from(ancestors[0])
+        for parent, ancestor in zip(ancestors, ancestors[1:]):
+            subquery = subquery.outerjoin(ancestor, parent.ParentID == ancestor._id)
+
+        column = (
+            subquery.where(ancestors[0]._id == start_alias._id)
+            .correlate(correlation_target)
+            .scalar_subquery()
+        )
+        return column, field, table
+
     def handle_tree_field(self, node, table, tree_rank: TreeRankQuery, next_join_path, current_field_spec: QueryFieldSpec):
         query = self
         if query.collection is None:
@@ -49,28 +96,8 @@ class QueryConstruct(namedtuple('QueryConstruct', 'collection objectformatter qu
         start_alias = node                       # keep as-is
         mapped_cls = sa_inspect(node).mapper.class_ if is_alias else node
 
-        # Use the specific start anchor in the cache key, so each branch has its own chain
-        cache_key = (start_alias, "TreeRanks")
-
-        if cache_key in query.join_cache:
-            logger.debug("using join cache for %r tree ranks.", start_alias)
-            ancestors, treedefs = query.join_cache[cache_key]
-        else:
-            treedefs = get_treedefs(query.collection, table.name)
-            max_depth = max(depth for _, depth in treedefs)
-
-            # Start ancestry from the provided alias (e.g., HostTaxon alias)
-            ancestors = [start_alias]
-
-            # Build parent chain using aliases of the mapped class
-            for _ in range(max_depth - 1):
-                ancestor = orm.aliased(mapped_cls)
-                query = query.outerjoin(ancestor, ancestors[-1].ParentID == ancestor._id)
-                ancestors.append(ancestor)
-
-            logger.debug("adding to join cache for %r tree ranks.", start_alias)
-            query = query._replace(join_cache=query.join_cache.copy())
-            query.join_cache[cache_key] = (ancestors, treedefs)
+        treedefs = get_treedefs(query.collection, table.name)
+        max_depth = max(depth for _, depth in treedefs)
 
         item_model = getattr(spmodels, table.django_name + "treedefitem")
 
@@ -85,23 +112,55 @@ class QueryConstruct(namedtuple('QueryConstruct', 'collection objectformatter qu
 
         treedefitem_params = [treedefitem_id for (_, treedefitem_id) in treedefs_with_ranks]
 
-        def make_tree_field_spec(tree_node):
-            return current_field_spec._replace(
-                root_table=table, # rebasing the query
-                root_sql_table=tree_node, # this is needed to preserve SQL aliased going to next part
-                join_path=next_join_path, # slicing join path to begin from after the tree
+        if self._tree_rank_can_use_subquery(table, next_join_path):
+            # Restrict the subquery strategy to Taxon, so that the alias disambiguation issue from paths like
+            # PreferredTaxon/HostTaxon are solved without changing SQL shape for other trees like Geography or Storage.
+            column, field, table = self._build_tree_rank_scalar_subquery(
+                start_alias,
+                mapped_cls,
+                table,
+                next_join_path,
+                treedefitem_params,
+                max_depth,
             )
+        else:
+            # Use the specific start anchor in the cache key, so each branch has its own chain
+            cache_key = (start_alias, "TreeRanks")
 
-        cases = []
-        field = None # just to stop mypy from complaining.
-        for ancestor in ancestors:
-            field_spec = make_tree_field_spec(ancestor)
-            query, orm_field, field, table = field_spec.add_spec_to_query(query)
-            # Field and table won't matter. Rank acts as fork, and these two will be same across siblings
-            for treedefitem_param in treedefitem_params:
-                cases.append((getattr(ancestor, treedefitem_column) == treedefitem_param, orm_field))
+            if cache_key in query.join_cache:
+                logger.debug("using join cache for %r tree ranks.", start_alias)
+                ancestors = query.join_cache[cache_key]
+            else:
+                # Start ancestry from the provided alias, like the HostTaxon alias
+                ancestors = [start_alias]
 
-        column = sql.case(cases)
+                # Build parent chain using aliases of the mapped class
+                for _ in range(max_depth - 1):
+                    ancestor = orm.aliased(mapped_cls)
+                    query = query.outerjoin(ancestor, ancestors[-1].ParentID == ancestor._id)
+                    ancestors.append(ancestor)
+
+                logger.debug("adding to join cache for %r tree ranks.", start_alias)
+                query = query._replace(join_cache=query.join_cache.copy())
+                query.join_cache[cache_key] = ancestors
+
+            def make_tree_field_spec(tree_node):
+                return current_field_spec._replace(
+                    root_table=table, # rebasing the query
+                    root_sql_table=tree_node, # this is needed to preserve SQL aliased going to next part
+                    join_path=next_join_path, # slicing join path to begin from after the tree
+                )
+
+            cases = []
+            field = None # just to stop mypy from complaining.
+            for ancestor in ancestors:
+                field_spec = make_tree_field_spec(ancestor)
+                query, orm_field, field, table = field_spec.add_spec_to_query(query)
+                # Field and table won't matter. Rank acts as fork, and these two will be same across siblings
+                for treedefitem_param in treedefitem_params:
+                    cases.append((getattr(ancestor, treedefitem_column) == treedefitem_param, orm_field))
+
+            column = sql.case(cases)
 
         defs_to_filter_on = [def_id for (def_id, _) in treedefs_with_ranks]
         # We don't want to include treedef if the rank is not present.


### PR DESCRIPTION
Fixes #7977

The change from #7509 fixed the QB disambiguation problem from #7436 by making taxon-related tree-rank fields resolve against the correct join path, but on some databases it also caused the generated SQL to exceed MariaDB's 61 table join limit.

The fix keeps the disambiguation behavior from #7436, but limits the SQL change to taxon tree rank fields. Instead of building a full parent-chain join in the main query for every taxon path, the main query now joins only to the starting taxon alias, such as Taxon, PreferredTaxon, or HostTaxon. Any requested taxon rank is then resolved in a correlated subquery rooted at that specific alias. This preserves correct disambiguation between taxon-related columns while avoiding the MariaDB “too many tables in a join” failure.

### Query Comparison

**old_query.sql:**
The main query had one full taxon ancestry chain off determination.TaxonID, and PreferredTaxonID was only joined directly.
This kept the join count lower, but it could resolve disambiguated taxon fields against the wrong taxon path.

**new_query.sql from the merged PR:**
The main query built separate full ancestry chains for both TaxonID and PreferredTaxonID.
This fixed the disambiguation problem, but it increased the outer join graph from 50 joins / 18 taxon aliases to 66 joins / 34 taxon aliases, which is what triggered the MariaDB limit on some databases.

**Initial changes in this PR:**
The main query still keeps separate starting aliases for the taxon paths, so the disambiguation fix remains.
The difference is that the parent-chain walk for taxon ranks is moved into correlated subqueries, so those extra taxon ancestry chains are no longer part of the main query’s outer join graph.
The query stays correct, but the expensive taxon tree expansion is split into separate SELECTs instead of one oversized join.

**Final changes in this PR:**:
The final version keeps the same disambiguated starting aliases, but resolves each requested taxon rank with a scalar correlated subquery that walks only the alias's own parent chain. So, instead of building a reusable taxon rank lookup for the whole tree, each taxon rank column now follows just the current Taxon or PreferredTaxon lineage and returns the matching rank value from that lineage.

This keeps the #7436 disambiguation fix, avoids the oversized outer-join graph that caused the MariaDB 61 table failure, and also avoids the slower full tree lookup plan from the initial draft of this PR. On the database that reproduced #7977, the problematic label query now completes successfully instead of timing out.

### Checklist

- [x] Self-review the PR after opening it to make sure the changes look good and
      self-explanatory (or properly documented)
- [ ] Add relevant issue to release milestone
- [ ] Add pr to documentation list


### Testing instructions

- Run the label generating query that caused a MariaDB 'Too many table joins' error.
- [x] See that the label now gets generated without any errors in the logs.
