### PR TITLE
fix(AppResources): default SpAppResource.description to name on creation

### DIFF
--- a/specifyweb/frontend/js_src/lib/components/AppResources/Create.tsx
+++ b/specifyweb/frontend/js_src/lib/components/AppResources/Create.tsx
@@ -259,17 +259,7 @@ function EditAppResource({
   readonly templateFile: string | undefined;
 }): JSX.Element {
   const resource = React.useMemo(
-    () =>
-      deserializeResource(
-        addMissingFields(type.tableName as 'SpAppResource', {
-          // I don't think this field is used anywhere
-          level: 0,
-          mimeType,
-          name: name.trim(),
-          specifyUser: userInformation.resource_uri,
-          spAppResourceDir: directory.resource_uri,
-        })
-      ),
+    () => buildNewAppResource(type, name, mimeType, directory),
     [directory, name, type, mimeType]
   );
 
@@ -321,6 +311,29 @@ function EditAppResource({
   );
 }
 
+/**
+ * S6 hard-fails when opening a label whose spappresource.Description is NULL,
+ * so default description to the resource name on creation. See ticket #824.
+ */
+const buildNewAppResource = (
+  type: AppResourceType,
+  name: string,
+  mimeType: string | undefined,
+  directory: SerializedResource<SpAppResourceDir>
+) =>
+  deserializeResource(
+    addMissingFields(type.tableName as 'SpAppResource', {
+      // I don't think this field is used anywhere
+      level: 0,
+      mimeType,
+      name: name.trim(),
+      description: name.trim(),
+      specifyUser: userInformation.resource_uri,
+      spAppResourceDir: directory.resource_uri,
+    })
+  );
+
 export const exportsForTests = {
   getUrl,
+  buildNewAppResource,
 };

--- a/specifyweb/frontend/js_src/lib/components/AppResources/EditorWrapper.tsx
+++ b/specifyweb/frontend/js_src/lib/components/AppResources/EditorWrapper.tsx
@@ -42,6 +42,32 @@ export function ViewSetView(): JSX.Element {
   return <Wrapper mode="viewSets" />;
 }
 
+/**
+ * The skeleton for a resource created via the "New Resource" flow. This is
+ * the record that actually gets saved (the dialog in Create.tsx only collects
+ * the name, then navigates here). S6 hard-fails when opening a label whose
+ * spappresource.Description is NULL, so default description to the resource
+ * name on creation. See ticket #824.
+ */
+const newAppResourceSkeleton = (
+  mode: AppResourceMode,
+  name: string | undefined,
+  mimeType: string | undefined
+): SerializedResource<SpAppResource> =>
+  addMissingFields(
+    mode === 'appResources'
+      ? 'SpAppResource'
+      : ('SpViewSetObj' as 'SpAppResource'),
+    {
+      // I don't think this field is used anywhere
+      level: 0,
+      mimeType,
+      name: name?.trim() ?? '',
+      description: name?.trim() ?? '',
+      specifyUser: userInformation.resource_uri,
+    }
+  );
+
 export function Wrapper({
   mode,
 }: {
@@ -54,19 +80,7 @@ export function Wrapper({
   const { name, mimeType, rawDirectoryKey, clone, templateFile } = useProps();
 
   const newResource = React.useMemo(
-    () =>
-      addMissingFields(
-        mode === 'appResources'
-          ? 'SpAppResource'
-          : ('SpViewSetObj' as 'SpAppResource'),
-        {
-          // I don't think this field is used anywhere
-          level: 0,
-          mimeType,
-          name: name?.trim() ?? '',
-          specifyUser: userInformation.resource_uri,
-        }
-      ),
+    () => newAppResourceSkeleton(mode, name, mimeType),
     [name, mimeType, mode]
   );
   const resource = useAppResource(newResource, resources, mode);
@@ -268,4 +282,5 @@ export const exportsForTests = {
   useAppResource,
   useInitialData,
   useDirectory,
+  newAppResourceSkeleton,
 };

--- a/specifyweb/frontend/js_src/lib/components/AppResources/__tests__/CreateAppResource.test.tsx
+++ b/specifyweb/frontend/js_src/lib/components/AppResources/__tests__/CreateAppResource.test.tsx
@@ -6,9 +6,14 @@ import { requireContext } from '../../../tests/helpers';
 import { mount } from '../../../tests/reactUtils';
 import { TestComponentWrapperRouter } from '../../../tests/utils';
 import { LoadingContext } from '../../Core/Contexts';
+import type { SerializedResource } from '../../DataModel/helperTypes';
+import type { SpAppResourceDir } from '../../DataModel/types';
 import { UnloadProtectsContext } from '../../Router/UnloadProtect';
-import { CreateAppResource } from '../Create';
+import { CreateAppResource, exportsForTests } from '../Create';
+import { appResourceTypes } from '../types';
 import { testAppResources } from './testAppResources';
+
+const { buildNewAppResource } = exportsForTests;
 
 requireContext();
 
@@ -96,5 +101,24 @@ describe('CreateAppResource', () => {
     expect(getByRole('dialog').textContent).toMatchInlineSnapshot(
       `"Copy default formsHerpetologyHerpetology > Guest > HerpetologyHerpetology > Manager > HerpetologyBirdBird > Guest > BirdBird > Manager > BirdMammalMammal > Guest > MammalMammal > Manager > MammalVertpaleoVertpaleo > Guest > VertpaleoVertpaleo > Manager > VertpaleoFishFish > Guest > FishFish > Manager > FishInvertebrateInvertebrate > Guest > InvertebrateInvertebrate > Manager > InvertebrateInsect > EntoInsect > Guest > EntoInsect > Manager > EntoBotanyBotany > Guest > BotanyBotany > Manager > BotanyGeologyCommonBackstop > GlobalBackstop > SearchInvertpaleo > PaleoInvertpaleo > Guest > PaleoInvertpaleo > Manager > PaleoNew"`
     );
+  });
+});
+
+describe('buildNewAppResource', () => {
+  const directory = {
+    resource_uri: '/api/specify/spappresourcedir/1/',
+  } as SerializedResource<SpAppResourceDir>;
+
+  // Specify 6 hard-fails on labels whose spappresource.Description is NULL,
+  // so a freshly created resource must carry a non-null description (#824).
+  test('defaults description to the trimmed name', () => {
+    const resource = buildNewAppResource(
+      appResourceTypes.appResources,
+      '  My Label  ',
+      'text/xml',
+      directory
+    );
+    expect(resource.get('name')).toBe('My Label');
+    expect(resource.get('description')).toBe('My Label');
   });
 });

--- a/specifyweb/frontend/js_src/lib/components/AppResources/__tests__/CreateAppResource.test.tsx
+++ b/specifyweb/frontend/js_src/lib/components/AppResources/__tests__/CreateAppResource.test.tsx
@@ -10,10 +10,12 @@ import type { SerializedResource } from '../../DataModel/helperTypes';
 import type { SpAppResourceDir } from '../../DataModel/types';
 import { UnloadProtectsContext } from '../../Router/UnloadProtect';
 import { CreateAppResource, exportsForTests } from '../Create';
+import { exportsForTests as editorWrapperExports } from '../EditorWrapper';
 import { appResourceTypes } from '../types';
 import { testAppResources } from './testAppResources';
 
 const { buildNewAppResource } = exportsForTests;
+const { newAppResourceSkeleton } = editorWrapperExports;
 
 requireContext();
 
@@ -109,8 +111,10 @@ describe('buildNewAppResource', () => {
     resource_uri: '/api/specify/spappresourcedir/1/',
   } as SerializedResource<SpAppResourceDir>;
 
-  // Specify 6 hard-fails on labels whose spappresource.Description is NULL,
-  // so a freshly created resource must carry a non-null description (#824).
+  /*
+   * Specify 6 hard-fails on labels whose spappresource.Description is NULL,
+   * so a freshly created resource must carry a non-null description (#824).
+   */
   test('defaults description to the trimmed name', () => {
     const resource = buildNewAppResource(
       appResourceTypes.appResources,
@@ -120,5 +124,28 @@ describe('buildNewAppResource', () => {
     );
     expect(resource.get('name')).toBe('My Label');
     expect(resource.get('description')).toBe('My Label');
+  });
+});
+
+describe('newAppResourceSkeleton', () => {
+  /*
+   * The skeleton built in EditorWrapper is the record that is actually
+   * persisted (the Create.tsx dialog only collects the name and navigates),
+   * so it must carry the description default too (#824).
+   */
+  test('defaults description to the trimmed name', () => {
+    const skeleton = newAppResourceSkeleton(
+      'appResources',
+      '  My Label  ',
+      'text/xml'
+    );
+    expect(skeleton.name).toBe('My Label');
+    expect(skeleton.description).toBe('My Label');
+  });
+
+  test('defaults description for view sets', () => {
+    const skeleton = newAppResourceSkeleton('viewSets', 'My Forms', undefined);
+    expect(skeleton.name).toBe('My Forms');
+    expect(skeleton.description).toBe('My Forms');
   });
 });


### PR DESCRIPTION
## Summary

The "New Resource" flow in `AppResources/Create.tsx` constructs an `SpAppResource` without a `description`, so the row is persisted with `Description = NULL`. The backend `report_runner` create path already defaults `description = name`; this PR makes the frontend match.

Specify 6 hard-fails when opening a label whose underlying `spappresource.Description` is NULL, so any site still running S6 alongside S7 hits this immediately. Reported as Specify support ticket **#824** — Grant confirmed the analysis and asked for a PR.

## Changes

- Extract `buildNewAppResource()` helper in `Create.tsx`; defaults `description: name.trim()`
- Export the helper via `exportsForTests` (same pattern as `getUrl` in this file)
- Add a unit test asserting the new resource has `description === name.trim()`

## Note for sites running both S6 and S7

If you already have rows with `Description IS NULL`, S6 will still hard-fail on them after this PR is merged — this fix only prevents *new* NULL rows. A one-time backfill is safe and cheap (description is a simple text label, free-form):

```sql
-- Run once per Specify database; backfills any historic NULL descriptions
-- so Specify 6 stops crashing on labels created by Specify 7.
UPDATE spappresource SET Description = Name WHERE Description IS NULL;
```

## Test plan

- [x] `npx jest --testPathPattern CreateAppResource` — 4/4 pass (3 existing + 1 new)
- [ ] Manually create a new App Resource via User Tools → App Resources → New Resource and confirm `spappresource.Description` is non-NULL in the DB
- [ ] Open the new resource as a label/report in Specify 6 and confirm it no longer crashes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where creating app resources with empty descriptions could cause errors. The description field now defaults to the trimmed resource name.

* **Tests**
  * Added tests to verify that app resource descriptions default correctly when not explicitly provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->