### PR TITLE
Fix WorkBench export file extension for selected delimiter

### DIFF
--- a/specifyweb/frontend/js_src/lib/components/WorkBench/__tests__/helpers.test.ts
+++ b/specifyweb/frontend/js_src/lib/components/WorkBench/__tests__/helpers.test.ts
@@ -1,0 +1,40 @@
+import { theories } from '../../../tests/utils';
+import { getDelimitedFileName } from '../helpers';
+
+theories(getDelimitedFileName, [
+  {
+    name: 'uses csv for comma delimiters',
+    in: ['Data Set', ','],
+    out: 'Data Set.csv',
+  },
+  {
+    name: 'uses csv for semicolon delimiters',
+    in: ['Data Set', ';'],
+    out: 'Data Set.csv',
+  },
+  {
+    name: 'uses tsv for tab delimiters',
+    in: ['Data Set', '\t'],
+    out: 'Data Set.tsv',
+  },
+  {
+    name: 'uses psv for pipe delimiters',
+    in: ['Data Set', '|'],
+    out: 'Data Set.psv',
+  },
+  {
+    name: 'uses txt for space delimiters',
+    in: ['Data Set', ' '],
+    out: 'Data Set.txt',
+  },
+  {
+    name: 'replaces known delimited file extensions',
+    in: ['Data.Set.TSV', ','],
+    out: 'Data.Set.csv',
+  },
+  {
+    name: 'preserves periods that are not known extensions',
+    in: ['Dr. Smith Data Set', ','],
+    out: 'Dr. Smith Data Set.csv',
+  },
+]);

--- a/specifyweb/frontend/js_src/lib/components/WorkBench/helpers.ts
+++ b/specifyweb/frontend/js_src/lib/components/WorkBench/helpers.ts
@@ -3,6 +3,21 @@ import { stringify } from 'csv-stringify/browser/esm';
 import type { RA } from '../../utils/types';
 import { downloadFile } from '../Molecules/FilePicker';
 
+const delimiterFileExtensions = new Map<string, string>([
+  [',', 'csv'],
+  [';', 'csv'],
+  ['\t', 'tsv'],
+  ['|', 'psv'],
+  [' ', 'txt'],
+]);
+
+const knownDelimitedFileExtension = /\.(csv|psv|tsv|txt)$/iu;
+
+export const getDelimitedFileName = (name: string, delimiter: string): string =>
+  `${name.replace(knownDelimitedFileExtension, '')}.${
+    delimiterFileExtensions.get(delimiter) ?? 'txt'
+  }`;
+
 export const downloadDataSet = async (
   name: string,
   rows: RA<RA<string>>,
@@ -19,9 +34,7 @@ export const downloadDataSet = async (
       },
       (error, output) => {
         if (error === undefined)
-          resolve(
-            downloadFile(name.endsWith('.csv') ? name : `${name}.tsv`, output)
-          );
+          resolve(downloadFile(getDelimitedFileName(name, delimiter), output));
         else reject(error);
       }
     )


### PR DESCRIPTION
Fixes #8047

Fixes WorkBench data set exports so the downloaded filename extension matches the selected `Export file delimiter` preference.

Previously, exports used the configured delimiter for file content, but the filename defaulted to `.tsv` unless the caller had already supplied `.csv`. This caused comma delimited exports to download with the wrong extension.

### Checklist

- [ ] Self-review the PR after opening it to make sure the changes look good and
      self-explanatory (or properly documented)
- [x] Add relevant issue to release milestone
- [ ] Add pr to documentation list
- [x] Add automated tests

### Testing instructions

- Open User Preferences > WorkBench.
- Set `Export file delimiter` to `Comma`.
- Open a WorkBench data set and click Export.
- [ ] Confirm the downloaded file ends in `.csv`.
- [ ] Confirm the exported content is comma-delimited.
- Change `Export file delimiter` to `Tab`.
- Export the same data set again.
- [ ] Confirm the downloaded file ends in `.tsv`.
- Optionally repeat with pipe, semicolon, and space delimiters to confirm the extension matches the selected delimiter behavior.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed data export file naming. Downloaded files now receive the correct extension (.csv, .tsv, .psv, or .txt) based on their actual delimiter format, improving file compatibility and clarity.

* **Tests**
  * Added comprehensive test coverage for delimited file naming scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->