### PR TITLE
Fix cascaded Discipline delete blockers for Division

### DIFF
--- a/specifyweb/backend/delete_blockers/views.py
+++ b/specifyweb/backend/delete_blockers/views.py
@@ -6,6 +6,7 @@ from specifyweb.middleware.general import require_http_methods
 from specifyweb.specify.api.crud import (
     get_discipline_delete_guard_blockers,
     get_object_or_404,
+    prepare_delete_cascade_disciplines,
     prepare_discipline_for_delete,
 )
 from specifyweb.specify.api.serializers import toJson
@@ -32,8 +33,10 @@ def delete_blockers(request, model, id):
                 result = _collect_delete_blockers(obj, using)
                 transaction.set_rollback(True, using=using)
     else:
-        # Standard delete blockers behavior
-        result = _collect_delete_blockers(obj, using)
+        with transaction.atomic(using=using):
+            prepare_delete_cascade_disciplines(obj, using)
+            result = _collect_delete_blockers(obj, using)
+            transaction.set_rollback(True, using=using)
 
     return http.HttpResponse(toJson(result), content_type='application/json')
 

--- a/specifyweb/backend/delete_blockers/views.py
+++ b/specifyweb/backend/delete_blockers/views.py
@@ -42,7 +42,7 @@ def delete_blockers(request, model, id):
 
 def _collect_delete_blockers(obj, using) -> list[dict]:
     collector = Collector(using=using)
