### PR TITLE
Integrate sync_schema_config_fields fixes into main

### DIFF
--- a/specifyweb/specify/migration_utils/update_schema_config.py
+++ b/specifyweb/specify/migration_utils/update_schema_config.py
@@ -399,9 +399,7 @@ def update_table_schema_config_with_defaults(
 
         pending_itemstr_rows.extend(item_str_rows)
 
-        for field in table.all_fields:
-            if field is table.idField:
-                continue
+        for field in table._all_fields(exclude_id_field=True):
             field_defaults = None
             if table_defaults.get('items'):
                 field_defaults = table_defaults['items'].get(field.name.lower())
@@ -664,17 +662,16 @@ def find_missing_schema_config_fields(discipline_id: int, apps=global_apps):
         if table_name_lower not in container_names:
             missing_tables.append(table_name)
             missing_fields[table_name] = sorted(
-                field.name for field in table.all_fields
-                if field.name and field is not table.idField
+                field.name for field in table._all_fields(exclude_id_field=True)
+                if field.name
             )
             continue
 
         existing_fields = existing_fields_by_table.get(table_name_lower, set())
         missing_in_table = sorted( # sort for better reproducablity
             field.name
-            for field in table.all_fields
+            for field in table._all_fields(exclude_id_field=True)
             if field.name
-            and field is not table.idField
             and field.name.lower() not in existing_fields
         )
 

--- a/specifyweb/specify/models_utils/load_datamodel.py
+++ b/specifyweb/specify/models_utils/load_datamodel.py
@@ -149,19 +149,32 @@ class Table:
             raise ValueError("classname is required to compute the name")
         return self.classname.split(".")[-1]
 
+    def _all_fields(
+        self,
+        exclude_fields: bool = False,
+        exclude_relationships: bool = False,
+        exclude_id_field: bool = False,
+        exclude_virtual_fields: bool = True,
+    ) -> Iterable[Union["Field", "Relationship"]]:
+        if not exclude_fields:
+            yield from self.fields or []
+        if not exclude_relationships:
+            yield from self.relationships or []
+        if not exclude_virtual_fields:
+            yield from self.virtual_fields or []
+        if not exclude_id_field and self.idField is not None:
+            yield self.idField
+
     @property
     def django_name(self) -> str:
         return self.name.capitalize()
 
     @property
     def all_fields(self) -> list[Union["Field", "Relationship"]]:
-        def af() -> Iterable[Union["Field","Relationship"]]:
-            yield from self.fields or []  # Handle None by using an empty list
-            yield from self.relationships or []  # Handle None by using an empty list
-            if self.idField is not None:
-                yield self.idField
-
-        return list(af())
+        """
+        A list of all non-virtual fields (including the ID field) and relationships for the table.
+        """
+        return list(self._all_fields())
 
 
     def is_virtual_field(self, fieldname: str) -> bool:


### PR DESCRIPTION
Fixes #8065

Integrate sync_schema_config_fields fixes into main.

This ports the release branch schema config fix into `main` while preserving the newer main-branch schema config locking and de-duplication logic.

### Checklist

- [ ] Self-review the PR after opening it to make sure the changes look good and
      self-explanatory (or properly documented)
- [ ] Add relevant issue to release milestone
- [ ] Add pr to documentation list

### Testing instructions


- Run `ve/bin/python manage.py sync_schema_config_fields --discipline-id <discipline_id>`.
- [ ] Confirm the “Missing fields” output does not include internal ID fields like `accessionId`, `localityId`, `collectionObjectId`, or other `{table}Id` fields.
- [ ] Confirm legitimate missing non-ID fields still appear in the output.
- Run `ve/bin/python manage.py sync_schema_config_fields --discipline-id <discipline_id> --apply`.
- [ ] Confirm created schema config records are limited to expected non-ID fields.
- [ ] Re-run the command and confirm previously created fields are no longer reported as missing.




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal schema configuration field handling to use a centralized helper for field iteration.
  * Enhanced data model field collection logic for better consistency in field filtering across migration utilities.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/specify/specify7/pull/8067?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->