### PR TITLE
Revert Back-end changes from Handle Disambiguation Case for Host Taxo…

### DIFF
--- a/specifyweb/backend/stored_queries/query_construct.py
+++ b/specifyweb/backend/stored_queries/query_construct.py
@@ -2,9 +2,6 @@ import logging
 from collections import namedtuple, deque
 
 from sqlalchemy import orm, sql, or_
-from sqlalchemy import inspect
-from sqlalchemy.orm.util import AliasedClass
-from sqlalchemy.inspection import inspect as sa_inspect
 
 import specifyweb.specify.models as spmodels
 from specifyweb.backend.trees.utils import get_treedefs
@@ -32,55 +29,47 @@ class QueryConstruct(namedtuple('QueryConstruct', 'collection objectformatter qu
 
     def handle_tree_field(self, node, table, tree_rank: TreeRankQuery, next_join_path, current_field_spec: QueryFieldSpec):
         query = self
-        if query.collection is None:
-            raise AssertionError(
-                f"No Collection found in Query for {table}",
-                {"table": table, "localizationKey": "noCollectionInQuery"},
-            )
-        logger.info("handling treefield %s rank: %s field: %s", table, tree_rank.name, next_join_path)
+        if query.collection is None: raise AssertionError( # Not sure it makes sense to query across collections
+            f"No Collection found in Query for {table}",
+            {"table" : table,
+             "localizationKey" : "noCollectionInQuery"}) 
+        logger.info('handling treefield %s rank: %s field: %s', table, tree_rank.name, next_join_path)
 
         treedefitem_column = table.name + 'TreeDefItemID'
         treedef_column = table.name + 'TreeDefID'
 
-        # Determine starting anchor correctly:
-        # If node is already an alias (from a relationship path), use that alias.
-        # If node is the mapped class (base table), don't alias it, start from the base table.
-        is_alias = isinstance(node, AliasedClass)
-        start_alias = node                       # keep as-is
-        mapped_cls = sa_inspect(node).mapper.class_ if is_alias else node
-
-        # Use the specific start anchor in the cache key, so each branch has its own chain
-        cache_key = (start_alias, "TreeRanks")
-
-        if cache_key in query.join_cache:
-            logger.debug("using join cache for %r tree ranks.", start_alias)
-            ancestors, treedefs = query.join_cache[cache_key]
+        if (table, 'TreeRanks') in query.join_cache:
+            logger.debug("using join cache for %r tree ranks.", table)
+            ancestors, treedefs = query.join_cache[(table, 'TreeRanks')]
         else:
+            
             treedefs = get_treedefs(query.collection, table.name)
+
+            # We need to take the max here. Otherwise, it is possible that the same rank
+            # name may not occur at the same level across tree defs.
             max_depth = max(depth for _, depth in treedefs)
-
-            # Start ancestry from the provided alias (e.g., HostTaxon alias)
-            ancestors = [start_alias]
-
-            # Build parent chain using aliases of the mapped class
-            for _ in range(max_depth - 1):
-                ancestor = orm.aliased(mapped_cls)
+            
+            ancestors = [node]
+            for _ in range(max_depth-1):
+                ancestor = orm.aliased(node)
                 query = query.outerjoin(ancestor, ancestors[-1].ParentID == ancestor._id)
                 ancestors.append(ancestor)
+        
 
-            logger.debug("adding to join cache for %r tree ranks.", start_alias)
+            logger.debug("adding to join cache for %r tree ranks.", table)
             query = query._replace(join_cache=query.join_cache.copy())
-            query.join_cache[cache_key] = (ancestors, treedefs)
+            query.join_cache[(table, 'TreeRanks')] = (ancestors, treedefs)
 
         item_model = getattr(spmodels, table.django_name + "treedefitem")
 
         # TODO: optimize out the ranks that appear? cache them
-        treedefs_with_ranks: list[tuple[int, int]] = [
-            (treedef_id, _safe_filter(item_model.objects.filter(treedef_id=treedef_id, name=tree_rank.name).values_list("id", flat=True)))
+        treedefs_with_ranks: list[tuple[int, int]] = [tup for tup in [
+            (treedef_id, _safe_filter(item_model.objects.filter(treedef_id=treedef_id, name=tree_rank.name).values_list('id', flat=True)))
             for treedef_id, _ in treedefs
             # For constructing tree queries for batch edit
             if (tree_rank.treedef_id is None or tree_rank.treedef_id == treedef_id)
-        ]
+            ] if tup[1] is not None]
+
         assert len(treedefs_with_ranks) >= 1, "Didn't find the tree rank across any tree"
 
         treedefitem_params = [treedefitem_id for (_, treedefitem_id) in treedefs_with_ranks]
@@ -107,8 +96,7 @@ class QueryConstruct(namedtuple('QueryConstruct', 'collection objectformatter qu
         # We don't want to include treedef if the rank is not present.
         new_filters = [
             *query.internal_filters,
-            or_(getattr(start_alias, treedef_column).in_(defs_to_filter_on), getattr(start_alias, treedef_column) == None),
-        ]
+            or_(getattr(node, treedef_column).in_(defs_to_filter_on), getattr(node, treedef_column) == None)]
         query = query._replace(internal_filters=new_filters)
 
         return query, column, field, table

--- a/specifyweb/backend/stored_queries/queryfieldspec.py
+++ b/specifyweb/backend/stored_queries/queryfieldspec.py
@@ -161,27 +161,10 @@ class TreeRankQuery(Relationship):
         # Treedef id included to make it easier to pass it to batch edit
         return f"{self.treedef_name}{RANK_KEY_DELIMITER}{self.name}{RANK_KEY_DELIMITER}{self.treedef_id}"
 
-def null_safe_not(field_expr, predicate):
-
-    """Return a NOT clause that still matches NULL values on the target field.
-
-    SQL's ``NOT IN`` and similar predicates exclude rows where the filtered column
-    is ``NULL``. Historical Specify 6 behaviour (and user expectation) is to keep
-    those "empty" rows when a negated filter is applied.  This helper wraps the
-    negated predicate in an OR that explicitly re-includes NULL rows for the
-    relevant field expression.
-
-    """
-    if predicate is None or isinstance(predicate, Query):
-        return predicate
-    target = field_expr if field_expr is not None else getattr(predicate, "left", None)
-    if target is None:
-        return sql.not_(predicate)
-    return sql.or_(target.is_(None), sql.not_(predicate))
-
 
 QueryNode = Field | Relationship | TreeRankQuery
 FieldSpecJoinPath = tuple[QueryNode]
+
 
 class QueryFieldSpec(
     namedtuple(
@@ -400,7 +383,6 @@ class QueryFieldSpec(
 
             query_op = QueryOps(uiformatter)
             op = query_op.by_op_num(op_num)
-            mod_orm_field = orm_field
             if query_op.is_precalculated(op_num):
                 f = op(
                     orm_field, value, query, is_strict=strict
@@ -417,15 +399,7 @@ class QueryFieldSpec(
                 op, mod_orm_field, value = apply_special_filter_cases(orm_field, field, table, value, op, op_num, uiformatter, collection, user)
                 f = op(mod_orm_field, value)
 
-            NULL_SAFE_NEGATE_OPS = {1, 10, 11}
-
-            if negate:
-                if op_num in NULL_SAFE_NEGATE_OPS:
-                    predicate = null_safe_not(mod_orm_field or orm_field, f)
-                else:
-                    predicate = sql.not_(f)
-            else:
-                predicate = f
+            predicate = sql.not_(f) if negate else f
         else:
             predicate = None
 
@@ -485,26 +459,17 @@ class QueryFieldSpec(
                     cycle_detector,
                 )
         else:
-            tree_rank_idxs = [i for i, n in enumerate(self.join_path) if isinstance(n, TreeRankQuery)]
-            if tree_rank_idxs:
-                tree_rank_idx = tree_rank_idxs[0]
-                prefix = self.join_path[:tree_rank_idx] # up to (but not including) the tree-rank node
-                tree_rank_node = self.join_path[tree_rank_idx]
-                suffix = self.join_path[tree_rank_idx + 1 :] # field after the rank, e.g., "Name"
-
-                # Join only the prefix to obtain the correct starting alias (e.g., HostTaxon)
-                query, orm_model, table, _ = self.build_join(query, prefix)
-
-                # Build the CASE/joins for the tree rank starting at that alias
+            query, orm_model, table, field = self.build_join(query, self.join_path)
+            if isinstance(field, TreeRankQuery):
+                tree_rank_idx = self.join_path.index(field)
                 query, orm_field, field, table = query.handle_tree_field(
                     orm_model,
                     table,
-                    tree_rank_node,
-                    suffix,
+                    field,
+                    self.join_path[tree_rank_idx + 1 :],
                     self,
                 )
             else:
-                query, orm_model, table, field = self.build_join(query, self.join_path)
                 try:
                     field_name = self.get_field().name
                     orm_field = getattr(orm_model, field_name)

--- a/specifyweb/backend/stored_queries/queryfieldspec.py
+++ b/specifyweb/backend/stored_queries/queryfieldspec.py
@@ -161,10 +161,27 @@ class TreeRankQuery(Relationship):
         # Treedef id included to make it easier to pass it to batch edit
         return f"{self.treedef_name}{RANK_KEY_DELIMITER}{self.name}{RANK_KEY_DELIMITER}{self.treedef_id}"
 
+def null_safe_not(field_expr, predicate):
+
+    """Return a NOT clause that still matches NULL values on the target field.
+
+    SQL's ``NOT IN`` and similar predicates exclude rows where the filtered column
+    is ``NULL``. Historical Specify 6 behaviour (and user expectation) is to keep
+    those "empty" rows when a negated filter is applied.  This helper wraps the
+    negated predicate in an OR that explicitly re-includes NULL rows for the
+    relevant field expression.
+
+    """
+    if predicate is None or isinstance(predicate, Query):
+        return predicate
+    target = field_expr if field_expr is not None else getattr(predicate, "left", None)
+    if target is None:
+        return sql.not_(predicate)
+    return sql.or_(target.is_(None), sql.not_(predicate))
+
 
 QueryNode = Field | Relationship | TreeRankQuery
 FieldSpecJoinPath = tuple[QueryNode]
-
 
 class QueryFieldSpec(
     namedtuple(
@@ -383,6 +400,7 @@ class QueryFieldSpec(
 
             query_op = QueryOps(uiformatter)
             op = query_op.by_op_num(op_num)
+            mod_orm_field = orm_field
             if query_op.is_precalculated(op_num):
                 f = op(
                     orm_field, value, query, is_strict=strict
@@ -399,7 +417,15 @@ class QueryFieldSpec(
                 op, mod_orm_field, value = apply_special_filter_cases(orm_field, field, table, value, op, op_num, uiformatter, collection, user)
                 f = op(mod_orm_field, value)
 
-            predicate = sql.not_(f) if negate else f
+            NULL_SAFE_NEGATE_OPS = {1, 10, 11}
+
+            if negate:
+                if op_num in NULL_SAFE_NEGATE_OPS:
+                    predicate = null_safe_not(mod_orm_field or orm_field, f)
+                else:
+                    predicate = sql.not_(f)
+            else:
+                predicate = f
         else:
             predicate = None
 


### PR DESCRIPTION
Revert the back-end changes from the #7509 PR in order to avoid the error of SQL exceeding MariaDB's 61-table join limit.

### Checklist

- [ ] Self-review the PR after opening it to make sure the changes look good and
      self-explanatory (or properly documented)
- [ ] Add relevant issue to release milestone
- [ ] Add pr to documentation list



### Testing instructions

- Run the label generating query that caused a MariaDB 'Too many table joins' error.
- [x] See that the label now gets generated without any errors in the logs.
