### PR TITLE
Fix aggregated relation parsing for stored queries

### DIFF
--- a/specifyweb/backend/stored_queries/queryfieldspec.py
+++ b/specifyweb/backend/stored_queries/queryfieldspec.py
@@ -253,10 +253,21 @@ class QueryFieldSpec(
             node = table
 
         extracted_fieldname, date_part = extract_date_part(field_name)
-        field = node.get_field(extracted_fieldname, strict=False)
+        relation_already_in_path = (
+            is_relation
+            and len(join_path) > 0
+            and isinstance(join_path[-1], Relationship)
+            and join_path[-1].type not in {"many-to-one", "one-to-one"}
+            and join_path[-1].name.lower() == extracted_fieldname.lower()
+        )
+        field = (
+            None
+            if relation_already_in_path
+            else node.get_field(extracted_fieldname, strict=False)
+        )
 
         tree_rank_name = None
-        if field is None:  # try finding tree
+        if field is None and not relation_already_in_path:  # try finding tree
             tree_rank_name, field = find_tree_and_field(node, extracted_fieldname)
             if tree_rank_name:
                 tree_rank = TreeRankQuery.create(


### PR DESCRIPTION
Fixes #8040

Fixes saved stored queries where (aggregated) to-many relationship fields, like Collecting Event > Collectors (aggregated), were parsed incorrectly after reload. The parser was treating the repeated relationship name in the saved string id as a tree rank, which caused query execution to join through the related table directly and return duplicate rows instead of one aggregated value.  Solved by preserving already parsed to-many relation fields when reading saved stored query string ids.


### Checklist

- [x] Self-review the PR after opening it to make sure the changes look good and
      self-explanatory (or properly documented)
- [x] Add relevant issue to release milestone
- [ ] Add pr to documentation list

### Testing instructions

https://github.com/specify/specify7/issues/8040#issue-4343416855

- Open Query Builder for Collection Object.
- Add a display field for Collecting Event > Collectors (aggregated).
- Use test data where one collection object’s collecting event has multiple collectors.
- Run the query and verify the collection object appears once, with all collectors shown in the aggregated collectors cell.
- Save the query, reopen it, and run it again.
- [ ] Verify the reopened query still returns one row per collection object and does not split collectors into duplicate rows.
