### PR TITLE
Fix: Disable Download All button when no attachments

### DIFF
--- a/specifyweb/frontend/js_src/lib/components/Attachments/RecordSetAttachment.tsx
+++ b/specifyweb/frontend/js_src/lib/components/Attachments/RecordSetAttachment.tsx
@@ -132,6 +132,9 @@ export function RecordSetAttachments<SCHEMA extends AnySchema>({
           buttons={
             <>
               <Button.Info
+                disabled={
+                    (attachmentsRef.current?.attachments.length ?? 0) === 0
+                  }
                 title={attachmentsText.downloadAllDescription()}
                 onClick={(): void =>
                   recordSetId === undefined && !isComplete

--- a/specifyweb/frontend/js_src/lib/components/Attachments/__tests__/recordSetAttachement.test.tsx
+++ b/specifyweb/frontend/js_src/lib/components/Attachments/__tests__/recordSetAttachement.test.tsx
@@ -1,0 +1,50 @@
+import { screen, waitFor } from '@testing-library/react';
+import React from 'react';
+
+import { clearIdStore } from '../../../hooks/useId';
+import { requireContext } from '../../../tests/helpers';
+import { mount } from '../../../tests/reactUtils';
+import { f } from '../../../utils/functools';
+import { LoadingContext } from '../../Core/Contexts';
+import { RecordSetAttachments } from '../RecordSetAttachment';
+
+requireContext();
+
+beforeEach(() => {
+  clearIdStore();
+});
+
+describe('RecordSetAttachments', () => {
+  test('Download All button is disabled when there are no attachments', async () => {
+    jest.spyOn(console, 'warn').mockImplementation();
+
+    const { user } = mount(
+      <LoadingContext.Provider value={f.void}>
+        <RecordSetAttachments
+          name="Test Record Set"
+          recordCount={0}
+          recordSetId={1}
+          records={[]}
+          onFetch={undefined}
+        />
+      </LoadingContext.Provider>
+    );
+
+    // Open the attachments dialog
+    const galleryButton = screen.getByTitle('attachments');
+    await user.click(galleryButton);
+
+    // Wait for the dialog to render with the Download All button
+    await waitFor(() => {
+      expect(
+        screen.getByText('Download All', { exact: false })
+      ).toBeInTheDocument();
+    });
+
+    // The Download All button should be disabled when there are no attachments
+    const downloadAllButton = screen.getByText('Download All', {
+      exact: false,
+    }).closest('button')!;
+    expect(downloadAllButton).toBeDisabled();
+  });
+});

--- a/specifyweb/frontend/js_src/lib/components/Attachments/__tests__/recordSetAttachement.test.tsx
+++ b/specifyweb/frontend/js_src/lib/components/Attachments/__tests__/recordSetAttachement.test.tsx
@@ -1,4 +1,4 @@
-import { screen, waitFor } from '@testing-library/react';
+import { screen } from '@testing-library/react';
 import React from 'react';
 
 import { clearIdStore } from '../../../hooks/useId';
@@ -16,35 +16,42 @@ beforeEach(() => {
 
 describe('RecordSetAttachments', () => {
   test('Download All button is disabled when there are no attachments', async () => {
-    jest.spyOn(console, 'warn').mockImplementation();
+    jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const mockRecord = {
+      specifyTable: {
+        name: 'TestTable',
+      },
+      populated: true,
+      rgetCollection: jest.fn().mockResolvedValue({
+        models: [],
+      }),
+    } as any;
 
     const { user } = mount(
       <LoadingContext.Provider value={f.void}>
         <RecordSetAttachments
           name="Test Record Set"
-          recordCount={0}
+          recordCount={1}
           recordSetId={1}
-          records={[]}
+          records={[mockRecord]}
           onFetch={undefined}
         />
       </LoadingContext.Provider>
     );
 
-    // Open the attachments dialog
-    const galleryButton = screen.getByTitle('attachments');
-    await user.click(galleryButton);
-
-    // Wait for the dialog to render with the Download All button
-    await waitFor(() => {
-      expect(
-        screen.getByText('Download All', { exact: false })
-      ).toBeInTheDocument();
+    // Open attachments dialog
+    const galleryButton = screen.getByRole('button', {
+      name: /attachments/i,
     });
 
-    // The Download All button should be disabled when there are no attachments
-    const downloadAllButton = screen.getByText('Download All', {
-      exact: false,
-    }).closest('button')!;
+    await user.click(galleryButton);
+
+    // Assert dialog opens and Download All appears (but disabled)
+    const downloadAllButton = await screen.findByRole('button', {
+      name: /download all/i,
+    });
+
     expect(downloadAllButton).toBeDisabled();
   });
 });


### PR DESCRIPTION
Fixes #7898

PR/code contribution made by @foozleface 

### Checklist

- [ ] Self-review the PR after opening it to make sure the changes look good and
      self-explanatory (or properly documented)
- [ ] Add relevant issue to release milestone


### Testing instructions

- Open a record set that has no attachments
-  Click the attachments gallery button to open the attachments dialog
-  Verify the "Download All" button is visually disabled and not clickable
-  [ ] Open a record set that does have attachments and verify the button is enabled