-    collector.delete_blockers = []
+    setattr(collector, "delete_blockers", [])
     collector.collect([obj])
     return flatten([
         [

--- a/specifyweb/backend/delete_blockers/views.py
+++ b/specifyweb/backend/delete_blockers/views.py
@@ -5,6 +5,8 @@ from django.db.models.deletion import Collector
 from specifyweb.middleware.general import require_http_methods
 from specifyweb.specify.api.crud import (
     get_discipline_delete_guard_blockers,
+    get_delete_cascade_discipline_guard_blockers,
+    get_delete_cascade_disciplines,
     get_object_or_404,
     prepare_delete_cascade_disciplines,
     prepare_discipline_for_delete,
@@ -33,10 +35,19 @@ def delete_blockers(request, model, id):
                 result = _collect_delete_blockers(obj, using)
                 transaction.set_rollback(True, using=using)
     else:
-        with transaction.atomic(using=using):
-            prepare_delete_cascade_disciplines(obj, using)
-            result = _collect_delete_blockers(obj, using)
-            transaction.set_rollback(True, using=using)
+        cascade_disciplines = get_delete_cascade_disciplines(obj, using)
+        guard_blockers = get_delete_cascade_discipline_guard_blockers(
+            obj, using, cascade_disciplines
+        )
+        if guard_blockers:
+            result = guard_blockers
+        else:
+            with transaction.atomic(using=using):
+                prepare_delete_cascade_disciplines(
+                    obj, using, cascade_disciplines
+                )
+                result = _collect_delete_blockers(obj, using)
+                transaction.set_rollback(True, using=using)
 
     return http.HttpResponse(toJson(result), content_type='application/json')
 

--- a/specifyweb/backend/delete_blockers/views.py
+++ b/specifyweb/backend/delete_blockers/views.py
@@ -1,14 +1,12 @@
 from django import http
 from django.db import router, transaction
 from django.db.models.deletion import Collector
+from django.db.models import ForeignKey
 
 from specifyweb.middleware.general import require_http_methods
 from specifyweb.specify.api.crud import (
     get_discipline_delete_guard_blockers,
-    get_delete_cascade_discipline_guard_blockers,
-    get_delete_cascade_disciplines,
     get_object_or_404,
-    prepare_delete_cascade_disciplines,
     prepare_discipline_for_delete,
 )
 from specifyweb.specify.api.serializers import toJson
@@ -35,35 +33,77 @@ def delete_blockers(request, model, id):
                 result = _collect_delete_blockers(obj, using)
                 transaction.set_rollback(True, using=using)
     else:
-        cascade_disciplines = get_delete_cascade_disciplines(obj, using)
-        guard_blockers = get_delete_cascade_discipline_guard_blockers(
-            obj, using, cascade_disciplines
-        )
-        if guard_blockers:
-            result = guard_blockers
-        else:
-            with transaction.atomic(using=using):
-                prepare_delete_cascade_disciplines(
-                    obj, using, cascade_disciplines
-                )
-                result = _collect_delete_blockers(obj, using)
-                transaction.set_rollback(True, using=using)
+        # Standard delete blockers behavior
+        result = _collect_delete_blockers(obj, using)
 
     return http.HttpResponse(toJson(result), content_type='application/json')
 
 def _collect_delete_blockers(obj, using) -> list[dict]:
     collector = Collector(using=using)
-    setattr(collector, "delete_blockers", [])
+    collector.delete_blockers = []
     collector.collect([obj])
     return flatten([
         [
-            {
-                'table': sub_objs[0].__class__.__name__,
-                'field': field.name,
-                'ids': [sub_obj.id for sub_obj in sub_objs]
-            }
+            _serialize_delete_blocker(field, sub_objs)
         ] for field, sub_objs in collector.delete_blockers
     ])
+
+def _serialize_delete_blocker(field, sub_objs) -> dict:
+    normalized = _normalize_many_to_many_blocker(field, sub_objs)
+    if normalized is not None:
+        return normalized
+
+    return {
+        'table': sub_objs[0].__class__.__name__,
+        'field': field.name,
+        'ids': [sub_obj.id for sub_obj in sub_objs]
+    }
+
+def _normalize_many_to_many_blocker(field, sub_objs) -> dict | None:
+    through_model = sub_objs[0].__class__
+    if hasattr(through_model, 'specify_model'):
+        return None
+
+    foreign_keys = [
+        model_field
+        for model_field in through_model._meta.fields
+        if isinstance(model_field, ForeignKey)
+    ]
+    if len(foreign_keys) != 2:
+        return None
+
+    other_field = next(
+        (
+            model_field
+            for model_field in foreign_keys
+            if model_field.name != field.name
+        ),
+        None,
+    )
+    if other_field is None:
+        return None
+
+    other_model = other_field.related_model
+    if not hasattr(other_model, 'specify_model'):
+        return None
+
+    relationship = next(
+        (
+            relationship
+            for relationship in other_model.specify_model.relationships
+            if getattr(relationship, 'through_model', None) == through_model.__name__
+            and getattr(relationship, 'through_field', None) == other_field.name
+        ),
+        None,
+    )
+    if relationship is None:
+        return None
+
+    return {
+        'table': other_model.specify_model.name,
+        'field': relationship.name,
+        'ids': [getattr(sub_obj, other_field.attname) for sub_obj in sub_objs],
+    }
 
 def flatten(l):
     return [item for sublist in l for item in sublist]

--- a/specifyweb/frontend/js_src/lib/components/Permissions/index.ts
+++ b/specifyweb/frontend/js_src/lib/components/Permissions/index.ts
@@ -64,7 +64,12 @@ export const getDerivedPermissions = () => derivedPermissions;
 const sortPolicies = (policy: typeof operationPolicies) =>
   JSON.stringify(
     Object.fromEntries(
-      Object.entries(policy).sort(sortFunction(([key]) => key))
+      Object.entries(policy)
+        .sort(sortFunction(([key]) => key))
+        .map(([key, actions]) => [
+          key,
+          [...actions].sort(sortFunction((action) => action)),
+        ])
     )
   );
 

--- a/specifyweb/frontend/js_src/lib/components/Permissions/index.ts
+++ b/specifyweb/frontend/js_src/lib/components/Permissions/index.ts
@@ -68,7 +68,7 @@ const sortPolicies = (policy: typeof operationPolicies) =>
         .sort(sortFunction(([key]) => key))
         .map(([key, actions]) => [
           key,
-          [...actions].sort(sortFunction((action) => action)),
+          Array.from(actions).sort(sortFunction((action) => action)),
         ])
     )
   );

--- a/specifyweb/specify/api/crud.py
+++ b/specifyweb/specify/api/crud.py
@@ -4,8 +4,7 @@
 import logging
 from typing import Any, Dict
 from collections.abc import Callable
-from django.db import transaction, router
-from django.db.models.deletion import Collector
+from django.db import transaction
 from django.core.exceptions import FieldError, FieldDoesNotExist
 from django.db.models import Model, F, Q, Subquery
 from django.http import (HttpResponseServerError, Http404)
@@ -248,61 +247,8 @@ def get_discipline_delete_guard_blockers(discipline) -> list[dict[str, Any]]:
             )
     return blockers
 
-def merge_delete_blockers(
-    blockers: list[dict[str, Any]],
-) -> list[dict[str, Any]]:
-    merged: dict[tuple[str, str], set[int]] = {}
-    for blocker in blockers:
-        key = (blocker["table"], blocker["field"])
-        ids = merged.setdefault(key, set())
-        ids.update(int(blocker_id) for blocker_id in blocker["ids"])
-
-    return [
-        {
-            "table": table,
-            "field": field,
-            "ids": sorted(ids),
-        }
-        for (table, field), ids in sorted(merged.items())
-    ]
-
 def _raw_delete_queryset(queryset) -> None:
     queryset._raw_delete(queryset.db)
-
-def delete_discipline_owned_app_resources(obj) -> None:
-    if not is_discipline(obj):
-        return
-
-    resource_dir_ids = models.Spappresourcedir.objects.filter(
-        discipline_id=obj.id
-    ).values("id")
-    app_resource_ids = models.Spappresource.objects.filter(
-        spappresourcedir_id__in=Subquery(resource_dir_ids)
-    ).values("id")
-    viewset_ids = models.Spviewsetobj.objects.filter(
-        spappresourcedir_id__in=Subquery(resource_dir_ids)
-    ).values("id")
-
-    _raw_delete_queryset(
-        models.Spappresourcedata.objects.filter(
-            Q(spappresource_id__in=Subquery(app_resource_ids))
-            | Q(spviewsetobj_id__in=Subquery(viewset_ids))
-        )
-    )
-    _raw_delete_queryset(
-        models.Spreport.objects.filter(appresource_id__in=Subquery(app_resource_ids))
-    )
-    _raw_delete_queryset(
-        models.Spappresource.objects.filter(
-            spappresourcedir_id__in=Subquery(resource_dir_ids)
-        )
-    )
-    _raw_delete_queryset(
-        models.Spviewsetobj.objects.filter(
-            spappresourcedir_id__in=Subquery(resource_dir_ids)
-        )
-    )
-    _raw_delete_queryset(models.Spappresourcedir.objects.filter(discipline_id=obj.id))
 
 def delete_discipline_owned_setup_data(obj) -> None:
     """
@@ -369,7 +315,7 @@ def delete_discipline_owned_setup_data(obj) -> None:
     )
     _raw_delete_queryset(UniquenessRule.objects.filter(discipline_id=obj.id))
 
-    delete_discipline_owned_app_resources(obj)
+    _raw_delete_queryset(models.Spappresourcedir.objects.filter(discipline_id=obj.id))
     _raw_delete_queryset(models.Sptasksemaphore.objects.filter(discipline_id=obj.id))
     _raw_delete_queryset(models.Autonumschdsp.objects.filter(discipline_id=obj.id))
 
@@ -384,52 +330,6 @@ def prepare_discipline_for_delete(obj) -> None:
     for tree_def_model in DISCIPLINE_TREE_MODELS:
         tree_def_model.objects.filter(discipline_id=obj.id).update(discipline_id=None)
     delete_discipline_owned_setup_data(obj)
-
-def get_delete_cascade_disciplines(obj, using) -> list[models.Discipline]:
-    """
-    Return any disciplines that would be deleted by cascading from obj
-    """
-    collector = Collector(using=using)
-    setattr(collector, "delete_blockers", [])
-    collector.collect([obj])
-
-    disciplines = {
-        candidate.id: candidate
-        for collected_objs in collector.data.values()
-        for candidate in collected_objs
-        if is_discipline(candidate)
-    }
-    return [disciplines[discipline_id] for discipline_id in sorted(disciplines)]
-
-def get_delete_cascade_discipline_guard_blockers(
-    obj,
-    using,
-    disciplines: list[models.Discipline] | None = None,
-) -> list[dict[str, Any]]:
-    if disciplines is None:
-        disciplines = get_delete_cascade_disciplines(obj, using)
-
-    return merge_delete_blockers(
-        [
-            blocker
-            for discipline in disciplines
-            for blocker in get_discipline_delete_guard_blockers(discipline)
-        ]
-    )
-
-def prepare_delete_cascade_disciplines(
-    obj,
-    using,
-    disciplines: list[models.Discipline] | None = None,
-) -> None:
-    """
-    Apply discipline pre-delete cleanup to any discipline reached through a cascading delete from obj
-    """
-    if disciplines is None:
-        disciplines = get_delete_cascade_disciplines(obj, using)
-
-    for discipline in disciplines:
-        prepare_discipline_for_delete(discipline)
 
 @transaction.atomic
 def put_resource(collection, agent, name: str, id, version, data: dict[str, Any]):
@@ -550,7 +450,6 @@ def delete_resource(collection, agent, name, id, version) -> None:
     locking 'version'.
     """
     obj = get_object_or_404(name, id=int(id))
-    using = router.db_for_write(obj.__class__, instance=obj)
     if is_discipline(obj):
         guard_blockers = get_discipline_delete_guard_blockers(obj)
         if guard_blockers:
@@ -559,19 +458,7 @@ def delete_resource(collection, agent, name, id, version) -> None:
             )
         clean_predelete = prepare_discipline_for_delete
     else:
