### PR TITLE
Prevent startup permission initialization from re-granting legacy collection access

### DIFF
--- a/.env
+++ b/.env
@@ -3,6 +3,9 @@ DATABASE_PORT=3306
 MYSQL_ROOT_PASSWORD=password
 DATABASE_NAME=specify
 
+# Decide whether to run key migration functions on startup.
+RUN_KEY_MIGRATION_ON_STARTUP=0
+
 # The following are database users with specific roles and privileges. 
 # If the migrator and app user are not defined, the system will use the master user credentials.
 # See documenation https://discourse.specifysoftware.org/t/new-blank-database-creation-database-user-levels/3023

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -13,7 +13,10 @@ if [ "$1" = 've/bin/gunicorn' ] || [ "$1" = 've/bin/python' ]; then
   ./sp7_db_setup_check.sh # Setup db users and run mirgations
   # ve/bin/python manage.py base_specify_migration
   # ve/bin/python manage.py migrate
-  ve/bin/python manage.py run_key_migration_functions # Uncomment if you want the key migration functions to run on startup.
+  if [ "${RUN_KEY_MIGRATION_ON_STARTUP:-0}" = "1" ]; then
+    echo "Running key migration functions."
+    ve/bin/python manage.py run_key_migration_functions
+  fi
   set -e
 fi
 exec "$@"

--- a/specifyweb/backend/permissions/initialize.py
+++ b/specifyweb/backend/permissions/initialize.py
@@ -32,16 +32,22 @@ def is_sp6_user_permissions_migrated(user, apps=apps) -> bool:
     return UserRole.objects.filter(specifyuser=user).exists() or \
         UserPolicy.objects.filter(specifyuser=user).exists()
 
-def initialize(wipe: bool=False, apps=apps) -> None:
+def initialize(
+    wipe: bool = False,
+    apps=apps,
+    *,
+    migrate_sp6_users: bool = True,
+) -> None:
     with transaction.atomic():
         if wipe:
             wipe_permissions(apps)
         create_admins(apps)
         create_roles(apps)
-        if 'test' in ''.join(sys.argv):
-            assign_users_to_roles_during_testing(apps)
-        else:
-            assign_users_to_roles(apps)
+        if migrate_sp6_users:
+            if 'test' in ''.join(sys.argv):
+                assign_users_to_roles_during_testing(apps)
+            else:
+                assign_users_to_roles(apps)
 
 def create_admins(apps=apps) -> None:
     UserPolicy = apps.get_model('permissions', 'UserPolicy')

--- a/specifyweb/backend/setup_tool/schema_defaults.py
+++ b/specifyweb/backend/setup_tool/schema_defaults.py
@@ -84,6 +84,8 @@ def queue_apply_schema_defaults_background(discipline_id: int) -> str:
 @app.task(bind=True, max_retries=SCHEMA_DEFAULTS_MISSING_DISCIPLINE_MAX_RETRIES)
 def apply_schema_defaults_task(self, discipline_id: int):
     """Run schema localization defaults for one discipline in a background worker."""
+    task_id = getattr(self.request, 'id', None)
+
     try:
         discipline = Discipline.objects.get(id=discipline_id)
     except Discipline.DoesNotExist as exc:
@@ -98,9 +100,11 @@ def apply_schema_defaults_task(self, discipline_id: int):
                 discipline_id,
                 SCHEMA_DEFAULTS_MISSING_DISCIPLINE_MAX_RETRIES,
             )
-            finish_discipline_background_task(discipline_id, self.request.id)
+            if task_id is not None:
+                finish_discipline_background_task(discipline_id, task_id)
             return
     try:
         apply_schema_defaults(discipline)
     finally:
-        finish_discipline_background_task(discipline_id, self.request.id)
+        if task_id is not None:
+            finish_discipline_background_task(discipline_id, task_id)

--- a/specifyweb/specify/management/commands/run_key_migration_functions.py
+++ b/specifyweb/specify/management/commands/run_key_migration_functions.py
@@ -129,7 +129,7 @@ def fix_business_rules(stdout: WriteToStdOut | None = None):
     log_and_run(funcs, stdout)
 
 def initialize_permissions(apps):
-    initialize(False, apps)
+    initialize(False, apps, migrate_sp6_users=False)
 
 def fix_permissions(stdout: WriteToStdOut | None = None):
     funcs = [


### PR DESCRIPTION
## Summary

This change stops the startup `run_key_migration_functions` path from re-importing legacy SP6 collection access into SP7 permissions.  Because the startup path re-ran the full initializer, users with legacy SP6 principal rows could regain `/system/sp7/collection` access on startup, even if that SP7 access had been intentionally removed.

Made running the key migrations function optional at startup with RUN_KEY_MIGRATION_ON_STARTUP=0 in the .env file.  Also fixed the warning of null tasks from happening in the key migration logs.

### Checklist

- [ ] Self-review the PR after opening it to make sure the changes look good and
      self-explanatory (or properly documented)
- [ ] Add relevant issue to release milestone
- [ ] Add pr to documentation list
