### PR TITLE
Show all app resources to users lacking preferences permission

### DIFF
--- a/specifyweb/frontend/js_src/lib/components/AppResources/__tests__/AppResourcesAside.test.tsx
+++ b/specifyweb/frontend/js_src/lib/components/AppResources/__tests__/AppResourcesAside.test.tsx
@@ -11,12 +11,48 @@ import { testAppResources } from './testAppResources';
 requireContext();
 
 jest.mock('../../Permissions/helpers', () => ({
-  hasPermission: jest.fn(),
+  hasPermission: jest.fn(() => true),
   hasToolPermission: jest.fn(() => true),
 }));
 
 describe('AppResourcesAside (simple no conformation case)', () => {
   test('simple no conformation case', () => {
+    const onOpen = jest.fn();
+    const setConformations = jest.fn();
+
+    const { asFragment, unmount } = mount(
+      <AppResourcesAside
+        conformations={[[], setConformations]}
+        filters={undefined}
+        isEmbedded
+        resources={testAppResources}
+        onOpen={onOpen}
+      />
+    );
+
+    expect(asFragment()).toMatchSnapshot();
+    unmount();
+  });
+});
+
+// TEST: This should really (also) be a test for filterAppResources, but
+// including this here just cause
+describe('Missing Collection Preferences Permission', () => {
+  beforeAll(() => {
+    jest.clearAllMocks();
+    jest.mock('../../Permissions/helpers', () => ({
+      hasPermission: jest.fn(() => false),
+      hasToolPermission: jest.fn(() => true),
+    }));
+  });
+  afterAll(() => {
+    jest.clearAllMocks();
+    jest.mock('../../Permissions/helpers', () => ({
+      hasPermission: jest.fn(() => true),
+      hasToolPermission: jest.fn(() => true),
+    }));
+  });
+  test('simple no conformation test', () => {
     const onOpen = jest.fn();
     const setConformations = jest.fn();
 
@@ -111,13 +147,13 @@ describe('AppResourcesAside (expanded case)', () => {
     const laterFragment = asFragmentLater().textContent;
 
     expect(initialFragment).toBe(
-      'Global Resources (0)Discipline Resources (1)Expand AllCollapse All'
+      'Global Resources (2)Discipline Resources (4)Expand AllCollapse All'
     );
     expect(intermediateFragment).toBe(
-      'Global Resources (0)Discipline Resources (1)Botany (1)Expand AllCollapse All'
+      'Global Resources (2)Discipline Resources (4)Botany (4)Expand AllCollapse All'
     );
     expect(laterFragment).toBe(
-      'Global Resources (0)Discipline Resources (1)Expand AllCollapse All'
+      'Global Resources (2)Discipline Resources (4)Expand AllCollapse All'
     );
 
     const expandAllButton = getFinal('button')[2];
@@ -141,7 +177,7 @@ describe('AppResourcesAside (expanded case)', () => {
     const expandedAllFragment = asFragmentAllExpanded().textContent;
 
     expect(expandedAllFragment).toBe(
-      'Global Resources (0)Discipline Resources (1)Botany (1)Add Resourcec (1)Collection PreferencesAdd ResourceUser Accounts (0)testiiif (0)User Types (0)FullAccess (0)Guest (0)LimitedAccess (0)Manager (0)Expand AllCollapse All'
+      'Global Resources (2)Global PreferencesRemote PreferencesAdd ResourceDiscipline Resources (4)Botany (4)Add Resourcec (4)Collection PreferencesAdd ResourceUser Accounts (3)testiiif (3)User PreferencesQueryExtraListQueryFreqListAdd ResourceUser Types (0)FullAccess (0)Guest (0)LimitedAccess (0)Manager (0)Expand AllCollapse All'
     );
     expect(asFragmentAllExpanded()).toMatchSnapshot();
     unmountExpandedll();

--- a/specifyweb/frontend/js_src/lib/components/AppResources/__tests__/AppResourcesAside.test.tsx
+++ b/specifyweb/frontend/js_src/lib/components/AppResources/__tests__/AppResourcesAside.test.tsx
@@ -35,8 +35,10 @@ describe('AppResourcesAside (simple no conformation case)', () => {
   });
 });
 
-// TEST: This should really (also) be a test for filterAppResources, but
-// including this here just cause
+/*
+ * TEST: This should really (also) be a test for filterAppResources, but
+ * including this here just cause
+ */
 describe('Missing Collection Preferences Permission', () => {
   beforeAll(() => {
     jest.clearAllMocks();

--- a/specifyweb/frontend/js_src/lib/components/AppResources/__tests__/__snapshots__/AppResourcesAside.test.tsx.snap
+++ b/specifyweb/frontend/js_src/lib/components/AppResources/__tests__/__snapshots__/AppResourcesAside.test.tsx.snap
@@ -15,43 +15,43 @@ exports[`AppResourcesAside (expanded case) expanded case 1`] = `
     >
       <li
         aria-expanded="false"
-        aria-labelledby="app-resources-tree-4-label"
+        aria-labelledby="app-resources-tree-6-label"
         class="flex flex-col gap-2"
-        id="app-resources-tree-4-li"
+        id="app-resources-tree-6-li"
         role="treeitem"
       >
         <button
-          aria-controls="app-resources-tree-4-li"
+          aria-controls="app-resources-tree-6-li"
           class="link inline text-left font-bold"
-          id="app-resources-tree-4-label"
+          id="app-resources-tree-6-label"
           type="button"
         >
           Global Resources 
           <span
             class="pl-2 text-neutral-500"
           >
-            (0)
+            (2)
           </span>
         </button>
       </li>
       <li
         aria-expanded="true"
-        aria-labelledby="app-resources-tree-5-label"
+        aria-labelledby="app-resources-tree-7-label"
         class="flex flex-col gap-2"
-        id="app-resources-tree-5-li"
+        id="app-resources-tree-7-li"
         role="treeitem"
       >
         <button
-          aria-controls="app-resources-tree-5-li"
+          aria-controls="app-resources-tree-7-li"
           class="link inline text-left font-bold"
-          id="app-resources-tree-5-label"
+          id="app-resources-tree-7-label"
           type="button"
         >
           Discipline Resources 
           <span
             class="pl-2 text-neutral-500"
           >
-            (1)
+            (4)
           </span>
         </button>
         <ul
@@ -61,22 +61,22 @@ exports[`AppResourcesAside (expanded case) expanded case 1`] = `
         >
           <li
             aria-expanded="false"
-            aria-labelledby="app-resources-tree-6-label"
+            aria-labelledby="app-resources-tree-8-label"
             class="flex flex-col gap-2"
-            id="app-resources-tree-6-li"
+            id="app-resources-tree-8-li"
             role="treeitem"
           >
             <button
-              aria-controls="app-resources-tree-6-li"
+              aria-controls="app-resources-tree-8-li"
               class="link inline text-left font-bold"
-              id="app-resources-tree-6-label"
+              id="app-resources-tree-8-label"
               type="button"
             >
               Botany 
               <span
                 class="pl-2 text-neutral-500"
               >
-                (1)
+                (4)
               </span>
             </button>
           </li>
@@ -121,44 +121,127 @@ exports[`AppResourcesAside (expanded case) expanded case 2`] = `
       role="tree"
     >
       <li
-        aria-expanded="false"
-        aria-labelledby="app-resources-tree-9-label"
+        aria-expanded="true"
+        aria-labelledby="app-resources-tree-11-label"
         class="flex flex-col gap-2"
-        id="app-resources-tree-9-li"
+        id="app-resources-tree-11-li"
         role="treeitem"
       >
         <button
-          aria-controls="app-resources-tree-9-li"
+          aria-controls="app-resources-tree-11-li"
           class="link inline text-left font-bold"
-          id="app-resources-tree-9-label"
+          id="app-resources-tree-11-label"
           type="button"
         >
           Global Resources 
           <span
             class="pl-2 text-neutral-500"
           >
-            (0)
+            (2)
           </span>
         </button>
+        <ul
+          aria-label="Resources"
+          class=" pl-4"
+          role="group"
+        >
+          <li>
+            <a
+              class="link [&:not([aria-current]):not(:hover)]:!text-neutral-500"
+              href="/specify/resources/app-resource/1/"
+            >
+              <span
+                aria-hidden="true"
+                title="Other Properties Resource"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="w-6 h-6 flex-shrink-0"
+                  fill="currentColor"
+                  viewBox="0 0 20 20"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    clip-rule="evenodd"
+                    d="M3 4a1 1 0 011-1h12a1 1 0 110 2H4a1 1 0 01-1-1zm0 4a1 1 0 011-1h12a1 1 0 110 2H4a1 1 0 01-1-1zm0 4a1 1 0 011-1h12a1 1 0 110 2H4a1 1 0 01-1-1zm0 4a1 1 0 011-1h12a1 1 0 110 2H4a1 1 0 01-1-1z"
+                    fill-rule="evenodd"
+                  />
+                </svg>
+              </span>
+              Global Preferences
+            </a>
+          </li>
+          <li>
+            <a
+              class="link [&:not([aria-current]):not(:hover)]:!text-neutral-500"
+              href="/specify/resources/app-resource/2/"
+            >
+              <span
+                aria-hidden="true"
+                title="Other Properties Resource"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="w-6 h-6 flex-shrink-0"
+                  fill="currentColor"
+                  viewBox="0 0 20 20"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    clip-rule="evenodd"
+                    d="M3 4a1 1 0 011-1h12a1 1 0 110 2H4a1 1 0 01-1-1zm0 4a1 1 0 011-1h12a1 1 0 110 2H4a1 1 0 01-1-1zm0 4a1 1 0 011-1h12a1 1 0 110 2H4a1 1 0 01-1-1zm0 4a1 1 0 011-1h12a1 1 0 110 2H4a1 1 0 01-1-1z"
+                    fill-rule="evenodd"
+                  />
+                </svg>
+              </span>
+              Remote Preferences
+            </a>
+          </li>
+          <li>
+            <a
+              class="link"
+              href="/specify/resources/create/globalResource/"
+            >
+              <span
+                class="!text-brand-400 print:hidden"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="w-6 h-6 flex-shrink-0"
+                  fill="currentColor"
+                  viewBox="0 0 20 20"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    clip-rule="evenodd"
+                    d="M10 5a1 1 0 011 1v3h3a1 1 0 110 2h-3v3a1 1 0 11-2 0v-3H6a1 1 0 110-2h3V6a1 1 0 011-1z"
+                    fill-rule="evenodd"
+                  />
+                </svg>
+              </span>
+              Add Resource
+            </a>
+          </li>
+        </ul>
       </li>
       <li
         aria-expanded="true"
-        aria-labelledby="app-resources-tree-10-label"
+        aria-labelledby="app-resources-tree-12-label"
         class="flex flex-col gap-2"
-        id="app-resources-tree-10-li"
+        id="app-resources-tree-12-li"
         role="treeitem"
       >
         <button
-          aria-controls="app-resources-tree-10-li"
+          aria-controls="app-resources-tree-12-li"
           class="link inline text-left font-bold"
-          id="app-resources-tree-10-label"
+          id="app-resources-tree-12-label"
           type="button"
         >
           Discipline Resources 
           <span
             class="pl-2 text-neutral-500"
           >
-            (1)
+            (4)
           </span>
         </button>
         <ul
@@ -168,22 +251,22 @@ exports[`AppResourcesAside (expanded case) expanded case 2`] = `
         >
           <li
             aria-expanded="true"
-            aria-labelledby="app-resources-tree-11-label"
+            aria-labelledby="app-resources-tree-13-label"
             class="flex flex-col gap-2"
-            id="app-resources-tree-11-li"
+            id="app-resources-tree-13-li"
             role="treeitem"
           >
             <button
-              aria-controls="app-resources-tree-11-li"
+              aria-controls="app-resources-tree-13-li"
               class="link inline text-left font-bold"
-              id="app-resources-tree-11-label"
+              id="app-resources-tree-13-label"
               type="button"
             >
               Botany 
               <span
                 class="pl-2 text-neutral-500"
               >
-                (1)
+                (4)
               </span>
             </button>
             <ul
@@ -224,22 +307,22 @@ exports[`AppResourcesAside (expanded case) expanded case 2`] = `
             >
               <li
                 aria-expanded="true"
-                aria-labelledby="app-resources-tree-12-label"
+                aria-labelledby="app-resources-tree-14-label"
                 class="flex flex-col gap-2"
-                id="app-resources-tree-12-li"
+                id="app-resources-tree-14-li"
                 role="treeitem"
               >
                 <button
-                  aria-controls="app-resources-tree-12-li"
+                  aria-controls="app-resources-tree-14-li"
                   class="link inline text-left font-bold"
-                  id="app-resources-tree-12-label"
+                  id="app-resources-tree-14-label"
                   type="button"
                 >
                   c 
                   <span
                     class="pl-2 text-neutral-500"
                   >
-                    (1)
+                    (4)
                   </span>
                 </button>
                 <ul
@@ -306,54 +389,6 @@ exports[`AppResourcesAside (expanded case) expanded case 2`] = `
                 >
                   <li
                     aria-expanded="true"
-                    aria-labelledby="app-resources-tree-13-label"
-                    class="flex flex-col gap-2"
-                    id="app-resources-tree-13-li"
-                    role="treeitem"
-                  >
-                    <button
-                      aria-controls="app-resources-tree-13-li"
-                      class="link inline text-left font-bold"
-                      id="app-resources-tree-13-label"
-                      type="button"
-                    >
-                      User Accounts 
-                      <span
-                        class="pl-2 text-neutral-500"
-                      >
-                        (0)
-                      </span>
-                    </button>
-                    <ul
-                      aria-label="Sub-categories"
-                      class=" flex flex-col gap-2 pl-4"
-                      role="group"
-                    >
-                      <li
-                        aria-expanded="false"
-                        aria-labelledby="app-resources-tree-14-label"
-                        class="flex flex-col gap-2"
-                        id="app-resources-tree-14-li"
-                        role="treeitem"
-                      >
-                        <button
-                          aria-controls="app-resources-tree-14-li"
-                          class="link inline text-left font-bold"
-                          id="app-resources-tree-14-label"
-                          type="button"
-                        >
-                          testiiif 
-                          <span
-                            class="pl-2 text-neutral-500"
-                          >
-                            (0)
-                          </span>
-                        </button>
-                      </li>
-                    </ul>
-                  </li>
-                  <li
-                    aria-expanded="true"
                     aria-labelledby="app-resources-tree-15-label"
                     class="flex flex-col gap-2"
                     id="app-resources-tree-15-li"
@@ -363,6 +398,163 @@ exports[`AppResourcesAside (expanded case) expanded case 2`] = `
                       aria-controls="app-resources-tree-15-li"
                       class="link inline text-left font-bold"
                       id="app-resources-tree-15-label"
+                      type="button"
+                    >
+                      User Accounts 
+                      <span
+                        class="pl-2 text-neutral-500"
+                      >
+                        (3)
+                      </span>
+                    </button>
+                    <ul
+                      aria-label="Sub-categories"
+                      class=" flex flex-col gap-2 pl-4"
+                      role="group"
+                    >
+                      <li
+                        aria-expanded="true"
+                        aria-labelledby="app-resources-tree-16-label"
+                        class="flex flex-col gap-2"
+                        id="app-resources-tree-16-li"
+                        role="treeitem"
+                      >
+                        <button
+                          aria-controls="app-resources-tree-16-li"
+                          class="link inline text-left font-bold"
+                          id="app-resources-tree-16-label"
+                          type="button"
+                        >
+                          testiiif 
+                          <span
+                            class="pl-2 text-neutral-500"
+                          >
+                            (3)
+                          </span>
+                        </button>
+                        <ul
+                          aria-label="Resources"
+                          class=" pl-4"
+                          role="group"
+                        >
+                          <li>
+                            <a
+                              class="link [&:not([aria-current]):not(:hover)]:!text-neutral-500"
+                              href="/specify/resources/app-resource/5/"
+                            >
+                              <span
+                                aria-hidden="true"
+                                title="User Preferences"
+                              >
+                                <svg
+                                  aria-hidden="true"
+                                  class="w-6 h-6 flex-shrink-0"
+                                  fill="currentColor"
+                                  viewBox="0 0 20 20"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    clip-rule="evenodd"
+                                    d="M11.49 3.17c-.38-1.56-2.6-1.56-2.98 0a1.532 1.532 0 01-2.286.948c-1.372-.836-2.942.734-2.106 2.106.54.886.061 2.042-.947 2.287-1.561.379-1.561 2.6 0 2.978a1.532 1.532 0 01.947 2.287c-.836 1.372.734 2.942 2.106 2.106a1.532 1.532 0 012.287.947c.379 1.561 2.6 1.561 2.978 0a1.533 1.533 0 012.287-.947c1.372.836 2.942-.734 2.106-2.106a1.533 1.533 0 01.947-2.287c1.561-.379 1.561-2.6 0-2.978a1.532 1.532 0 01-.947-2.287c.836-1.372-.734-2.942-2.106-2.106a1.532 1.532 0 01-2.287-.947zM10 13a3 3 0 100-6 3 3 0 000 6z"
+                                    fill-rule="evenodd"
+                                  />
+                                </svg>
+                              </span>
+                              User Preferences
+                            </a>
+                          </li>
+                          <li>
+                            <a
+                              class="link [&:not([aria-current]):not(:hover)]:!text-neutral-500"
+                              href="/specify/resources/app-resource/4/"
+                            >
+                              <span
+                                aria-hidden="true"
+                                title="Other XML Resource"
+                              >
+                                <svg
+                                  aria-hidden="true"
+                                  class="w-6 h-6 flex-shrink-0"
+                                  fill="currentColor"
+                                  viewBox="0 0 20 20"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    clip-rule="evenodd"
+                                    d="M12.316 3.051a1 1 0 01.633 1.265l-4 12a1 1 0 11-1.898-.632l4-12a1 1 0 011.265-.633zM5.707 6.293a1 1 0 010 1.414L3.414 10l2.293 2.293a1 1 0 11-1.414 1.414l-3-3a1 1 0 010-1.414l3-3a1 1 0 011.414 0zm8.586 0a1 1 0 011.414 0l3 3a1 1 0 010 1.414l-3 3a1 1 0 11-1.414-1.414L16.586 10l-2.293-2.293a1 1 0 010-1.414z"
+                                    fill-rule="evenodd"
+                                  />
+                                </svg>
+                              </span>
+                              QueryExtraList
+                            </a>
+                          </li>
+                          <li>
+                            <a
+                              class="link [&:not([aria-current]):not(:hover)]:!text-neutral-500"
+                              href="/specify/resources/app-resource/3/"
+                            >
+                              <span
+                                aria-hidden="true"
+                                title="Other XML Resource"
+                              >
+                                <svg
+                                  aria-hidden="true"
+                                  class="w-6 h-6 flex-shrink-0"
+                                  fill="currentColor"
+                                  viewBox="0 0 20 20"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    clip-rule="evenodd"
+                                    d="M12.316 3.051a1 1 0 01.633 1.265l-4 12a1 1 0 11-1.898-.632l4-12a1 1 0 011.265-.633zM5.707 6.293a1 1 0 010 1.414L3.414 10l2.293 2.293a1 1 0 11-1.414 1.414l-3-3a1 1 0 010-1.414l3-3a1 1 0 011.414 0zm8.586 0a1 1 0 011.414 0l3 3a1 1 0 010 1.414l-3 3a1 1 0 11-1.414-1.414L16.586 10l-2.293-2.293a1 1 0 010-1.414z"
+                                    fill-rule="evenodd"
+                                  />
+                                </svg>
+                              </span>
+                              QueryFreqList
+                            </a>
+                          </li>
+                          <li>
+                            <a
+                              class="link"
+                              href="/specify/resources/create/collection_4_user_1/"
+                            >
+                              <span
+                                class="!text-brand-400 print:hidden"
+                              >
+                                <svg
+                                  aria-hidden="true"
+                                  class="w-6 h-6 flex-shrink-0"
+                                  fill="currentColor"
+                                  viewBox="0 0 20 20"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    clip-rule="evenodd"
+                                    d="M10 5a1 1 0 011 1v3h3a1 1 0 110 2h-3v3a1 1 0 11-2 0v-3H6a1 1 0 110-2h3V6a1 1 0 011-1z"
+                                    fill-rule="evenodd"
+                                  />
+                                </svg>
+                              </span>
+                              Add Resource
+                            </a>
+                          </li>
+                        </ul>
+                      </li>
+                    </ul>
+                  </li>
+                  <li
+                    aria-expanded="true"
+                    aria-labelledby="app-resources-tree-17-label"
+                    class="flex flex-col gap-2"
+                    id="app-resources-tree-17-li"
+                    role="treeitem"
+                  >
+                    <button
+                      aria-controls="app-resources-tree-17-li"
+                      class="link inline text-left font-bold"
+                      id="app-resources-tree-17-label"
                       type="button"
                     >
                       User Types 
@@ -379,48 +571,6 @@ exports[`AppResourcesAside (expanded case) expanded case 2`] = `
                     >
                       <li
                         aria-expanded="false"
-                        aria-labelledby="app-resources-tree-16-label"
-                        class="flex flex-col gap-2"
-                        id="app-resources-tree-16-li"
-                        role="treeitem"
-                      >
-                        <button
-                          aria-controls="app-resources-tree-16-li"
-                          class="link inline text-left font-bold"
-                          id="app-resources-tree-16-label"
-                          type="button"
-                        >
-                          FullAccess 
-                          <span
-                            class="pl-2 text-neutral-500"
-                          >
-                            (0)
-                          </span>
-                        </button>
-                      </li>
-                      <li
-                        aria-expanded="false"
-                        aria-labelledby="app-resources-tree-17-label"
-                        class="flex flex-col gap-2"
-                        id="app-resources-tree-17-li"
-                        role="treeitem"
-                      >
-                        <button
-                          aria-controls="app-resources-tree-17-li"
-                          class="link inline text-left font-bold"
-                          id="app-resources-tree-17-label"
-                          type="button"
-                        >
-                          Guest 
-                          <span
-                            class="pl-2 text-neutral-500"
-                          >
-                            (0)
-                          </span>
-                        </button>
-                      </li>
-                      <li
-                        aria-expanded="false"
                         aria-labelledby="app-resources-tree-18-label"
                         class="flex flex-col gap-2"
                         id="app-resources-tree-18-li"
@@ -432,7 +582,7 @@ exports[`AppResourcesAside (expanded case) expanded case 2`] = `
                           id="app-resources-tree-18-label"
                           type="button"
                         >
-                          LimitedAccess 
+                          FullAccess 
                           <span
                             class="pl-2 text-neutral-500"
                           >
@@ -451,6 +601,48 @@ exports[`AppResourcesAside (expanded case) expanded case 2`] = `
                           aria-controls="app-resources-tree-19-li"
                           class="link inline text-left font-bold"
                           id="app-resources-tree-19-label"
+                          type="button"
+                        >
+                          Guest 
+                          <span
+                            class="pl-2 text-neutral-500"
+                          >
+                            (0)
+                          </span>
+                        </button>
+                      </li>
+                      <li
+                        aria-expanded="false"
+                        aria-labelledby="app-resources-tree-20-label"
+                        class="flex flex-col gap-2"
+                        id="app-resources-tree-20-li"
+                        role="treeitem"
+                      >
+                        <button
+                          aria-controls="app-resources-tree-20-li"
+                          class="link inline text-left font-bold"
+                          id="app-resources-tree-20-label"
+                          type="button"
+                        >
+                          LimitedAccess 
+                          <span
+                            class="pl-2 text-neutral-500"
+                          >
+                            (0)
+                          </span>
+                        </button>
+                      </li>
+                      <li
+                        aria-expanded="false"
+                        aria-labelledby="app-resources-tree-21-label"
+                        class="flex flex-col gap-2"
+                        id="app-resources-tree-21-li"
+                        role="treeitem"
+                      >
+                        <button
+                          aria-controls="app-resources-tree-21-li"
+                          class="link inline text-left font-bold"
+                          id="app-resources-tree-21-label"
                           type="button"
                         >
                           Manager 
@@ -524,7 +716,7 @@ exports[`AppResourcesAside (simple no conformation case) simple no conformation 
           <span
             class="pl-2 text-neutral-500"
           >
-            (0)
+            (2)
           </span>
         </button>
       </li>
@@ -545,7 +737,87 @@ exports[`AppResourcesAside (simple no conformation case) simple no conformation 
           <span
             class="pl-2 text-neutral-500"
           >
-            (1)
+            (4)
+          </span>
+        </button>
+      </li>
+    </ul>
+    <div
+      class="flex flex-wrap gap-2"
+    >
+      <button
+        class="button rounded cursor-pointer active:brightness-80 px-4 py-2
+    disabled:bg-gray-200 disabled:dark:ring-neutral-500 disabled:ring-gray-400 disabled:text-gray-500 
+    dark:disabled:!bg-neutral-700 gap-2 inline-flex items-center capitalize justify-center shadow-sm dialog-icon-info hover:brightness-90 dark:hover:brightness-140 bg-[color:var(--info-button-color)] text-white grow"
+        type="button"
+      >
+        Expand All
+      </button>
+      <button
+        class="button rounded cursor-pointer active:brightness-80 px-4 py-2
+    disabled:bg-gray-200 disabled:dark:ring-neutral-500 disabled:ring-gray-400 disabled:text-gray-500 
+    dark:disabled:!bg-neutral-700 gap-2 inline-flex items-center capitalize justify-center shadow-sm dialog-icon-info hover:brightness-90 dark:hover:brightness-140 bg-[color:var(--info-button-color)] text-white grow"
+        type="button"
+      >
+        Collapse All
+      </button>
+    </div>
+  </aside>
+</DocumentFragment>
+`;
+
+exports[`Missing Collection Preferences Permission simple no conformation test 1`] = `
+<DocumentFragment>
+  <aside
+    class="
+        !gap-2 sm:overflow-visible
+        flex flex-col gap-4 overflow-scroll
+  overflow-x-auto [overflow-y:overlay] [scrollbar-gutter:auto] 
+      "
+  >
+    <ul
+      class=" flex flex-1 flex-col gap-1 overflow-auto"
+      role="tree"
+    >
+      <li
+        aria-expanded="false"
+        aria-labelledby="app-resources-tree-2-label"
+        class="flex flex-col gap-2"
+        id="app-resources-tree-2-li"
+        role="treeitem"
+      >
+        <button
+          aria-controls="app-resources-tree-2-li"
+          class="link inline text-left font-bold"
+          id="app-resources-tree-2-label"
+          type="button"
+        >
+          Global Resources 
+          <span
+            class="pl-2 text-neutral-500"
+          >
+            (2)
+          </span>
+        </button>
+      </li>
+      <li
+        aria-expanded="false"
+        aria-labelledby="app-resources-tree-3-label"
+        class="flex flex-col gap-2"
+        id="app-resources-tree-3-li"
+        role="treeitem"
+      >
+        <button
+          aria-controls="app-resources-tree-3-li"
+          class="link inline text-left font-bold"
+          id="app-resources-tree-3-label"
+          type="button"
+        >
+          Discipline Resources 
+          <span
+            class="pl-2 text-neutral-500"
+          >
+            (4)
           </span>
         </button>
       </li>

--- a/specifyweb/frontend/js_src/lib/components/AppResources/filtersHelpers.ts
+++ b/specifyweb/frontend/js_src/lib/components/AppResources/filtersHelpers.ts
@@ -58,7 +58,7 @@ export const filterAppResources = (
   );
 
   const finalAppResources = baseAppResources.filter((resource) => {
-    if (resource.name !== 'CollectionPreferences') {
+    if (resource.name === 'CollectionPreferences') {
       return hasEditPermission;
     }
     return true;


### PR DESCRIPTION
Fixes part of #7984

> The other is an error in the filter behavior to determine which App Resources to show that was introduced by [f27aa03](https://github.com/specify/specify7/commit/f27aa03dbff04c0304037216bf07990cb796297f) in [#7557](https://github.com/specify/specify7/pull/7557):
> 
> [specify7/specifyweb/frontend/js_src/lib/components/AppResources/filtersHelpers.ts](https://github.com/specify/specify7/blob/816121c99a86c5a7a37ef2851df9a8ea477c3ec1/specifyweb/frontend/js_src/lib/components/AppResources/filtersHelpers.ts#L55-L63)
> 
> Lines 55 to 63 in [816121c](/specify/specify7/commit/816121c99a86c5a7a37ef2851df9a8ea477c3ec1)
> 
>  const hasEditPermission = hasPermission( 
>    '/preferences/collection', 
>    'edit_collection' 
>  ); 
>   
>  const finalAppResources = baseAppResources.filter((resource) => { 
>    if (resource.name !== 'CollectionPreferences') { 
>      return hasEditPermission; 
>    } 
> If the user does not have permissions to edit the new Collection Preferences, then _all_ AppResources will be hidden except for Collection Preferences. The intention here was to clearly flip that behavior and only hide the Collection Preferences when the user does not have the permission

### Checklist

- [x] Self-review the PR after opening it to make sure the changes look good and
      self-explanatory (or properly documented)
- [x] Add relevant issue to release milestone
- [ ] Add pr to documentation list
- [x] Add automated tests


### Testing instructions
> 💡 In the application, the `/preferences/collection > edit_collection` permission is displayed as `Preferences > Collection > Edit Collection`
> <img width="493" height="50" alt="Screenshot 2026-04-17 at 12 52 51 PM" src="https://github.com/user-attachments/assets/b8436c40-bcff-4cb6-b7dd-5b6a6727688d" />


- Login to a specify instance as a user which has the `/preferences/collection > edit_collection` permission
- [ ] Ensure that all App Resources in all scopes are present on this branch compared to the instance on `v7.11.4`
- Login to a specify instance as a user which does not have the `/preferences/collection > edit_collection` permission
- [ ] Ensure that _only_ the Collection Preferences App Resources scoped to Collection are not visible when compared to the instance on `v7.11.4`