### PR TITLE
Fix: Fix autocomplete requiring double click due to blur/mousedown race

### DIFF
--- a/specifyweb/frontend/js_src/lib/components/Molecules/AutoComplete.tsx
+++ b/specifyweb/frontend/js_src/lib/components/Molecules/AutoComplete.tsx
@@ -430,6 +430,9 @@ export function AutoComplete<T>({
             overflow-y-auto rounded rounded bg-white shadow-lg
             shadow-gray-400 dark:border dark:border-gray-500 dark:bg-neutral-900
           `}
+          onMouseDown={(e) => {
+                      e.preventDefault();
+                    }}
           ref={dataListRefCallback}
         >
           {isLoading && (

--- a/specifyweb/frontend/js_src/lib/components/Molecules/AutoComplete.tsx
+++ b/specifyweb/frontend/js_src/lib/components/Molecules/AutoComplete.tsx
@@ -343,6 +343,7 @@ export function AutoComplete<T>({
   );
 
   const inputRef = React.useRef<HTMLInputElement | null>(null);
+  const shouldBlurAfterMouseSelection = React.useRef(false);
   const forwardChildRef: React.RefCallback<HTMLInputElement> =
     React.useCallback(
       (input): void => {
@@ -383,9 +384,15 @@ export function AutoComplete<T>({
       value={currentItem ?? null}
       // Triggers on enter or selects new item
       onChange={(value): void => {
+        const blurAfterSelection = shouldBlurAfterMouseSelection.current;
+        shouldBlurAfterMouseSelection.current = false;
         if (value === null) handleCleared?.();
         else if (typeof value === 'string') handleNewValue?.(value);
-        else handleChanged(value);
+        else {
+          handleChanged(value);
+          if (blurAfterSelection)
+            globalThis.setTimeout(() => inputRef.current?.blur(), 0);
+        }
       }}
     >
       <Combobox.Input
@@ -506,7 +513,12 @@ export function AutoComplete<T>({
             return (
               <Combobox.Option as={React.Fragment} key={index} value={item}>
                 {({ active, selected }): JSX.Element => (
-                  <li className={optionClassName(active, selected)}>
+                  <li
+                    className={optionClassName(active, selected)}
+                    onMouseDown={(): void => {
+                      shouldBlurAfterMouseSelection.current = true;
+                    }}
+                  >
                     {typeof item.icon === 'string' ? (
                       <div className="flex items-center">
                         {item.icon}
@@ -523,7 +535,12 @@ export function AutoComplete<T>({
           {showAdd && (
             <Combobox.Option as={React.Fragment} value={pendingValue}>
               {({ active, selected }): JSX.Element => (
-                <li className={optionClassName(active, selected)}>
+                <li
+                  className={optionClassName(active, selected)}
+                  onMouseDown={(): void => {
+                    shouldBlurAfterMouseSelection.current = true;
+                  }}
+                >
                   <div className="flex items-center">
                     <span className={className.dataEntryAdd}>{icons.plus}</span>
                     {commonText.add()}

--- a/specifyweb/frontend/js_src/lib/components/Molecules/AutoComplete.tsx
+++ b/specifyweb/frontend/js_src/lib/components/Molecules/AutoComplete.tsx
@@ -431,8 +431,9 @@ export function AutoComplete<T>({
             shadow-gray-400 dark:border dark:border-gray-500 dark:bg-neutral-900
           `}
           onMouseDown={(e: React.MouseEvent) => {
-                      e.preventDefault();
-                    }}
+            e.preventDefault();
+            e.stopPropagation();
+          }}
           ref={dataListRefCallback}
         >
           {isLoading && (

--- a/specifyweb/frontend/js_src/lib/components/Molecules/AutoComplete.tsx
+++ b/specifyweb/frontend/js_src/lib/components/Molecules/AutoComplete.tsx
@@ -430,7 +430,7 @@ export function AutoComplete<T>({
             overflow-y-auto rounded rounded bg-white shadow-lg
             shadow-gray-400 dark:border dark:border-gray-500 dark:bg-neutral-900
           `}
-          onMouseDown={(e) => {
+          onMouseDown={(e: React.MouseEvent) => {
                       e.preventDefault();
                     }}
           ref={dataListRefCallback}


### PR DESCRIPTION
Fixes #8005


### Checklist

- [ ] Self-review the PR after opening it to make sure the changes look good and
      self-explanatory (or properly documented)
- [ ] Add relevant issue to release milestone


### Testing instructions

- Go to the collection object form
- Select any query combo box (i.e. accession)
- Type in an existing record
- Select a result
- [ ] Verify the results disappear

