### PR TITLE
Upgrade PyJWT from version 2.4.0 to 2.12.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ SQLAlchemy==1.4.54
 sqlalchemy2-stubs
 requests==2.32.4
 pycryptodome==3.21.0
-PyJWT==2.4.0
+PyJWT==2.12.1
 django-auth-ldap==1.2.17
 jsonschema==4.0.1
 typing-extensions==4.12.2


### PR DESCRIPTION
Fixes #7996 
Fixes https://github.com/specify/specify7/security/dependabot/196

Updating PyJWT from version 2.4.0 to the latest 2.12.1 version didn't require any code changes, just a simple upgrade.

### Checklist

- [x] Self-review the PR after opening it to make sure the changes look good and
      self-explanatory (or properly documented)
- [x] Add relevant issue to release milestone
- [ ] Add pr to documentation list


### Testing instructions

- [x] Light general testing.  The upgraded package is involved in API requests, so just make sure no new errors pop-up from API requests.
- [x] Test the logging into Specify works.
