### PR TITLE
Fix crash for negated tree rank field query filters

### DIFF
--- a/specifyweb/backend/stored_queries/queryfieldspec.py
+++ b/specifyweb/backend/stored_queries/queryfieldspec.py
@@ -421,7 +421,8 @@ class QueryFieldSpec(
 
             if negate:
                 if op_num in NULL_SAFE_NEGATE_OPS:
-                    predicate = null_safe_not(mod_orm_field or orm_field, f)
+                    field_expr = mod_orm_field if mod_orm_field is not None else orm_field
+                    predicate = null_safe_not(field_expr, f)
                 else:
                     predicate = sql.not_(f)
             else:

--- a/specifyweb/backend/stored_queries/tests/test_execution/test_run_ephemeral_query.py
+++ b/specifyweb/backend/stored_queries/tests/test_execution/test_run_ephemeral_query.py
@@ -1,6 +1,8 @@
 from specifyweb.backend.stored_queries.execution import run_ephemeral_query
 from specifyweb.backend.stored_queries.tests.test_execution.simple_query import simple_query
 from specifyweb.backend.stored_queries.tests.tests import SQLAlchemySetup
+from specifyweb.backend.trees.tests.test_trees import SqlTreeSetup
+from specifyweb.specify import models
 from unittest.mock import patch, Mock
 
 
@@ -13,4 +15,56 @@ class TestRunEphemeralQuery(SQLAlchemySetup):
         self.assertCountEqual(
             {"results": [(co.id, co.catalognumber) for co in self.collectionobjects]},
             result,
+        )
+
+
+class TestRunEphemeralQueryByRank(SqlTreeSetup):
+
+    @patch("specifyweb.backend.stored_queries.execution.models.session_context")
+    def test_negated_contains_on_tree_rank_field(self, context: Mock):
+        context.return_value = TestRunEphemeralQueryByRank.test_session_context()
+
+        life = self.make_taxontree("Life", "Taxonomy Root")
+        animalia = self.make_taxontree("Animalia", "Kingdom", parent=life)
+        phylum = self.make_taxontree("TestPhylum", "Phylum", parent=animalia)
+
+        models.Determination.objects.create(
+            collectionobject=self.collectionobjects[0],
+            taxon=phylum,
+            iscurrent=True,
+        )
+
+        query = {
+            "contexttableid": 1,
+            "countonly": False,
+            "formatauditrecids": False,
+            "selectdistinct": False,
+            "fields": [
+                {
+                    "fieldname": "Phylum",
+                    "formatname": None,
+                    "isdisplay": True,
+                    "isnot": True,
+                    "isrelfld": False,
+                    "operstart": 11,
+                    "position": 0,
+                    "sorttype": 0,
+                    "startvalue": "Ooof",
+                    "stringid": "1,9-determinations,4.taxon.Phylum",
+                    "isstrict": False,
+                }
+            ],
+        }
+
+        result = run_ephemeral_query(self.collection, self.specifyuser, query)
+
+        self.assertCountEqual(
+            result["results"],
+            [
+                (self.collectionobjects[0].id, "TestPhylum"),
+                (self.collectionobjects[1].id, None),
+                (self.collectionobjects[2].id, None),
+                (self.collectionobjects[3].id, None),
+                (self.collectionobjects[4].id, None),
+            ],
         )


### PR DESCRIPTION
Fixes #7982

Stored queries could crash when a rank tree field was used with a negated operator.  So using the QB with "not equal" on `Determinations -> Taxon -> Phylum` could throw an error.

Tree rank fields resolve to a SQLAlchemy `CASE` expression. The null-safe negation path used `mod_orm_field` or `orm_field`, which attempted to evaluate that SQL expression in Python boolean context and raised the error`TypeError: Boolean value of this clause is not defined`.

Fixed by replacing the boolean `or` fallback with an explicit `is not None` check before calling `null_safe_not()`.  Added a unit test to check this case for the future.

### Checklist

- [x] Self-review the PR after opening it to make sure the changes look good and
      self-explanatory (or properly documented)
- [x] Add relevant issue to release milestone
- [ ] Add pr to documentation list
- [x] Add automated tests

### Testing instructions

- Open Query Builder for `CollectionObject`
- Add the field `Determinations -> Taxon -> Phylum`
- Choose a negated operator flow that maps to "not equal" / negated contains
- Enter a test value
- Run the query
- [x] Confirm the query completes without a crash or 500 error
- [x] Confirm rows with non-matching phylum values are still returned
- [x] Confirm rows with empty phylum values are still handled correctly
