### PR TITLE
Fix form column definition precedence

### DIFF
--- a/specifyweb/frontend/js_src/lib/components/FormParse/__tests__/index.test.ts
+++ b/specifyweb/frontend/js_src/lib/components/FormParse/__tests__/index.test.ts
@@ -471,6 +471,30 @@ describe('parseFormDefinition', () => {
 describe('getColumnDefinitions', () => {
   requireContext();
 
+  test('prefers linux definition over generic definition', () =>
+    expect(
+      getColumnDefinitions(
+        xml(
+          `<viewdef>
+            <columnDef>Generic</columnDef>
+            <columnDef os="lnx">Linux</columnDef>
+          </viewdef>`
+        )
+      )
+    ).toBe('Linux'));
+
+  test('uses generic definition if linux definition is not available', () =>
+    expect(
+      getColumnDefinitions(
+        xml(
+          `<viewdef>
+            <columnDef os="mac">Mac</columnDef>
+            <columnDef>Generic</columnDef>
+          </viewdef>`
+        )
+      )
+    ).toBe('Generic'));
+
   test('fall back to first definition available', () =>
     expect(
       getColumnDefinitions(
@@ -510,7 +534,7 @@ theories(getColumnDefinition, [
       ),
       undefined,
     ],
-    out: 'B',
+    out: 'A',
   },
 ]);
 

--- a/specifyweb/frontend/js_src/lib/components/FormParse/index.ts
+++ b/specifyweb/frontend/js_src/lib/components/FormParse/index.ts
@@ -89,6 +89,8 @@ export const formTypes = ['form', 'formTable'] as const;
 export type FormType = (typeof formTypes)[number];
 export type FormMode = 'edit' | 'search' | 'view';
 
+const defaultColumnDefinitionOs = 'lnx';
+
 let views: R<ViewDefinition | undefined> = {};
 
 export const getViewSetApiUrl = (viewName: string): string =>
@@ -539,10 +541,25 @@ function getColumnDefinitions(viewDefinition: SimpleXmlNode): string {
 const getColumnDefinition = (
   viewDefinition: SimpleXmlNode,
   os: string | undefined
-): string | undefined =>
-  viewDefinition.children.columnDef?.find((child) =>
-    typeof os === 'string' ? getParsedAttribute(child, 'os') === os : true
-  )?.text;
+): string | undefined => {
+  const columnDefinitions = viewDefinition.children.columnDef;
+  if (columnDefinitions === undefined) return undefined;
+
+  if (typeof os === 'string')
+    return columnDefinitions.find(
+      (child) => getParsedAttribute(child, 'os') === os
+    )?.text;
+
+  return (
+    columnDefinitions.find(
+      (child) => getParsedAttribute(child, 'os') === defaultColumnDefinitionOs
+    )?.text ??
+    columnDefinitions.find(
+      (child) => getParsedAttribute(child, 'os') === undefined
+    )?.text ??
+    columnDefinitions[0]?.text
+  );
+};
 
 const parseRows = async (
   rawRows: RA<SimpleXmlNode>,


### PR DESCRIPTION
Fixes #8022

Fixes a regression where generic `<columnDef>` entries were being used before `<columnDef os="lnx">` entries when parsing form layouts. The form parser now prefers the Linux-specific column definition, then falls back to the generic definition, then to the first available definition.


### Checklist

- [x] Self-review the PR after opening it to make sure the changes look good and
      self-explanatory (or properly documented)
- [x] Add relevant issue to release milestone
- [ ] Add pr to documentation list


### Testing instructions

- Open a form that defines both `<columnDef>` and `<columnDef os="lnx">`, such as the reported Determination form.
- [x] Confirm the rendered web form uses the `os="lnx"` column layout rather than the generic layout.
- Temporarily remove or disable the `os="lnx"` column definition and confirm the generic `<columnDef>` layout is used as the fallback.
- [x] Check a form table/subview still renders correctly.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed column definition selection logic to properly prioritize operating system-specific variants when multiple options are available, ensuring correct configurations are applied based on your system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->