-        cascade_disciplines = get_delete_cascade_disciplines(obj, using)
-        guard_blockers = get_delete_cascade_discipline_guard_blockers(
-            obj, using, cascade_disciplines
-        )
-        if guard_blockers:
-            raise BusinessRuleException(
-                "A cascaded Discipline cannot be deleted while it has associated users or collections."
-            )
-
-        def clean_predelete(delete_obj):
-            prepare_delete_cascade_disciplines(
-                delete_obj, using, cascade_disciplines
-            )
+        clean_predelete = None
 
     return delete_obj(
         obj,

--- a/specifyweb/specify/api/crud.py
+++ b/specifyweb/specify/api/crud.py
@@ -248,8 +248,61 @@ def get_discipline_delete_guard_blockers(discipline) -> list[dict[str, Any]]:
             )
     return blockers
 
+def merge_delete_blockers(
+    blockers: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    merged: dict[tuple[str, str], set[int]] = {}
+    for blocker in blockers:
+        key = (blocker["table"], blocker["field"])
+        ids = merged.setdefault(key, set())
+        ids.update(int(blocker_id) for blocker_id in blocker["ids"])
+
+    return [
+        {
+            "table": table,
+            "field": field,
+            "ids": sorted(ids),
+        }
+        for (table, field), ids in sorted(merged.items())
+    ]
+
 def _raw_delete_queryset(queryset) -> None:
     queryset._raw_delete(queryset.db)
+
+def delete_discipline_owned_app_resources(obj) -> None:
+    if not is_discipline(obj):
+        return
+
+    resource_dir_ids = models.Spappresourcedir.objects.filter(
+        discipline_id=obj.id
+    ).values("id")
+    app_resource_ids = models.Spappresource.objects.filter(
+        spappresourcedir_id__in=Subquery(resource_dir_ids)
+    ).values("id")
+    viewset_ids = models.Spviewsetobj.objects.filter(
+        spappresourcedir_id__in=Subquery(resource_dir_ids)
+    ).values("id")
+
+    _raw_delete_queryset(
+        models.Spappresourcedata.objects.filter(
+            Q(spappresource_id__in=Subquery(app_resource_ids))
+            | Q(spviewsetobj_id__in=Subquery(viewset_ids))
+        )
+    )
+    _raw_delete_queryset(
+        models.Spreport.objects.filter(appresource_id__in=Subquery(app_resource_ids))
+    )
+    _raw_delete_queryset(
+        models.Spappresource.objects.filter(
+            spappresourcedir_id__in=Subquery(resource_dir_ids)
+        )
+    )
+    _raw_delete_queryset(
+        models.Spviewsetobj.objects.filter(
+            spappresourcedir_id__in=Subquery(resource_dir_ids)
+        )
+    )
+    _raw_delete_queryset(models.Spappresourcedir.objects.filter(discipline_id=obj.id))
 
 def delete_discipline_owned_setup_data(obj) -> None:
     """
@@ -316,7 +369,7 @@ def delete_discipline_owned_setup_data(obj) -> None:
     )
     _raw_delete_queryset(UniquenessRule.objects.filter(discipline_id=obj.id))
 
-    _raw_delete_queryset(models.Spappresourcedir.objects.filter(discipline_id=obj.id))
+    delete_discipline_owned_app_resources(obj)
     _raw_delete_queryset(models.Sptasksemaphore.objects.filter(discipline_id=obj.id))
     _raw_delete_queryset(models.Autonumschdsp.objects.filter(discipline_id=obj.id))
 
@@ -348,11 +401,34 @@ def get_delete_cascade_disciplines(obj, using) -> list[models.Discipline]:
     }
     return [disciplines[discipline_id] for discipline_id in sorted(disciplines)]
 
-def prepare_delete_cascade_disciplines(obj, using) -> None:
+def get_delete_cascade_discipline_guard_blockers(
+    obj,
+    using,
+    disciplines: list[models.Discipline] | None = None,
+) -> list[dict[str, Any]]:
+    if disciplines is None:
+        disciplines = get_delete_cascade_disciplines(obj, using)
+
+    return merge_delete_blockers(
+        [
+            blocker
+            for discipline in disciplines
+            for blocker in get_discipline_delete_guard_blockers(discipline)
+        ]
+    )
+
+def prepare_delete_cascade_disciplines(
+    obj,
+    using,
+    disciplines: list[models.Discipline] | None = None,
+) -> None:
     """
     Apply discipline pre-delete cleanup to any discipline reached through a cascading delete from obj
     """
-    for discipline in get_delete_cascade_disciplines(obj, using):
+    if disciplines is None:
+        disciplines = get_delete_cascade_disciplines(obj, using)
+
+    for discipline in disciplines:
         prepare_discipline_for_delete(discipline)
 
 @transaction.atomic
@@ -483,8 +559,19 @@ def delete_resource(collection, agent, name, id, version) -> None:
             )
         clean_predelete = prepare_discipline_for_delete
     else:
+        cascade_disciplines = get_delete_cascade_disciplines(obj, using)
+        guard_blockers = get_delete_cascade_discipline_guard_blockers(
+            obj, using, cascade_disciplines
+        )
+        if guard_blockers:
+            raise BusinessRuleException(
+                "A cascaded Discipline cannot be deleted while it has associated users or collections."
+            )
+
         def clean_predelete(delete_obj):
-            prepare_delete_cascade_disciplines(delete_obj, using)
+            prepare_delete_cascade_disciplines(
+                delete_obj, using, cascade_disciplines
+            )
 
     return delete_obj(
         obj,

--- a/specifyweb/specify/api/crud.py
+++ b/specifyweb/specify/api/crud.py
@@ -337,7 +337,7 @@ def get_delete_cascade_disciplines(obj, using) -> list[models.Discipline]:
     Return any disciplines that would be deleted by cascading from obj
     """
     collector = Collector(using=using)
-    collector.delete_blockers = []
+    setattr(collector, "delete_blockers", [])
     collector.collect([obj])
 
     disciplines = {
@@ -350,8 +350,7 @@ def get_delete_cascade_disciplines(obj, using) -> list[models.Discipline]:
 
 def prepare_delete_cascade_disciplines(obj, using) -> None:
     """
-    Apply discipline pre-delete cleanup to any discipline reached through
-    a cascading delete from obj.
+    Apply discipline pre-delete cleanup to any discipline reached through a cascading delete from obj
     """
     for discipline in get_delete_cascade_disciplines(obj, using):
         prepare_discipline_for_delete(discipline)

--- a/specifyweb/specify/api/crud.py
+++ b/specifyweb/specify/api/crud.py
@@ -4,7 +4,8 @@
 import logging
 from typing import Any, Dict
 from collections.abc import Callable
-from django.db import transaction
+from django.db import transaction, router
+from django.db.models.deletion import Collector
 from django.core.exceptions import FieldError, FieldDoesNotExist
 from django.db.models import Model, F, Q, Subquery
 from django.http import (HttpResponseServerError, Http404)
@@ -331,6 +332,30 @@ def prepare_discipline_for_delete(obj) -> None:
         tree_def_model.objects.filter(discipline_id=obj.id).update(discipline_id=None)
     delete_discipline_owned_setup_data(obj)
 
+def get_delete_cascade_disciplines(obj, using) -> list[models.Discipline]:
+    """
+    Return any disciplines that would be deleted by cascading from obj
+    """
+    collector = Collector(using=using)
+    collector.delete_blockers = []
+    collector.collect([obj])
+
+    disciplines = {
+        candidate.id: candidate
+        for collected_objs in collector.data.values()
+        for candidate in collected_objs
+        if is_discipline(candidate)
+    }
+    return [disciplines[discipline_id] for discipline_id in sorted(disciplines)]
+
+def prepare_delete_cascade_disciplines(obj, using) -> None:
+    """
+    Apply discipline pre-delete cleanup to any discipline reached through
+    a cascading delete from obj.
+    """
+    for discipline in get_delete_cascade_disciplines(obj, using):
+        prepare_discipline_for_delete(discipline)
+
 @transaction.atomic
 def put_resource(collection, agent, name: str, id, version, data: dict[str, Any]):
     return update_obj(collection, agent, name, id, version, data)
@@ -450,6 +475,7 @@ def delete_resource(collection, agent, name, id, version) -> None:
     locking 'version'.
     """
     obj = get_object_or_404(name, id=int(id))
+    using = router.db_for_write(obj.__class__, instance=obj)
     if is_discipline(obj):
         guard_blockers = get_discipline_delete_guard_blockers(obj)
         if guard_blockers:
@@ -458,7 +484,8 @@ def delete_resource(collection, agent, name, id, version) -> None:
             )
         clean_predelete = prepare_discipline_for_delete
     else:
-        clean_predelete = None
+        def clean_predelete(delete_obj):
+            prepare_delete_cascade_disciplines(delete_obj, using)
 
     return delete_obj(
         obj,

--- a/specifyweb/specify/tests/test_delete_blockers.py
+++ b/specifyweb/specify/tests/test_delete_blockers.py
@@ -1,10 +1,11 @@
-import json
 from django.test import Client
+import json
 
-from specifyweb.backend.businessrules.exceptions import BusinessRuleException
-from specifyweb.backend.trees.tests.test_trees import GeographyTree
 from specifyweb.specify import models
-from specifyweb.specify.api.crud import delete_resource
+from django.db import router
+from django.test import TestCase
+from specifyweb.backend.delete_blockers.views import _collect_delete_blockers
+from specifyweb.backend.trees.tests.test_trees import GeographyTree
 
 def _url(obj):
     return f"/delete_blockers/delete_blockers/{obj._meta.model_name}/{obj.id}/"
@@ -32,135 +33,20 @@ class TestDeleteBlockers(GeographyTree):
 
     def _get_blockers(self, obj):
         response = self.c.get(_url(obj))
+        self.assertEqual(
+            response.status_code,
+            200,
+            f"ERROR: {response.content.decode()}",
+        )
         return json.loads(response.content.decode())
 
-    def _create_discipline_with_owned_export_schema(
-        self,
-        discipline,
-        name='Disposable Export Schema',
-    ):
-        schema = models.Spexportschema.objects.create(
-            discipline=discipline,
-            schemaname=name,
-        )
-        mapping = models.Spexportschemamapping.objects.create(
-            collectionmemberid=self.collection.id,
-            mappingname=f'{name} Mapping',
-        )
-        models.Spexportschema_exportmapping.objects.create(
-            spexportschema=schema,
-            spexportschemamapping=mapping,
-        )
+    def _assertContains(self, blockers, expected):
+        normalized = [
+            {**obj, 'ids': sorted(obj['ids'])}
+            for obj in blockers
+        ]
+        self.assertIn({**expected, 'ids': sorted(expected['ids'])}, normalized)
 
-    def _create_discipline_with_owned_app_resources(
-        self,
-        discipline,
-        name='Disposable App Resources',
-    ):
-        resource_dir = models.Spappresourcedir.objects.create(
-            discipline=discipline,
-            ispersonal=False,
-        )
-        app_resource = models.Spappresource.objects.create(
-            name=f'{name} Resource',
-            level=0,
-            spappresourcedir=resource_dir,
-            specifyuser=self.specifyuser,
-        )
-        models.Spappresourcedata.objects.create(
-            spappresource=app_resource,
-            data=b'{}',
-        )
-        models.Spreport.objects.create(
-            name=f'{name} Report',
-            appresource=app_resource,
-            specifyuser=self.specifyuser,
-        )
-        viewset = models.Spviewsetobj.objects.create(
-            name=f'{name} Viewset',
-            level=0,
-            spappresourcedir=resource_dir,
-        )
-        models.Spappresourcedata.objects.create(
-            spviewsetobj=viewset,
-            data=b'{}',
-        )
-        return resource_dir
-
-    def _create_discipline_with_owned_trees(
-        self,
-        name='Disposable Discipline',
-        division=None,
-    ):
-        placeholder_geo = models.Geographytreedef.objects.create(
-            name=f'{name} placeholder geo'
-        )
-        placeholder_geo_time = models.Geologictimeperiodtreedef.objects.create(
-            name=f'{name} placeholder geotime'
-        )
-
-        discipline = models.Discipline.objects.create(
-            name=name,
-            type='paleobotany',
-            division=self.division if division is None else division,
-            datatype=self.datatype,
-            geographytreedef=placeholder_geo,
-            geologictimeperiodtreedef=placeholder_geo_time,
-        )
-
-        geography_tree = models.Geographytreedef.objects.create(
-            name=f'{name} geography',
-            discipline=discipline,
-        )
-        geography_rank = models.Geographytreedefitem.objects.create(
-            name='Planet',
-            rankid=0,
-            treedef=geography_tree,
-        )
-        models.Geography.objects.create(
-            name='Earth',
-            rankid=0,
-            definition=geography_tree,
-            definitionitem=geography_rank,
-        )
-
-        geotime_tree = models.Geologictimeperiodtreedef.objects.create(
-            name=f'{name} geotime',
-            discipline=discipline,
-        )
-        geotime_rank = models.Geologictimeperiodtreedefitem.objects.create(
-            name='Root',
-            rankid=0,
-            treedef=geotime_tree,
-        )
-        models.Geologictimeperiod.objects.create(
-            name='Root',
-            rankid=0,
-            definition=geotime_tree,
-            definitionitem=geotime_rank,
-        )
-
-        taxon_tree = models.Taxontreedef.objects.create(
-            name=f'{name} taxon',
-            discipline=discipline,
-        )
-        taxon_rank = models.Taxontreedefitem.objects.create(
-            name='Life',
-            rankid=0,
-            treedef=taxon_tree,
-        )
-        models.Taxon.objects.create(
-            name='Life',
-            rankid=0,
-            definition=taxon_tree,
-            definitionitem=taxon_rank,
-        )
-
-        discipline.geographytreedef = geography_tree
-        discipline.geologictimeperiodtreedef = geotime_tree
-        discipline.taxontreedef = taxon_tree
-        discipline.save()
-        return discipline
 
     def test_simple_agent_delete_blockers(self):
         prep_list = []
@@ -194,91 +80,85 @@ class TestDeleteBlockers(GeographyTree):
         for node in self._node_list:
             self._assertSame(self._get_blockers(node), [])
 
-    def test_division_delete_blockers_ignore_cascaded_discipline_setup_rows(self):
-        division = models.Division.objects.create(
-            name='Disposable Division',
-            institution=self.institution,
+    def test_many_to_many_join_blockers_are_normalized(self):
+        export_schema = models.Spexportschema.objects.create(
+            discipline=self.discipline
         )
-        discipline = self._create_discipline_with_owned_trees(
-            'Division Discipline',
-            division=division,
+        export_mapping = models.Spexportschemamapping.objects.create(
+            collectionmemberid=self.collection.id
         )
-        self._create_discipline_with_owned_export_schema(discipline)
+        export_schema.mappings.add(export_mapping)
 
-        blockers = self._get_blockers(division)
-        self._assertSame(blockers, [])
+        delete_blockers = self._get_blockers(export_schema)
 
-    def test_delete_division_removes_owned_setup_from_cascaded_discipline(self):
-        division = models.Division.objects.create(
-            name='Deletable Division',
-            institution=self.institution,
-        )
-        discipline = self._create_discipline_with_owned_trees(
-            'Division Delete Discipline',
-            division=division,
-        )
-        self._create_discipline_with_owned_export_schema(discipline)
-
-        delete_resource(
-            self.collection, self.agent, 'division', division.id, division.version
-        )
-        self.assertFalse(models.Division.objects.filter(id=division.id).exists())
-        self.assertFalse(models.Discipline.objects.filter(id=discipline.id).exists())
-
-    def test_division_delete_blockers_ignore_cascaded_discipline_app_resource_rows(self):
-        division = models.Division.objects.create(
-            name='App Resource Division',
-            institution=self.institution,
-        )
-        discipline = self._create_discipline_with_owned_trees(
-            'App Resource Discipline',
-            division=division,
-        )
-        self._create_discipline_with_owned_app_resources(discipline)
-
-        blockers = self._get_blockers(division)
-        self._assertSame(blockers, [])
-
-    def test_delete_division_removes_cascaded_discipline_app_resource_rows(self):
-        division = models.Division.objects.create(
-            name='App Resource Delete Division',
-            institution=self.institution,
-        )
-        discipline = self._create_discipline_with_owned_trees(
-            'App Resource Delete Discipline',
-            division=division,
-        )
-        resource_dir = self._create_discipline_with_owned_app_resources(discipline)
-
-        delete_resource(
-            self.collection, self.agent, 'division', division.id, division.version
-        )
-        self.assertFalse(models.Division.objects.filter(id=division.id).exists())
-        self.assertFalse(models.Discipline.objects.filter(id=discipline.id).exists())
-        self.assertFalse(models.Spappresourcedir.objects.filter(id=resource_dir.id).exists())
-
-    def test_division_delete_blockers_include_cascaded_discipline_user_blockers(self):
-        division = models.Division.objects.create(
-            name='User Blocker Division',
-            institution=self.institution,
-        )
-        discipline = self._create_discipline_with_owned_trees(
-            'User Blocker Discipline',
-            division=division,
-        )
-        resource_dir = models.Spappresourcedir.objects.create(
-            discipline=discipline,
-            specifyuser=self.specifyuser,
-            ispersonal=False,
-        )
-
-        blockers = self._get_blockers(division)
-        self._assertSame(
-            blockers,
-            [dict(table='Spappresourcedir', field='specifyuser', ids=[resource_dir.id])],
-        )
-
-        with self.assertRaises(BusinessRuleException):
-            delete_resource(
-                self.collection, self.agent, 'division', division.id, division.version
+        expected = [
+            dict(
+                table='SpExportSchemaMapping',
+                field='spExportSchemas',
+                ids=[export_mapping.id],
             )
+        ]
+
+        self._assertSame(delete_blockers, expected)
+
+class TestDeleteBlockersCascade(TestCase):
+
+    def _assertContains(self, blockers, expected):
+        normalized = [
+            {**obj, 'ids': sorted(obj['ids'])}
+            for obj in blockers
+        ]
+        self.assertIn({**expected, 'ids': sorted(expected['ids'])}, normalized)
+
+    def test_division_collects_normalized_cascaded_discipline_blockers(self):
+        institution = models.Institution.objects.create(
+            name='Test Institution',
+            isaccessionsglobal=True,
+            issecurityon=False,
+            isserverbased=False,
+            issharinglocalities=True,
+            issinglegeographytree=True,
+        )
+        division = models.Division.objects.create(
+            institution=institution,
+            name='Test Division',
+        )
+        geologictimeperiodtreedef = models.Geologictimeperiodtreedef.objects.create(
+            name='Test gtptd'
+        )
+        geographytreedef = models.Geographytreedef.objects.create(
+            name='Test gtd'
+        )
+        datatype = models.Datatype.objects.create(name='Test datatype')
+        discipline = models.Discipline.objects.create(
+            geologictimeperiodtreedef=geologictimeperiodtreedef,
+            geographytreedef=geographytreedef,
+            division=division,
+            datatype=datatype,
+            type='paleobotany',
+        )
+        export_schema = models.Spexportschema.objects.create(
+            discipline=discipline
+        )
+        export_mapping = models.Spexportschemamapping.objects.create(
+            collectionmemberid=1
+        )
+        export_schema.mappings.add(export_mapping)
+
+        using = router.db_for_write(division.__class__, instance=division)
+        delete_blockers = _collect_delete_blockers(division, using)
+
+        self._assertContains(
+            delete_blockers,
+            dict(
+                table='SpExportSchemaMapping',
+                field='spExportSchemas',
+                ids=[export_mapping.id],
+            ),
+        )
+        self.assertFalse(
+            any(
+                blocker['table'] == 'Spexportschema_exportmapping'
+                for blocker in delete_blockers
+            )
+        )

--- a/specifyweb/specify/tests/test_delete_blockers.py
+++ b/specifyweb/specify/tests/test_delete_blockers.py
@@ -1,6 +1,7 @@
 import json
 from django.test import Client
 
+from specifyweb.backend.businessrules.exceptions import BusinessRuleException
 from specifyweb.backend.trees.tests.test_trees import GeographyTree
 from specifyweb.specify import models
 from specifyweb.specify.api.crud import delete_resource
@@ -50,6 +51,41 @@ class TestDeleteBlockers(GeographyTree):
             spexportschema=schema,
             spexportschemamapping=mapping,
         )
+
+    def _create_discipline_with_owned_app_resources(
+        self,
+        discipline,
+        name='Disposable App Resources',
+    ):
+        resource_dir = models.Spappresourcedir.objects.create(
+            discipline=discipline,
+            ispersonal=False,
+        )
+        app_resource = models.Spappresource.objects.create(
+            name=f'{name} Resource',
+            level=0,
+            spappresourcedir=resource_dir,
+            specifyuser=self.specifyuser,
+        )
+        models.Spappresourcedata.objects.create(
+            spappresource=app_resource,
+            data=b'{}',
+        )
+        models.Spreport.objects.create(
+            name=f'{name} Report',
+            appresource=app_resource,
+            specifyuser=self.specifyuser,
+        )
+        viewset = models.Spviewsetobj.objects.create(
+            name=f'{name} Viewset',
+            level=0,
+            spappresourcedir=resource_dir,
+        )
+        models.Spappresourcedata.objects.create(
+            spviewsetobj=viewset,
+            data=b'{}',
+        )
+        return resource_dir
 
     def _create_discipline_with_owned_trees(
         self,
@@ -188,3 +224,61 @@ class TestDeleteBlockers(GeographyTree):
         )
         self.assertFalse(models.Division.objects.filter(id=division.id).exists())
         self.assertFalse(models.Discipline.objects.filter(id=discipline.id).exists())
+
+    def test_division_delete_blockers_ignore_cascaded_discipline_app_resource_rows(self):
+        division = models.Division.objects.create(
+            name='App Resource Division',
+            institution=self.institution,
+        )
+        discipline = self._create_discipline_with_owned_trees(
+            'App Resource Discipline',
+            division=division,
+        )
+        self._create_discipline_with_owned_app_resources(discipline)
+
+        blockers = self._get_blockers(division)
+        self._assertSame(blockers, [])
+
+    def test_delete_division_removes_cascaded_discipline_app_resource_rows(self):
+        division = models.Division.objects.create(
+            name='App Resource Delete Division',
+            institution=self.institution,
+        )
+        discipline = self._create_discipline_with_owned_trees(
+            'App Resource Delete Discipline',
+            division=division,
+        )
+        resource_dir = self._create_discipline_with_owned_app_resources(discipline)
+
+        delete_resource(
+            self.collection, self.agent, 'division', division.id, division.version
+        )
+        self.assertFalse(models.Division.objects.filter(id=division.id).exists())
+        self.assertFalse(models.Discipline.objects.filter(id=discipline.id).exists())
+        self.assertFalse(models.Spappresourcedir.objects.filter(id=resource_dir.id).exists())
+
+    def test_division_delete_blockers_include_cascaded_discipline_user_blockers(self):
+        division = models.Division.objects.create(
+            name='User Blocker Division',
+            institution=self.institution,
+        )
+        discipline = self._create_discipline_with_owned_trees(
+            'User Blocker Discipline',
+            division=division,
+        )
+        resource_dir = models.Spappresourcedir.objects.create(
+            discipline=discipline,
+            specifyuser=self.specifyuser,
+            ispersonal=False,
+        )
+
+        blockers = self._get_blockers(division)
+        self._assertSame(
+            blockers,
+            [dict(table='Spappresourcedir', field='specifyuser', ids=[resource_dir.id])],
+        )
+
+        with self.assertRaises(BusinessRuleException):
+            delete_resource(
+                self.collection, self.agent, 'division', division.id, division.version
+            )

--- a/specifyweb/specify/tests/test_delete_blockers.py
+++ b/specifyweb/specify/tests/test_delete_blockers.py
@@ -162,3 +162,167 @@ class TestDeleteBlockersCascade(TestCase):
                 for blocker in delete_blockers
             )
         )
+from django.test import Client
+import json
+
+from specifyweb.specify import models
+from django.db import router
+from django.test import TestCase
+from specifyweb.backend.delete_blockers.views import _collect_delete_blockers
+from specifyweb.backend.trees.tests.test_trees import GeographyTree
+
+def _url(obj):
+    return f"/delete_blockers/delete_blockers/{obj._meta.model_name}/{obj.id}/"
+
+class TestDeleteBlockers(GeographyTree):
+
+    def setUp(self):
+        super().setUp()
+        self._create_prep_type()
+        c = Client()
+        c.force_login(self.specifyuser)
+        self.c = c
+
+    def _assertSame(self, base, other):
+        key = lambda obj: (obj['table'], obj['field'])
+
+        sort_by_ids = lambda _blockers: [{**obj, 'ids': sorted(obj['ids'])} for obj in _blockers]
+        base = sorted(base, key=key)
+        other = sorted(other, key=key)
+
+        base = sort_by_ids(base)
+        other = sort_by_ids(other)
+
+        self.assertEqual(base, other)
+
+    def _get_blockers(self, obj):
+        response = self.c.get(_url(obj))
+        self.assertEqual(
+            response.status_code,
+            200,
+            f"ERROR: {response.content.decode()}",
+        )
+        return json.loads(response.content.decode())
+
+    def _assertContains(self, blockers, expected):
+        normalized = [
+            {**obj, 'ids': sorted(obj['ids'])}
+            for obj in blockers
+        ]
+        self.assertIn({**expected, 'ids': sorted(expected['ids'])}, normalized)
+
+
+    def test_simple_agent_delete_blockers(self):
+        prep_list = []
+        for co in self.collectionobjects:
+            self._update(co, {'cataloger': self.agent, 'createdbyagent': self.agent})
+            for _ in range(5):
+                self._create_prep(co, prep_list, preparedbyagent=self.agent)
+
+        delete_blockers = self._get_blockers(self.agent)
+        
+        expected =  [
+            dict(table='Collectionobject', field='cataloger', ids=[co.id for co in self.collectionobjects]),
+            dict(table='Collectionobject', field='createdbyagent', ids=[co.id for co in self.collectionobjects]),
+            dict(table='Preparation', field='preparedbyagent', ids=[prep.id for prep in prep_list])
+        ]
+
+        self._assertSame(delete_blockers, expected)
+
+    def test_to_many_dependents_not_in_blockers(self):
+        prep_list = []
+        for co in self.collectionobjects:
+            for _ in range(5):
+                self._create_prep(co, prep_list, preparedbyagent=self.agent)
+
+        for co in self.collectionobjects:
+            delete_blockers = self._get_blockers(co)
+            self._assertSame(delete_blockers, [])
+
+    def test_children_dont_block_deletion(self):
+        
+        for node in self._node_list:
+            self._assertSame(self._get_blockers(node), [])
+
+    def test_many_to_many_join_blockers_are_normalized(self):
+        export_schema = models.Spexportschema.objects.create(
+            discipline=self.discipline
+        )
+        export_mapping = models.Spexportschemamapping.objects.create(
+            collectionmemberid=self.collection.id
+        )
+        export_schema.mappings.add(export_mapping)
+
+        delete_blockers = self._get_blockers(export_schema)
+
+        expected = [
+            dict(
+                table='SpExportSchemaMapping',
+                field='spExportSchemas',
+                ids=[export_mapping.id],
+            )
+        ]
+
+        self._assertSame(delete_blockers, expected)
+
+class TestDeleteBlockersCascade(TestCase):
+
+    def _assertContains(self, blockers, expected):
+        normalized = [
+            {**obj, 'ids': sorted(obj['ids'])}
+            for obj in blockers
+        ]
+        self.assertIn({**expected, 'ids': sorted(expected['ids'])}, normalized)
+
+    def test_division_collects_normalized_cascaded_discipline_blockers(self):
+        institution = models.Institution.objects.create(
+            name='Test Institution',
+            isaccessionsglobal=True,
+            issecurityon=False,
+            isserverbased=False,
+            issharinglocalities=True,
+            issinglegeographytree=True,
+        )
+        division = models.Division.objects.create(
+            institution=institution,
+            name='Test Division',
+        )
+        geologictimeperiodtreedef = models.Geologictimeperiodtreedef.objects.create(
+            name='Test gtptd'
+        )
+        geographytreedef = models.Geographytreedef.objects.create(
+            name='Test gtd'
+        )
+        datatype = models.Datatype.objects.create(name='Test datatype')
+        discipline = models.Discipline.objects.create(
+            geologictimeperiodtreedef=geologictimeperiodtreedef,
+            geographytreedef=geographytreedef,
+            division=division,
+            datatype=datatype,
+            type='paleobotany',
+        )
+        export_schema = models.Spexportschema.objects.create(
+            discipline=discipline
+        )
+        export_mapping = models.Spexportschemamapping.objects.create(
+            collectionmemberid=1
+        )
+        export_schema.mappings.add(export_mapping)
+
+        using = router.db_for_write(division.__class__, instance=division)
+        delete_blockers = _collect_delete_blockers(division, using)
+
+        self._assertContains(
+            delete_blockers,
+            dict(
+                table='SpExportSchemaMapping',
+                field='spExportSchemas',
+                ids=[export_mapping.id],
+            ),
+        )
+        self.assertFalse(
+            any(
+                blocker['table'] == 'Spexportschema_exportmapping'
+                for blocker in delete_blockers
+            )
+        )

--- a/specifyweb/specify/tests/test_delete_blockers.py
+++ b/specifyweb/specify/tests/test_delete_blockers.py
@@ -1,7 +1,9 @@
-from django.test import Client
 import json
+from django.test import Client
 
 from specifyweb.backend.trees.tests.test_trees import GeographyTree
+from specifyweb.specify import models
+from specifyweb.specify.api.crud import delete_resource
 
 def _url(obj):
     return f"/delete_blockers/delete_blockers/{obj._meta.model_name}/{obj.id}/"
@@ -31,6 +33,98 @@ class TestDeleteBlockers(GeographyTree):
         response = self.c.get(_url(obj))
         return json.loads(response.content.decode())
 
+    def _create_discipline_with_owned_export_schema(
+        self,
+        discipline,
+        name='Disposable Export Schema',
+    ):
+        schema = models.Spexportschema.objects.create(
+            discipline=discipline,
+            schemaname=name,
+        )
+        mapping = models.Spexportschemamapping.objects.create(
+            collectionmemberid=self.collection.id,
+            mappingname=f'{name} Mapping',
+        )
+        models.Spexportschema_exportmapping.objects.create(
+            spexportschema=schema,
+            spexportschemamapping=mapping,
+        )
+
+    def _create_discipline_with_owned_trees(
+        self,
+        name='Disposable Discipline',
+        division=None,
+    ):
+        placeholder_geo = models.Geographytreedef.objects.create(
+            name=f'{name} placeholder geo'
+        )
+        placeholder_geo_time = models.Geologictimeperiodtreedef.objects.create(
+            name=f'{name} placeholder geotime'
+        )
+
+        discipline = models.Discipline.objects.create(
+            name=name,
+            type='paleobotany',
+            division=self.division if division is None else division,
+            datatype=self.datatype,
+            geographytreedef=placeholder_geo,
+            geologictimeperiodtreedef=placeholder_geo_time,
+        )
+
+        geography_tree = models.Geographytreedef.objects.create(
+            name=f'{name} geography',
+            discipline=discipline,
+        )
+        geography_rank = models.Geographytreedefitem.objects.create(
+            name='Planet',
+            rankid=0,
+            treedef=geography_tree,
+        )
+        models.Geography.objects.create(
+            name='Earth',
+            rankid=0,
+            definition=geography_tree,
+            definitionitem=geography_rank,
+        )
+
+        geotime_tree = models.Geologictimeperiodtreedef.objects.create(
+            name=f'{name} geotime',
+            discipline=discipline,
+        )
+        geotime_rank = models.Geologictimeperiodtreedefitem.objects.create(
+            name='Root',
+            rankid=0,
+            treedef=geotime_tree,
+        )
+        models.Geologictimeperiod.objects.create(
+            name='Root',
+            rankid=0,
+            definition=geotime_tree,
+            definitionitem=geotime_rank,
+        )
+
+        taxon_tree = models.Taxontreedef.objects.create(
+            name=f'{name} taxon',
+            discipline=discipline,
+        )
+        taxon_rank = models.Taxontreedefitem.objects.create(
+            name='Life',
+            rankid=0,
+            treedef=taxon_tree,
+        )
+        models.Taxon.objects.create(
+            name='Life',
+            rankid=0,
+            definition=taxon_tree,
+            definitionitem=taxon_rank,
+        )
+
+        discipline.geographytreedef = geography_tree
+        discipline.geologictimeperiodtreedef = geotime_tree
+        discipline.taxontreedef = taxon_tree
+        discipline.save()
+        return discipline
 
     def test_simple_agent_delete_blockers(self):
         prep_list = []
@@ -63,3 +157,34 @@ class TestDeleteBlockers(GeographyTree):
         
         for node in self._node_list:
             self._assertSame(self._get_blockers(node), [])
+
+    def test_division_delete_blockers_ignore_cascaded_discipline_setup_rows(self):
+        division = models.Division.objects.create(
+            name='Disposable Division',
+            institution=self.institution,
+        )
+        discipline = self._create_discipline_with_owned_trees(
+            'Division Discipline',
+            division=division,
+        )
+        self._create_discipline_with_owned_export_schema(discipline)
+
+        blockers = self._get_blockers(division)
+        self._assertSame(blockers, [])
+
+    def test_delete_division_removes_owned_setup_from_cascaded_discipline(self):
+        division = models.Division.objects.create(
+            name='Deletable Division',
+            institution=self.institution,
+        )
+        discipline = self._create_discipline_with_owned_trees(
+            'Division Delete Discipline',
+            division=division,
+        )
+        self._create_discipline_with_owned_export_schema(discipline)
+
+        delete_resource(
+            self.collection, self.agent, 'division', division.id, division.version
+        )
+        self.assertFalse(models.Division.objects.filter(id=division.id).exists())
+        self.assertFalse(models.Discipline.objects.filter(id=discipline.id).exists())


### PR DESCRIPTION
Fixes #7998

Fixes the remaining cascaded delete blockers cases related to #7797 that were not covered by #7833.

The previous fix only applied discipline-specific cleanup when `Discipline` was the base table being checked. That left a gap for parent records like `Division`, where Django cascades into related `Discipline` rows during delete blocker collection. In that path, discipline-owned setup rows such as `Spexportschema_exportmapping` could still surface and break the System Config UI.

I also found an issue with registry validation compared sorted policy keys.  It treated action array order as significant. That caused false `"operationPolicies is out of date"` errors when the front-end and back-end exposed the same actions in a different order.

## Changes

By normalize policy resource keys before comparison and normalize each resource's action array before comparison, the issue is solved.  Equivalent policy definitions no longer fail registry validation just because of action ordering differences.

The `delete_blockers` request it still taking a while to run when there are a lot of delete blockers.  In the future, we could try looking more into trying to speed it up.

### Checklist

- [x] Self-review the PR after opening it to make sure the changes look good and
      self-explanatory (or properly documented)
- [x] Add relevant issue to release milestone
- [ ] Add pr to documentation list
- [ ] Add automated tests

### Testing instructions

- Open System Config and navigate to a `Division` that has a related `Discipline`. (ex. sp7demofish)
- Ensure that the related `Discipline` has discipline-scoped setup data, such as export schema mappings.
- Trigger delete blocker collection for the `Division`.
- [x] Confirm the delete blockers UI loads without error.
- [x] Confirm the 'link records' appear after loading.