### PR TITLE
Prevent regranting legacy user roles and access

### DIFF
--- a/specifyweb/backend/permissions/initialize.py
+++ b/specifyweb/backend/permissions/initialize.py
@@ -32,16 +32,22 @@ def is_sp6_user_permissions_migrated(user, apps=apps) -> bool:
     return UserRole.objects.filter(specifyuser=user).exists() or \
         UserPolicy.objects.filter(specifyuser=user).exists()
 
-def initialize(wipe: bool=False, apps=apps) -> None:
+def initialize(
+    wipe: bool = False,
+    apps=apps,
+    *,
+    migrate_sp6_users: bool = True,
+) -> None:
     with transaction.atomic():
         if wipe:
             wipe_permissions(apps)
         create_admins(apps)
         create_roles(apps)
-        if 'test' in ''.join(sys.argv):
-            assign_users_to_roles_during_testing(apps)
-        else:
-            assign_users_to_roles(apps)
+        if migrate_sp6_users:
+            if 'test' in ''.join(sys.argv):
+                assign_users_to_roles_during_testing(apps)
+            else:
+                assign_users_to_roles(apps)
 
 def create_admins(apps=apps) -> None:
     UserPolicy = apps.get_model('permissions', 'UserPolicy')

--- a/specifyweb/backend/setup_tool/schema_defaults.py
+++ b/specifyweb/backend/setup_tool/schema_defaults.py
@@ -84,6 +84,8 @@ def queue_apply_schema_defaults_background(discipline_id: int) -> str:
 @app.task(bind=True, max_retries=SCHEMA_DEFAULTS_MISSING_DISCIPLINE_MAX_RETRIES)
 def apply_schema_defaults_task(self, discipline_id: int):
     """Run schema localization defaults for one discipline in a background worker."""
+    task_id = getattr(self.request, 'id', None)
+
     try:
         discipline = Discipline.objects.get(id=discipline_id)
     except Discipline.DoesNotExist as exc:
@@ -98,9 +100,11 @@ def apply_schema_defaults_task(self, discipline_id: int):
                 discipline_id,
                 SCHEMA_DEFAULTS_MISSING_DISCIPLINE_MAX_RETRIES,
             )
-            finish_discipline_background_task(discipline_id, self.request.id)
+            if task_id is not None:
+                finish_discipline_background_task(discipline_id, task_id)
             return
     try:
         apply_schema_defaults(discipline)
     finally:
-        finish_discipline_background_task(discipline_id, self.request.id)
+        if task_id is not None:
+            finish_discipline_background_task(discipline_id, task_id)

--- a/specifyweb/specify/management/commands/run_key_migration_functions.py
+++ b/specifyweb/specify/management/commands/run_key_migration_functions.py
@@ -129,7 +129,7 @@ def fix_business_rules(stdout: WriteToStdOut | None = None):
     log_and_run(funcs, stdout)
 
 def initialize_permissions(apps):
-    initialize(False, apps)
+    initialize(False, apps, migrate_sp6_users=False)
 
 def fix_permissions(stdout: WriteToStdOut | None = None):
     funcs = [

--- a/specifyweb/specify/management/commands/run_key_migration_functions.py
+++ b/specifyweb/specify/management/commands/run_key_migration_functions.py
@@ -56,7 +56,7 @@ def fix_schema_config(stdout: WriteToStdOut | None = None):
                 stdout(
                     f"Applying schema defaults/overrides for discipline {discipline.id} ({discipline.type})..."
                 )
-            apply_schema_defaults_task.run(discipline.id)
+            apply_schema_defaults_task.apply(args=[discipline.id])
 
     funcs = [
         # usc.update_all_table_schema_config_with_defaults,


### PR DESCRIPTION
Brings in changes from #7992, while keeping the run key migration functions enabled by default

<!--
> [!WARNING]  
> This PR affects database migrations. See [migration testing instructions](https://specify.github.io/testing/pull_requests.html#prs-tagged-with-label-migration).
-->

### Checklist

- [ ] Self-review the PR after opening it to make sure the changes look good and
      self-explanatory (or properly documented)
- [ ] Add relevant issue to release milestone
- [ ] Add pr to documentation list
- [ ] Add automated tests
- [ ] Add a reverse migration if a migration is present in the PR
- [ ] Add migration function to https://github.com/specify/specify7/blob/ea04665987e1b8a1b76955c7b7f702b7bf701b47/specifyweb/specify/management/commands/run_key_migration_functions.py#L50


### Testing instructions
