### PR TITLE
Fix supressing leading zeros in Collection Object's Catalog Number in data entry

### DIFF
--- a/specifyweb/frontend/js_src/lib/components/Formatters/formatters.ts
+++ b/specifyweb/frontend/js_src/lib/components/Formatters/formatters.ts
@@ -196,8 +196,8 @@ async function formatField(
       ? naiveFormatter(parentResource.specifyTable.name, parentResource.id)
       : userText.noPermission();
 
-  if (trimZeros) 
-    formatted = Number.isNaN(Number(formatted)) && /\d/.test(formatted ?? '')
+  if (trimZeros)
+    formatted = Number.isNaN(Number(formatted)) || (formatted ?? '').trim() === ''
       ? formatted
       : Number(formatted).toString();
 

--- a/specifyweb/frontend/js_src/lib/components/Formatters/formatters.ts
+++ b/specifyweb/frontend/js_src/lib/components/Formatters/formatters.ts
@@ -196,8 +196,8 @@ async function formatField(
       ? naiveFormatter(parentResource.specifyTable.name, parentResource.id)
       : userText.noPermission();
 
-  if (trimZeros)
-    formatted = Number.isNaN(Number(formatted))
+  if (trimZeros) 
+    formatted = Number.isNaN(Number(formatted)) && /\d/.test(formatted ?? '')
       ? formatted
       : Number(formatted).toString();
 

--- a/specifyweb/frontend/js_src/lib/components/Formatters/formatters.ts
+++ b/specifyweb/frontend/js_src/lib/components/Formatters/formatters.ts
@@ -196,10 +196,12 @@ async function formatField(
       ? naiveFormatter(parentResource.specifyTable.name, parentResource.id)
       : userText.noPermission();
 
-  if (trimZeros)
-    formatted = Number.isNaN(Number(formatted)) || (formatted ?? '').trim() === ''
+  if (trimZeros) {
+    const num = Number(formatted);
+    formatted = Number.isNaN(num) || (formatted ?? '').trim() === '' || !Number.isSafeInteger(num)
       ? formatted
-      : Number(formatted).toString();
+      : num.toString();
+  }
 
   return {
     formatted: formatted?.toString() ?? '',


### PR DESCRIPTION
Fixes #1707

### Checklist

- [x] Self-review the PR after opening it to make sure the changes look good and
      self-explanatory (or properly documented)
- [ ] Add relevant issue to release milestone
- [ ] Add pr to documentation list
- [ ] Add automated tests


### Testing instructions

- Go to app resources -> Record formatters -> Collection Object. Click the gear next to the catalogNumber field formatter and enable Trim Zeros.
- [ ] On data entry, the title of the unsaved CO should read "Collection Object"
- Save the collection object
- [ ] On data entry, the title of the saved CO should read something like "Collection Object: 1"
- Disable Trim Zeros
- [ ] On data entry, the title of the unsaved CO should read "Collection Object"
- Save the collection object
- [ ] On data entry, the title of the saved CO should read something like "Collection Object: 000000001"
- [ ] Generally test table formatters in the preview to make sure they are okay. You don't need to test formatters in query results.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved trimming of trailing zeros for formatted numbers: empty, whitespace-only, non-numeric, or unsafe-integer values are now preserved instead of being coerced, preventing incorrect or inconsistent displays.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->