### PR TITLE
Issue 4766 redux

### DIFF
--- a/specifyweb/frontend/js_src/lib/components/AttachmentsBulkImport/Datasets.tsx
+++ b/specifyweb/frontend/js_src/lib/components/AttachmentsBulkImport/Datasets.tsx
@@ -32,6 +32,7 @@ import type {
   AttachmentDataSet,
   AttachmentDataSetPlan,
   FetchedDataSet,
+  PartialUploadableFileSpec,
 } from './types';
 import { useEagerDataSet } from './useEagerDataset';
 
@@ -97,11 +98,20 @@ function ModifyDataset({
   );
 }
 
-const createEmpty = async (name: LocalizedString) =>
+const createEmpty = async (
+  name: LocalizedString,
+  rows: RA<PartialUploadableFileSpec> = []
+) =>
   createEmptyDataSet<AttachmentDataSet>('bulkAttachment', name, {
     uploadplan: { staticPathKey: undefined },
     uploaderstatus: 'main',
+    rows,
   });
+
+export const createEmptyAttachmentDataset = (
+  name: LocalizedString,
+  rows: RA<PartialUploadableFileSpec> = []
+) => createEmpty(name, rows);
 
 export function AttachmentsImportOverlay(): JSX.Element | null {
   const handleClose = React.useContext(OverlayContext);
@@ -274,7 +284,7 @@ function NewDataSet(): JSX.Element | null {
             id={id('form')}
             onSubmit={async () => {
               loading(
-                createEmpty(pendingName).then(({ id }) =>
+                createEmptyAttachmentDataset(pendingName).then(({ id }) =>
                   navigate(`/specify/attachments/import/${id}`)
                 )
               );

--- a/specifyweb/frontend/js_src/lib/components/AttachmentsBulkImport/ImportFromMappingFile.tsx
+++ b/specifyweb/frontend/js_src/lib/components/AttachmentsBulkImport/ImportFromMappingFile.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import { localized, RA } from '../../utils/types';
+import { CsvFilePicker } from '../Molecules/CsvFilePicker';
+import { attachmentsText } from '../../localization/attachments';
+import { useNavigate } from 'react-router-dom';
+
+import { PartialUploadableFileSpec } from './types';
+import { createEmptyAttachmentDataset } from './Datasets';
+
+// TODO: Is this needed?
+//const requiredHeaders = ['filename', 'identifier'];
+
+export function ImportFromMappingFile(): JSX.Element {
+  const navigate = useNavigate();
+  return (
+    <>
+      <CsvFilePicker
+        header={attachmentsText.importFromMappingFile()}
+        onFileImport={({ data: rawRows, fileName }) => {
+          // To support mapping file, we just create a new dataset with files. Matching behaviour
+          // within dataset takes care of rest
+          const attachmentRows: RA<PartialUploadableFileSpec> = rawRows.map(
+            ([fileName, parsedName]) => ({
+              uploadFile: {
+                file: {
+                  name: fileName,
+                },
+                parsedName,
+              },
+            })
+          );
+          createEmptyAttachmentDataset(
+            localized(fileName),
+            attachmentRows
+          ).then(({ id }) => navigate(`/specify/attachments/import/${id}`));
+        }}
+      />
+    </>
+  );
+}

--- a/specifyweb/frontend/js_src/lib/components/AttachmentsBulkImport/ViewAttachmentFiles.tsx
+++ b/specifyweb/frontend/js_src/lib/components/AttachmentsBulkImport/ViewAttachmentFiles.tsx
@@ -63,7 +63,10 @@ const resolveAttachmentDatasetData = (
             {uploadFile.file.name}
           </div>,
         ],
-        fileSize: formatFileSize(uploadFile.file.size),
+        fileSize:
+          uploadFile.file.size === undefined
+            ? ''
+            : formatFileSize(uploadFile.file.size),
         record: [
           resolvedRecord?.type === 'matched'
             ? resolvedRecord.id

--- a/specifyweb/frontend/js_src/lib/components/AttachmentsBulkImport/types.ts
+++ b/specifyweb/frontend/js_src/lib/components/AttachmentsBulkImport/types.ts
@@ -9,7 +9,6 @@ import type { DatasetBase, DatasetBriefBase } from '../WbPlanView/Wrapped';
 import type { PartialAttachmentUploadSpec } from './Import';
 import type { staticAttachmentImportPaths } from './importPaths';
 import type { keyLocalizationMapAttachment } from './utils';
-import { Optional } from 'typedoc/dist/lib/utils/validation';
 
 export type UploadAttachmentSpec = {
   readonly token: string;

--- a/specifyweb/frontend/js_src/lib/components/AttachmentsBulkImport/types.ts
+++ b/specifyweb/frontend/js_src/lib/components/AttachmentsBulkImport/types.ts
@@ -9,6 +9,7 @@ import type { DatasetBase, DatasetBriefBase } from '../WbPlanView/Wrapped';
 import type { PartialAttachmentUploadSpec } from './Import';
 import type { staticAttachmentImportPaths } from './importPaths';
 import type { keyLocalizationMapAttachment } from './utils';
+import { Optional } from 'typedoc/dist/lib/utils/validation';
 
 export type UploadAttachmentSpec = {
   readonly token: string;
@@ -57,7 +58,8 @@ type UploadableFileSpec = {
  * Forcing keys to be primitive because objects would be
  * ignored during syncing to backend.
  */
-export type BoundFile = Pick<File, 'name' | 'size' | 'type'>;
+export type BoundFile = Pick<File, 'name'> &
+  Partial<Pick<File, 'size' | 'type'>>;
 
 export type UnBoundFile = {
   readonly file: BoundFile | File;

--- a/specifyweb/frontend/js_src/lib/components/AttachmentsBulkImport/utils.ts
+++ b/specifyweb/frontend/js_src/lib/components/AttachmentsBulkImport/utils.ts
@@ -15,7 +15,6 @@ import {
   keysToLowerCase,
   mappedFind,
   replaceItem,
-  stripFileExtension,
 } from '../../utils/utils';
 import { addMissingFields } from '../DataModel/addMissingFields';
 import type {
@@ -157,6 +156,7 @@ type MatchSelectedFiles = {
   readonly resolvedFiles: RA<PartialUploadableFileSpec>;
   readonly duplicateFiles: RA<PartialUploadableFileSpec>;
 };
+
 export const matchSelectedFiles = (
   previousUploadables: RA<PartialUploadableFileSpec>,
   filesToResolve: RA<PartialUploadableFileSpec>
@@ -168,10 +168,14 @@ export const matchSelectedFiles = (
           previousUploadable.uploadFile !== undefined &&
           previousUploadable.uploadFile.file.name ===
             uploadable.uploadFile.file.name &&
-          previousUploadable.uploadFile.file.size ===
-            uploadable.uploadFile.file.size &&
-          previousUploadable.uploadFile.file.type ===
-            uploadable.uploadFile.file.type
+          // If previous uploadables do not have size, skip them.
+          // Happens when mapping file is being used
+          (previousUploadable.uploadFile.file.size === undefined ||
+            previousUploadable.uploadFile.file.size ===
+              uploadable.uploadFile.file.size) &&
+          (previousUploadable.uploadFile.file.type === undefined ||
+            previousUploadable.uploadFile.file.type ===
+              uploadable.uploadFile.file.type)
       );
       if (matchedIndex === -1)
         return {
@@ -189,6 +193,7 @@ export const matchSelectedFiles = (
           duplicateFiles: [...previousMatchedSpec.duplicateFiles, uploadable],
         };
 
+      // We get here if we are going to preserve the incoming file.
       return {
         ...previousMatchedSpec,
         resolvedFiles: replaceItem(
@@ -196,15 +201,17 @@ export const matchSelectedFiles = (
           matchedIndex,
           {
             ...previousMatch,
-            uploadFile: uploadable.uploadFile,
+            uploadFile: {
+              file: uploadable.uploadFile.file,
+              parsedName: previousMatch.uploadFile.parsedName,
+            },
             /*
              * Generating tokens again because the file could have been
              * uploaded to the asset server but not yet recorded in Specify DB.
              */
             uploadTokenSpec: undefined,
             /*
-             * Take the new status in case of parse failure was reported.
-             * But take the previous status it was a success
+             * Take the previous status it was a success
              */
             status:
               previousMatch.status?.type === 'success' ||
@@ -228,7 +235,7 @@ export function resolveFileNames(
   formatter?: UiFormatter
 ): string | undefined {
   // BUG: Won't catch if formatters begin or end with a space
-  const splitName = stripFileExtension(fileName).trim();
+  const splitName = fileName.trim();
   let nameToParse = splitName;
   if (formatter?.parts.every((field) => field.type !== 'regex') === true) {
     nameToParse = fileName.trim().slice(0, formatter.size);

--- a/specifyweb/frontend/js_src/lib/components/Molecules/CsvFilePicker.tsx
+++ b/specifyweb/frontend/js_src/lib/components/Molecules/CsvFilePicker.tsx
@@ -79,11 +79,13 @@ export function CsvFilePreview({
     hasHeader,
     encoding,
     getSetDelimiter,
+    fileName,
   }: {
     readonly data: RA<RA<string>>;
     readonly hasHeader: boolean;
     readonly encoding: string;
     readonly getSetDelimiter: GetOrSet<string | undefined>;
+    readonly fileName: string;
   }) => void;
 }): JSX.Element {
   const [encoding, setEncoding] = React.useState<string>('utf-8');
@@ -104,6 +106,7 @@ export function CsvFilePreview({
           hasHeader,
           encoding,
           getSetDelimiter,
+          fileName: file.name,
         });
       }}
     >

--- a/specifyweb/frontend/js_src/lib/components/Router/Routes.tsx
+++ b/specifyweb/frontend/js_src/lib/components/Router/Routes.tsx
@@ -200,6 +200,13 @@ export const routes: RA<EnhancedRoute> = [
             ({ AttachmentImportById }) => AttachmentImportById
           ),
       },
+      {
+        path: 'import',
+        element: () =>
+          import('../AttachmentsBulkImport/ImportFromMappingFile').then(
+            ({ ImportFromMappingFile }) => ImportFromMappingFile
+          ),
+      },
     ],
   },
   {

--- a/specifyweb/frontend/js_src/lib/components/WbImport/index.tsx
+++ b/specifyweb/frontend/js_src/lib/components/WbImport/index.tsx
@@ -29,6 +29,7 @@ import {
   parseXls,
   wbImportPreviewSize,
 } from './helpers';
+import { stripFileExtension } from '../../utils/utils';
 
 export function WbImportView(): JSX.Element {
   useMenuItem('workBench');

--- a/specifyweb/frontend/js_src/lib/localization/attachments.ts
+++ b/specifyweb/frontend/js_src/lib/localization/attachments.ts
@@ -848,4 +848,7 @@ export const attachmentsText = createDictionary({
     'hr-hr':
       'Ovo kontrolira hoće li se novi privitci dodani u ovu kolekciju prema zadanim postavkama označavati kao "Javni". Javni privitci automatski će biti vidljivi na Navedite web portalu. Ova se postavka može poništiti za svaki pojedinačni privitak i ne utječe na postojeće privitke.',
   },
+  importFromMappingFile: {
+    'en-us': 'Import from Mapping File',
+  },
 } as const);


### PR DESCRIPTION
Fixes #4766

From @realVinayak:
> Realized that previously implemented logic covered most of the cases. We already supported matching files to previously selected files. So, now, we just make a new attachment dataset based on the selected csv. When user selects files, they will be matched to this dataset (which is based on csv) so we just preserve the parsed name. 
> 
> I'll add more automated tests for this before making this open for review for everything seems to be working!
> 
> EDIT: I based it off @melton-jason coge-import because I realized I could reuse some of that code. I'm still considering directly using workbench's implementation though
> 
> ![image](https://github.com/specify/specify7/assets/61122018/311f0486-9505-48d0-9be1-20bdd59e8e30)
> 
> ![image](https://github.com/specify/specify7/assets/61122018/c845979d-146d-413b-b968-e74edf1b7ded)

### Checklist

- [ ] Self-review the PR after opening it to make sure the changes look good
      and self-explanatory (or properly documented)
- [ ] Add automated tests
- [ ] Add relevant issue to release milestone

### Testing instructions

<!-- What are the steps to verify the fixes/changes in this PR? -->
<!-- Can part of that be replaced by automated tests? -->


### Checklist

- [ ] Self-review the PR after opening it to make sure the changes look good and
      self-explanatory (or properly documented)
- [ ] Add relevant issue to release milestone
- [ ] Add pr to documentation list
- [ ] Add automated tests
- [ ] Add a reverse migration if a migration is present in the PR
- [ ] Add migration function to https://github.com/specify/specify7/blob/ea04665987e1b8a1b76955c7b7f702b7bf701b47/specifyweb/specify/management/commands/run_key_migration_functions.py#L50


### Testing instructions

<!-- What are the steps to verify the fixes/changes in this PR? -->
<!-- Can part of that be replaced by automated tests? -->
