### PR TITLE
Fix Add button on QCBXs not working

### DIFF
--- a/specifyweb/backend/stored_queries/tests/test_batch_edit.py
+++ b/specifyweb/backend/stored_queries/tests/test_batch_edit.py
@@ -583,7 +583,7 @@ class QueryConstructionTests(SQLAlchemySetup):
                 "Determination integer1 #3",
                 "Determination remarks #3",
                 "Preparation countAmt",
-                "Preparation text1",
+                "Preparation text1"
             ],
         )
 

--- a/specifyweb/backend/stored_queries/tests/test_batch_edit.py
+++ b/specifyweb/backend/stored_queries/tests/test_batch_edit.py
@@ -583,7 +583,7 @@ class QueryConstructionTests(SQLAlchemySetup):
                 "Determination integer1 #3",
                 "Determination remarks #3",
                 "Preparation countAmt",
-                "Preparation text1"
+                "Preparation text1",
             ],
         )
 

--- a/specifyweb/frontend/js_src/lib/components/Molecules/AutoComplete.tsx
+++ b/specifyweb/frontend/js_src/lib/components/Molecules/AutoComplete.tsx
@@ -540,7 +540,8 @@ export function AutoComplete<T>({
               {({ active, selected }): JSX.Element => (
                 <li
                   className={optionClassName(active, selected)}
-                  onMouseDown={(): void => {
+                  onMouseDown={(e: React.MouseEvent): void => {
+                    e.stopPropagation();
                     shouldBlurAfterMouseSelection.current = true;
                   }}
                 >

--- a/specifyweb/frontend/js_src/lib/components/Molecules/AutoComplete.tsx
+++ b/specifyweb/frontend/js_src/lib/components/Molecules/AutoComplete.tsx
@@ -375,6 +375,15 @@ export function AutoComplete<T>({
     );
   }, [currentValue]);
 
+  const handleOptionMouseDown = React.useCallback(
+    (e: React.MouseEvent): void => {
+      e.preventDefault();
+      e.stopPropagation();
+      shouldBlurAfterMouseSelection.current = true;
+    },
+    []
+  );
+
   return (
     <Combobox
       as="div"
@@ -437,10 +446,6 @@ export function AutoComplete<T>({
             overflow-y-auto rounded rounded bg-white shadow-lg
             shadow-gray-400 dark:border dark:border-gray-500 dark:bg-neutral-900
           `}
-          onMouseDown={(e: React.MouseEvent) => {
-            //e.preventDefault();
-            e.stopPropagation();
-          }}
           ref={dataListRefCallback}
         >
           {isLoading && (
@@ -515,9 +520,7 @@ export function AutoComplete<T>({
                 {({ active, selected }): JSX.Element => (
                   <li
                     className={optionClassName(active, selected)}
-                    onMouseDown={(): void => {
-                      shouldBlurAfterMouseSelection.current = true;
-                    }}
+                    onMouseDown={handleOptionMouseDown}
                   >
                     {typeof item.icon === 'string' ? (
                       <div className="flex items-center">

--- a/specifyweb/frontend/js_src/lib/components/Molecules/AutoComplete.tsx
+++ b/specifyweb/frontend/js_src/lib/components/Molecules/AutoComplete.tsx
@@ -438,7 +438,7 @@ export function AutoComplete<T>({
             shadow-gray-400 dark:border dark:border-gray-500 dark:bg-neutral-900
           `}
           onMouseDown={(e: React.MouseEvent) => {
-            e.preventDefault();
+            //e.preventDefault();
             e.stopPropagation();
           }}
           ref={dataListRefCallback}


### PR DESCRIPTION
Fixes #8070

The add button in the QCBX results should work now.

<img width="184" height="72" alt="image" src="https://github.com/user-attachments/assets/abe9a73b-11ee-448b-ab51-b6f480ef5876" />

### Checklist

- [ ] Self-review the PR after opening it to make sure the changes look good and
      self-explanatory (or properly documented)
- [ ] Add relevant issue to release milestone
- [ ] Add pr to documentation list
- [ ] Add automated tests

### Testing instructions
- Go to data entry onto any form with QCBXs
- [ ] Ensure you can successfully click on any results that show up
- [ ] Ensure you can click the 'Add' button in the autocomplete results (Not the plus button to the right of the QCBX, and also don't press Enter).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Standardized mouse event handling for autocomplete options so selection consistently blurs the input; aligned the "Add" option to stop event propagation on mouse-down.

* **Tests**
  * Minor test update adjusting expected formatting in a batch-edit visual-headers assertion (no behavior change).

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/specify/specify7/pull/8071)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->