### PR TITLE
Auto-populate Collecting Event end date from start date

### DIFF
--- a/specifyweb/frontend/js_src/lib/components/DataModel/__tests__/businessRules.test.ts
+++ b/specifyweb/frontend/js_src/lib/components/DataModel/__tests__/businessRules.test.ts
@@ -498,6 +498,56 @@ describe.skip('Dependent Collections isPrimary', () => {
 });
 
 describe('Collecting Event', () => {
+  test('copies start date into an empty end date', () => {
+    const collectingEvent = new tables.CollectingEvent.Resource();
+
+    collectingEvent.set('startDate', '2026-04-27');
+
+    expect(collectingEvent.get('endDate')).toBe('2026-04-27');
+  });
+
+  test('updates an automatically copied end date when start date changes', () => {
+    const collectingEvent = new tables.CollectingEvent.Resource();
+
+    collectingEvent.set('startDate', '2026-04-27');
+    collectingEvent.set('startDate', '2026-04-28');
+
+    expect(collectingEvent.get('endDate')).toBe('2026-04-28');
+  });
+
+  test('preserves a manually changed end date', () => {
+    const collectingEvent = new tables.CollectingEvent.Resource();
+
+    collectingEvent.set('startDate', '2026-04-27');
+    collectingEvent.set('endDate', '2026-04-29');
+    collectingEvent.set('startDate', '2026-04-28');
+
+    expect(collectingEvent.get('endDate')).toBe('2026-04-29');
+  });
+
+  test('keeps end date precision with an automatically copied end date', () => {
+    const collectingEvent = new tables.CollectingEvent.Resource();
+
+    collectingEvent.set('startDatePrecision', 2);
+    collectingEvent.set('endDatePrecision', 1, { silent: true });
+    collectingEvent.set('startDate', '2026-04-01');
+    collectingEvent.set('startDatePrecision', 3);
+
+    expect(collectingEvent.get('endDate')).toBe('2026-04-01');
+    expect(collectingEvent.get('endDatePrecision')).toBe(3);
+  });
+
+  test('preserves a manually changed end date precision', () => {
+    const collectingEvent = new tables.CollectingEvent.Resource();
+
+    collectingEvent.set('startDate', '2026-04-01');
+    collectingEvent.set('startDatePrecision', 2);
+    collectingEvent.set('endDatePrecision', 1);
+    collectingEvent.set('startDatePrecision', 3);
+
+    expect(collectingEvent.get('endDatePrecision')).toBe(1);
+  });
+
   test('Removing Collector sets first Collector as primary', () => {
     const collectingEvent = new tables.CollectingEvent.Resource({
       collectors: [

--- a/specifyweb/frontend/js_src/lib/components/DataModel/__tests__/businessRules.test.ts
+++ b/specifyweb/frontend/js_src/lib/components/DataModel/__tests__/businessRules.test.ts
@@ -498,6 +498,16 @@ describe.skip('Dependent Collections isPrimary', () => {
 });
 
 describe('Collecting Event', () => {
+  test('copies start date into end date during initialization', () => {
+    const collectingEvent = new tables.CollectingEvent.Resource({
+      startDate: '2026-04-27',
+      startDatePrecision: 2,
+    });
+
+    expect(collectingEvent.get('endDate')).toBe('2026-04-27');
+    expect(collectingEvent.get('endDatePrecision')).toBe(2);
+  });
+
   test('copies start date into an empty end date', () => {
     const collectingEvent = new tables.CollectingEvent.Resource();
 

--- a/specifyweb/frontend/js_src/lib/components/DataModel/businessRuleDefs.ts
+++ b/specifyweb/frontend/js_src/lib/components/DataModel/businessRuleDefs.ts
@@ -116,6 +116,7 @@ const getCollectingEventDateRangeSyncState = (
 function initializeCollectingEventDateRangeSync(
   collectingEvent: SpecifyResource<CollectingEvent>
 ): void {
+  syncCollectingEventEndDate(collectingEvent);
   updateCollectingEventDateRangeSyncState(collectingEvent);
   updateCollectingEventDatePrecisionSyncState(collectingEvent);
 }
@@ -143,14 +144,12 @@ function updateCollectingEventDatePrecisionSyncState(
   const endDatePrecision = normalizeDatePrecision(
     collectingEvent.get('endDatePrecision')
   );
-  const isSynced =
-    startDatePrecision !== null && startDatePrecision === endDatePrecision;
+  const isSynced = startDatePrecision === endDatePrecision;
 
   collectingEventDateRangeSyncState.set(collectingEvent, {
     ...state,
     endDatePrecision: isSynced ? endDatePrecision : undefined,
-    isEndDatePrecisionManual:
-      startDatePrecision !== null && endDatePrecision !== null && !isSynced,
+    isEndDatePrecisionManual: !isSynced,
   });
 }
 

--- a/specifyweb/frontend/js_src/lib/components/DataModel/businessRuleDefs.ts
+++ b/specifyweb/frontend/js_src/lib/components/DataModel/businessRuleDefs.ts
@@ -167,8 +167,10 @@ function syncCollectingEventEndDate(
     });
     collectingEvent.set('endDate', startDate);
     syncCollectingEventEndDatePrecision(collectingEvent, true);
-  } else if (startDate !== null && startDate === endDate)
+  } else if (startDate !== null && startDate === endDate) {
     updateCollectingEventDateRangeSyncState(collectingEvent);
+    syncCollectingEventEndDatePrecision(collectingEvent);
+  }
 }
 
 function syncCollectingEventEndDatePrecision(

--- a/specifyweb/frontend/js_src/lib/components/DataModel/businessRuleDefs.ts
+++ b/specifyweb/frontend/js_src/lib/components/DataModel/businessRuleDefs.ts
@@ -129,8 +129,7 @@ function updateCollectingEventDateRangeSyncState(
 
   collectingEventDateRangeSyncState.set(collectingEvent, {
     ...state,
-    endDate:
-      startDate !== null && startDate === endDate ? endDate : undefined,
+    endDate: startDate !== null && startDate === endDate ? endDate : undefined,
   });
 }
 
@@ -325,9 +324,10 @@ export const businessRuleDefs: MappedBusinessRuleDefs = {
         return undefined;
       },
       catalogNumber: async (resource): Promise<undefined> => {
-        const preferences = await import(
-          '../Preferences/collectionPreferences'
-        ).then(({ collectionPreferences }) => collectionPreferences);
+        const preferences =
+          await import('../Preferences/collectionPreferences').then(
+            ({ collectionPreferences }) => collectionPreferences
+          );
 
         const uniqueCatalogNumberAccrossComponentAndCOPref = preferences.get(
           'uniqueCatalogNumberAccrossComponentAndCO',
@@ -564,9 +564,10 @@ export const businessRuleDefs: MappedBusinessRuleDefs = {
         return undefined;
       },
       catalogNumber: async (resource): Promise<undefined> => {
-        const preferences = await import(
-          '../Preferences/collectionPreferences'
-        ).then(({ collectionPreferences }) => collectionPreferences);
+        const preferences =
+          await import('../Preferences/collectionPreferences').then(
+            ({ collectionPreferences }) => collectionPreferences
+          );
 
         const uniqueCatalogNumberAccrossComponentAndCOPref = preferences.get(
           'uniqueCatalogNumberAccrossComponentAndCO',

--- a/specifyweb/frontend/js_src/lib/components/DataModel/businessRuleDefs.ts
+++ b/specifyweb/frontend/js_src/lib/components/DataModel/businessRuleDefs.ts
@@ -40,6 +40,7 @@ import type { Collection } from './specifyTable';
 import { tables } from './tables';
 import type {
   BorrowMaterial,
+  CollectingEvent,
   CollectionObject,
   CollectionObjectGroup,
   CollectionObjectGroupJoin,
@@ -82,6 +83,129 @@ export type BusinessRuleDefs<SCHEMA extends AnySchema> = {
 type MappedBusinessRuleDefs = {
   readonly [TABLE in keyof Tables]?: BusinessRuleDefs<Tables[TABLE]>;
 };
+
+type CollectingEventDateRangeSyncState = {
+  readonly endDate?: string | null;
+  readonly endDatePrecision?: number | null;
+  readonly isEndDatePrecisionManual?: boolean;
+};
+
+const collectingEventDateRangeSyncState = new WeakMap<
+  SpecifyResource<CollectingEvent>,
+  CollectingEventDateRangeSyncState
+>();
+
+const normalizeDateValue = (value: string | null | undefined): string | null =>
+  typeof value === 'string' && value.length > 0 ? value : null;
+
+const normalizeDatePrecision = (
+  value: number | null | undefined
+): number | null => (typeof value === 'number' ? value : null);
+
+const getCollectingEventDateRangeSyncState = (
+  collectingEvent: SpecifyResource<CollectingEvent>
+): CollectingEventDateRangeSyncState => {
+  const state = collectingEventDateRangeSyncState.get(collectingEvent);
+  if (state !== undefined) return state;
+
+  const newState = {};
+  collectingEventDateRangeSyncState.set(collectingEvent, newState);
+  return newState;
+};
+
+function initializeCollectingEventDateRangeSync(
+  collectingEvent: SpecifyResource<CollectingEvent>
+): void {
+  updateCollectingEventDateRangeSyncState(collectingEvent);
+  updateCollectingEventDatePrecisionSyncState(collectingEvent);
+}
+
+function updateCollectingEventDateRangeSyncState(
+  collectingEvent: SpecifyResource<CollectingEvent>
+): void {
+  const state = getCollectingEventDateRangeSyncState(collectingEvent);
+  const startDate = normalizeDateValue(collectingEvent.get('startDate'));
+  const endDate = normalizeDateValue(collectingEvent.get('endDate'));
+
+  collectingEventDateRangeSyncState.set(collectingEvent, {
+    ...state,
+    endDate:
+      startDate !== null && startDate === endDate ? endDate : undefined,
+  });
+}
+
+function updateCollectingEventDatePrecisionSyncState(
+  collectingEvent: SpecifyResource<CollectingEvent>
+): void {
+  const state = getCollectingEventDateRangeSyncState(collectingEvent);
+  const startDatePrecision = normalizeDatePrecision(
+    collectingEvent.get('startDatePrecision')
+  );
+  const endDatePrecision = normalizeDatePrecision(
+    collectingEvent.get('endDatePrecision')
+  );
+  const isSynced =
+    startDatePrecision !== null && startDatePrecision === endDatePrecision;
+
+  collectingEventDateRangeSyncState.set(collectingEvent, {
+    ...state,
+    endDatePrecision: isSynced ? endDatePrecision : undefined,
+    isEndDatePrecisionManual:
+      startDatePrecision !== null && endDatePrecision !== null && !isSynced,
+  });
+}
+
+function syncCollectingEventEndDate(
+  collectingEvent: SpecifyResource<CollectingEvent>
+): void {
+  const state = getCollectingEventDateRangeSyncState(collectingEvent);
+  const startDate = normalizeDateValue(collectingEvent.get('startDate'));
+  const endDate = normalizeDateValue(collectingEvent.get('endDate'));
+
+  if (endDate === null || endDate === state.endDate) {
+    collectingEventDateRangeSyncState.set(collectingEvent, {
+      ...state,
+      endDate: startDate,
+    });
+    collectingEvent.set('endDate', startDate);
+    syncCollectingEventEndDatePrecision(collectingEvent, true);
+  } else if (startDate !== null && startDate === endDate)
+    updateCollectingEventDateRangeSyncState(collectingEvent);
+}
+
+function syncCollectingEventEndDatePrecision(
+  collectingEvent: SpecifyResource<CollectingEvent>,
+  force = false
+): void {
+  const state = getCollectingEventDateRangeSyncState(collectingEvent);
+  const startDate = normalizeDateValue(collectingEvent.get('startDate'));
+  const endDate = normalizeDateValue(collectingEvent.get('endDate'));
+  const startDatePrecision = normalizeDatePrecision(
+    collectingEvent.get('startDatePrecision')
+  );
+  const endDatePrecision = normalizeDatePrecision(
+    collectingEvent.get('endDatePrecision')
+  );
+
+  if (startDate === null || startDate !== endDate) return;
+  if (state.isEndDatePrecisionManual === true) return;
+  if (
+    force ||
+    endDatePrecision === null ||
+    endDatePrecision === state.endDatePrecision ||
+    state.endDatePrecision === undefined
+  ) {
+    collectingEventDateRangeSyncState.set(collectingEvent, {
+      ...state,
+      endDatePrecision: startDatePrecision,
+    });
+    collectingEvent.set('endDatePrecision', startDatePrecision);
+  } else if (
+    startDatePrecision !== null &&
+    startDatePrecision === endDatePrecision
+  )
+    updateCollectingEventDatePrecisionSyncState(collectingEvent);
+}
 
 export const businessRuleDefs: MappedBusinessRuleDefs = {
   Address: {
@@ -376,6 +500,17 @@ export const businessRuleDefs: MappedBusinessRuleDefs = {
       }
     },
     onAdded: onAddedEnsureBoolInCollection('isPrimary'),
+  },
+
+  CollectingEvent: {
+    customInit: initializeCollectingEventDateRangeSync,
+    fieldChecks: {
+      startDate: syncCollectingEventEndDate,
+      startDatePrecision: (collectingEvent): void =>
+        syncCollectingEventEndDatePrecision(collectingEvent),
+      endDate: updateCollectingEventDateRangeSyncState,
+      endDatePrecision: updateCollectingEventDatePrecisionSyncState,
+    },
   },
 
   Component: {


### PR DESCRIPTION
Fixes #8044

Add a Collecting Event business rule that copies `startDate` into `endDate` when the end date is empty or was previously auto-copied.  This keeps user-entered `endDate` values intact when the start date changes later, and applies the same sync behavior to `startDatePrecision` and `endDatePrecision`.

### Checklist

- [ ] Self-review the PR after opening it to make sure the changes look good and
      self-explanatory (or properly documented)
- [x] Add relevant issue to release milestone
- [ ] Add pr to documentation list
- [x] Add automated tests

### Testing instructions

- Open or create a Collecting Event form that shows both Start Date and End Date.
- [ ] Enter a Start Date while End Date is empty, then confirm End Date fills with the same value.
- [ ] Change the Start Date again, then confirm End Date updates with it.
- [ ] Manually change End Date to a different value, then change Start Date again and confirm End Date is not overwritten.
- [ ] Test month/year or year precision, if available, and confirm End Date precision follows Start Date until manually changed.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added unit tests covering Collecting Event date-range syncing, auto-copying of end date/precision from start date, and preservation of user-set end dates and precisions.

* **Bug Fixes**
  * Improved Collecting Event behavior so end date and its precision follow the start date when appropriate, while respecting manual overrides and initializing sync on setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->