### PR TITLE
Fix blank partial date values in QB results

### DIFF
--- a/specifyweb/backend/stored_queries/format.py
+++ b/specifyweb/backend/stored_queries/format.py
@@ -394,12 +394,14 @@ class ObjectFormatter:
         if field_spec.get_field() is not None:
             if field_spec.is_temporal() and field_spec.date_part == "Full Date":
                 field = self._dateformat(field_spec.get_field(), field)
-
+            elif field_spec.is_temporal() and field_spec.date_part is not None:
+                # Numeric date_part fields are already derived SQL expressions
+                pass
             elif field_spec.is_relationship():
                 pass
-
             else:
                 field = self._fieldformat(field_spec.table, field_spec.get_field(), field)
+        
         return blank_nulls(field) if self.replace_nulls else field
 
     def _dateformat(self, specify_field, field):

--- a/specifyweb/backend/stored_queries/format.py
+++ b/specifyweb/backend/stored_queries/format.py
@@ -434,7 +434,11 @@ class ObjectFormatter:
 
     def _fieldformat(self, table: Table, specify_field: Field,
                      field: InstrumentedAttribute | Extract):
-        if self.format_types and specify_field.is_temporal():
+        if (
+            self.format_types
+            and specify_field.is_temporal()
+            and isinstance(field, InstrumentedAttribute)
+        ):
             return self._dateformat(specify_field, field)
         
         if self.format_agent_type and specify_field is Agent_model.get_field("agenttype"):

--- a/specifyweb/backend/stored_queries/tests/test_execution/test_execute.py
+++ b/specifyweb/backend/stored_queries/tests/test_execution/test_execute.py
@@ -1,7 +1,10 @@
+from datetime import datetime
+
 from specifyweb.specify.models import Collectionobject, Recordset, Recordsetitem
 from specifyweb.backend.stored_queries.execution import execute
+from specifyweb.backend.stored_queries.queryfieldspec import QueryFieldSpec
 from specifyweb.backend.stored_queries.tests.tests import SQLAlchemySetup
-from specifyweb.backend.stored_queries.tests.utils import make_query_fields_test
+from specifyweb.backend.stored_queries.tests.utils import make_query_fields_test, make_query_test
 
 
 class TestExecute(SQLAlchemySetup):
@@ -197,6 +200,60 @@ class TestExecute(SQLAlchemySetup):
         )
 
         self.assertEqual(result_count_only, dict(count=2))
+
+    def test_related_date_part_query_fields(self):
+        self._update(
+            self.collectingevent,
+            {
+                "startdate": datetime(1999, 3, 15),
+                "startdateprecision": 1,
+            },
+        )
+        for collectionobject in self.collectionobjects:
+            self._update(collectionobject, {"collectingevent": self.collectingevent})
+
+        table, query_fields = make_query_fields_test(
+            "Collectionobject",
+            [["collectingEvent", "startDate"]],
+        )
+        year_field = QueryFieldSpec.from_path(
+            ("Collectionobject", "collectingEvent", "startDate")
+        )._replace(date_part="Year")
+        month_field = QueryFieldSpec.from_path(
+            ("Collectionobject", "collectingEvent", "startDate")
+        )._replace(date_part="Month")
+        day_field = QueryFieldSpec.from_path(
+            ("Collectionobject", "collectingEvent", "startDate")
+        )._replace(date_part="Day")
+        query_fields = [
+            make_query_test(year_field),
+            make_query_test(month_field),
+            make_query_test(day_field),
+        ]
+
+        with TestExecute.test_session_context() as session:
+            result = execute(
+                session,
+                self.collection,
+                self.specifyuser,
+                table.tableId,
+                distinct=False,
+                series=False,
+                count_only=False,
+                field_specs=query_fields,
+                limit=0,
+                offset=0,
+            )
+
+        self.assertEqual(
+            {
+                "results": [
+                    (collectionobject.id, 1999, 3, 15)
+                    for collectionobject in self.collectionobjects
+                ]
+            },
+            result,
+        )
 
     def test_simple_query_series(self):
         table, query_fields = make_query_fields_test(


### PR DESCRIPTION
Fixes #7986

Fix a regression where partial date fields in Query Builder results could render as blank values.

Query Builder date-part fields are returned from SQL as extracted expressions like `EXTRACT(Year FROM ...)`.  We were treating those expressions like full date columns and passed them through `DATE_FORMAT()`, which caused partial date result cells to come back blank.

The fix was to stop applying full-date formatting to query result expressions that already represent extracted partial date values, and just keep full-date formatting for actual temporal columns.  I added a unit test covering related partial date query fields for year, month, and day output.

### Checklist

- [x] Self-review the PR after opening it to make sure the changes look good and
      self-explanatory (or properly documented)
- [x] Add relevant issue to release milestone
- [ ] Add pr to documentation list
- [x] Add automated tests

### Testing instructions

- In the QB, build a query that includes a related partial date field such as `Collection Object -> Collecting Event -> Start Date -> Year`.
- [x] Run the query and confirm the partial date column shows values instead of blank cells.
- [x] Repeat with `Month` and `Day`.
- [x] Add the full date field alongside the partial date fields and confirm full date formatting still works.
