### PR TITLE
Correct creation of and deduplicate SpAppResourceDirs

### DIFF
--- a/specifyweb/backend/setup_tool/app_resource_defaults.py
+++ b/specifyweb/backend/setup_tool/app_resource_defaults.py
@@ -89,7 +89,6 @@ def _ensure_discipline_resource_dir(
         Spappresourcedir.objects.filter(
             discipline=discipline,
             collection__isnull=True,
-            specifyuser__isnull=True,
             usertype__isnull=True,
             ispersonal=False
         )
@@ -100,7 +99,12 @@ def _ensure_discipline_resource_dir(
         return (
             Spappresourcedir.objects.create(
             discipline=discipline,
-            disciplinetype=discipline.type,
+            # This is intentional and not a typo.
+            # DisciplineType is actually the Discipline Name for
+            # SpAppResourceDir records...
+            # This is another weird behavior from Specify 6 :/
+            # See #7984
+            disciplinetype=discipline.name,
             ispersonal=False,
             ),
             True,
@@ -108,8 +112,8 @@ def _ensure_discipline_resource_dir(
         )
 
     was_updated = False
-    if existing_dir.disciplinetype != discipline.type:
-        existing_dir.disciplinetype = discipline.type
+    if existing_dir.disciplinetype != discipline.name:
+        existing_dir.disciplinetype = discipline.name
         existing_dir.save(update_fields=['disciplinetype'])
         was_updated = True
 
@@ -125,7 +129,7 @@ def ensure_all_discipline_resource_dirs() -> dict[str, int]:
     created = 0
     updated = 0
 
-    for discipline in Discipline.objects.only('id', 'type'):
+    for discipline in Discipline.objects.only('id', 'name'):
         total += 1
         _, was_created, was_updated = _ensure_discipline_resource_dir(discipline)
         if was_created:

--- a/specifyweb/specify/management/commands/run_key_migration_functions.py
+++ b/specifyweb/specify/management/commands/run_key_migration_functions.py
@@ -4,6 +4,7 @@ from collections.abc import Callable, Iterable
 from django.core.management.base import BaseCommand
 from django.apps import apps
 from django.db import transaction
+from django.db.models import Exists, OuterRef, Q
 from specifyweb.backend.businessrules.migration_utils import catnum_rule_editable
 from specifyweb.backend.businessrules.uniqueness_rules import (
     apply_default_uniqueness_rules,
@@ -95,9 +96,37 @@ def fix_schema_config(stdout: WriteToStdOut | None = None):
     ]
     log_and_run(funcs, stdout)
 
-def fix_app_resource_dirs(stdout: WriteToStdOut | None = None):
-    from specifyweb.backend.setup_tool.app_resource_defaults import ensure_all_discipline_resource_dirs
+def deduplicate_discipline_resource_dirs(apps):
+    """
+    De-deuplicate SpAppResourceDirs scoped to Discipline.
+    We will attempt to preserve the oldest SpAppResourceDir, and will only
+    remove SpAppResourceDirs that are completely empty (do not have any related
+    view sets or appresources)
+    """
+    SpAppResourceDir = apps.get_model('specify', 'SpAppResourceDir')
+    with transaction.atomic():
+        common_filters = {
+            "collection__isnull": True,
+            "usertype__isnull": True,
+            "ispersonal": False,
+        }
+        duplicate_dirs = SpAppResourceDir.objects.filter(
+            sppersistedviewsets__isnull=True,
+            sppersistedappresources__isnull=True,
+            **common_filters
+            ).annotate(
+                earlier_exists=Exists(
+                    SpAppResourceDir.objects.filter(
+                        discipline_id=OuterRef('discipline_id'),
+                        timestampcreated__lt=OuterRef('timestampcreated'),
+                        **common_filters
+                )
+            )
+        ).filter(earlier_exists=True)
+        duplicate_dirs.delete()
 
+def create_missing_app_resource_dirs(stdout, apps):
+    from specifyweb.backend.setup_tool.app_resource_defaults import ensure_all_discipline_resource_dirs
     results = ensure_all_discipline_resource_dirs()
     if stdout is not None:
         stdout(
@@ -106,6 +135,13 @@ def fix_app_resource_dirs(stdout: WriteToStdOut | None = None):
             f"created={results['created']}, "
             f"updated={results['updated']}"
         )
+
+def fix_app_resource_dirs(stdout: WriteToStdOut | None = None):
+    funcs = [
+        lambda apps: create_missing_app_resource_dirs(stdout, apps),
+        deduplicate_discipline_resource_dirs,
+    ]
+    log_and_run(funcs, stdout)
 
 def apply_default_uniqueness_rules_to_disciplines(apps):
     Discipline = apps.get_model('specify', 'Discipline')

--- a/specifyweb/specify/migration_utils/update_schema_config.py
+++ b/specifyweb/specify/migration_utils/update_schema_config.py
@@ -701,7 +701,7 @@ def deduplicate_schema_config_sql(apps=None):
     cursor.execute(dedupe_sql)
     cursor.close()
 
-def deduplicate_schema_config_orm(apps, schema_editor=None):
+def deduplicate_splocalecontainers(apps):
     Container = apps.get_model('specify', 'SpLocaleContainer')
     ContainerItem = apps.get_model('specify', 'SpLocaleContainerItem')
     ItemStr = apps.get_model('specify', 'SpLocaleItemStr')
@@ -743,6 +743,11 @@ def deduplicate_schema_config_orm(apps, schema_editor=None):
         ItemStr.objects.filter(containerdesc__in=duplicate_containers).delete()
         duplicate_containers.delete()
 
+
+def deduplicate_containeritems_and_strings(apps):
+    ContainerItem = apps.get_model('specify', 'SpLocaleContainerItem')
+    ItemStr = apps.get_model('specify', 'SpLocaleItemStr')
+    with transaction.atomic():
         # Identify duplicate container items using a Window function.
         # Partition by container_id + item name only.
         # Only schema type 0 containers (standard schema) are eligible for this cleanup.
@@ -784,6 +789,11 @@ def deduplicate_schema_config_orm(apps, schema_editor=None):
             print(f"Successfully deleted {len(ids_to_delete)} duplicate schema items.")
         else:
             print("No duplicates found.")
+
+def deduplicate_schema_config_orm(apps, schema_editor=None):
+    with transaction.atomic():
+        deduplicate_splocalecontainers(apps)
+        deduplicate_containeritems_and_strings(apps)
 
 # ##############################################################################
 # Migration schema config helper functions


### PR DESCRIPTION
Fixes part of #7984
Companion of #7990

### Checklist

- [x] Self-review the PR after opening it to make sure the changes look good and
      self-explanatory (or properly documented)
- [x] Add relevant issue to release milestone
- [ ] Add pr to documentation list
- [ ] Add automated tests
- [x] Add migration function to https://github.com/specify/specify7/blob/ea04665987e1b8a1b76955c7b7f702b7bf701b47/specifyweb/specify/management/commands/run_key_migration_functions.py#L50


### Testing instructions

If needed, you can use the following Query to identity SpAppResourceDirs and any AppResources within those "directories":

```sql
SELECT dir.SpAppResourceDirID, dir.TimestampCreated, dir.DisciplineID, dir.SpecifyUserID, dir.DisciplineType, dir.UserType, CASE WHEN dir.IsPersonal=1 THEN 'True' ELSE 'False' END AS 'Is Personal', appresource.Description, appresource.Level, appresource.MimeType, appresource.Name FROM SpAppResourceDir dir LEFT OUTER JOIN SpAppResource appresource ON appresource.SpAppResourceDirID=dir.SpAppResourceDirID ORDER BY dir.SpAppResourceDirID;
```

You can also use the following query to idenity SpAppResourceDirs and any View Sets within those "directories": 
```sql
SELECT dir.SpAppResourceDirID, dir.TimestampCreated, dir.DisciplineID, dir.SpecifyUserID, dir.DisciplineType, dir.UserType, CASE WHEN dir.IsPersonal=1 THEN 'True' ELSE 'False' END AS 'Is Personal', viewset.FileName, viewset.Level, viewset.Name FROM SpAppResourceDir dir LEFT OUTER JOIN SpViewsetObj viewset ON viewset.SpAppResourceDirID=dir.SpAppResourceDirID ORDER BY dir.SpAppResourceDirID;
```

For the Issue when looking for duplicates, you will be looking for SpAppResourceDir records that have a new Timestamp Created and have the following attributes (which should appear in earlier SpAppResourceDir records if they previously existed): 
- a non-NULL DisciplineID
- NULL CollectionID
- NULL UserType
- False IsPersonal

- Use a database that has migrations ran from any version of `v7.12.0.0`-`v7.12.0.3` (and thus will have duplicated SpAppResourceDirs)
- [ ] Execute the `run_key_migration_functions` and ensure the duplicate SpAppResourceDir records get deleted 
- Use a database that does not have migrations from any version of `v7.12.0` ran on it
- [ ] Ensure that there are no duplicated SpAppResourceDir records, and if any were created that they have a "correct" DisciplineType (the name of the Discipline they're assigned to)