### PR TITLE
Fix tree definition relationship queries through tree nodes

### DIFF
--- a/specifyweb/backend/stored_queries/queryfieldspec.py
+++ b/specifyweb/backend/stored_queries/queryfieldspec.py
@@ -45,6 +45,15 @@ PRECALCULATED_FIELDS = {
     "CollectionObject": "age",
 }
 
+TREE_TABLE_NAMES = {
+    "geography",
+    "geologictimeperiod",
+    "lithostrat",
+    "storage",
+    "taxon",
+    "tectonicunit",
+}
+
 class SpQueryAttrs(TypedDict):
     tablelist: str
     stringid: str
@@ -257,7 +266,7 @@ class QueryFieldSpec(
             if (
                 is_relation
                 and idx == len(path_elems) - 1
-                and fieldname is not None
+                and (fieldname is not None or table.name.lower() in TREE_TABLE_NAMES)
                 and isinstance(field, Relationship)
                 and field.name.lower() == extracted_fieldname.lower()
             ):

--- a/specifyweb/backend/stored_queries/queryfieldspec.py
+++ b/specifyweb/backend/stored_queries/queryfieldspec.py
@@ -243,7 +243,9 @@ class QueryFieldSpec(
 
         join_path = []
         node = root_table
-        for elem in path:
+        extracted_fieldname, date_part = extract_date_part(field_name)
+        path_elems = list(path)
+        for idx, elem in enumerate(path_elems):
             try:
                 tableid, fieldname = elem.split("-")
             except ValueError:
@@ -252,10 +254,17 @@ class QueryFieldSpec(
             field = (
                 node.get_field(fieldname) if fieldname else node.get_field(table.name)
             )
+            if (
+                is_relation
+                and idx == len(path_elems) - 1
+                and fieldname is not None
+                and isinstance(field, Relationship)
+                and field.name.lower() == extracted_fieldname.lower()
+            ):
+                break
             join_path.append(field)
             node = table
 
-        extracted_fieldname, date_part = extract_date_part(field_name)
         field = node.get_field(extracted_fieldname, strict=False)
 
         tree_rank_name = None

--- a/specifyweb/backend/stored_queries/queryfieldspec.py
+++ b/specifyweb/backend/stored_queries/queryfieldspec.py
@@ -10,14 +10,14 @@ from specifyweb.specify.utils.uiformatters import get_uiformatter
 from sqlalchemy import sql, Table as SQLTable
 from sqlalchemy.orm.query import Query
 
-from specifyweb.specify.models_utils.load_datamodel import Field, Table
-from specifyweb.specify.models import Collectionobject, Collectionobjectgroupjoin, Component, datamodel
+from specifyweb.specify.datamodel import datamodel, is_tree_table
+from specifyweb.specify.models_utils.load_datamodel import Field, Relationship, Table
+from specifyweb.specify.models import Collectionobject, Collectionobjectgroupjoin, Component
 from specifyweb.backend.stored_queries.models import CollectionObject as sq_CollectionObject
 from specifyweb.backend.stored_queries.models import Component as sq_Component
 
 from . import models
 from .query_ops import QueryOps
-from specifyweb.specify.models_utils.load_datamodel import Table, Field, Relationship
 
 logger = logging.getLogger(__name__)
 
@@ -46,12 +46,7 @@ PRECALCULATED_FIELDS = {
 }
 
 TREE_TABLE_NAMES = {
-    "geography",
-    "geologictimeperiod",
-    "lithostrat",
-    "storage",
-    "taxon",
-    "tectonicunit",
+    table.name.lower() for table in datamodel.tables if is_tree_table(table)
 }
 
 class SpQueryAttrs(TypedDict):


### PR DESCRIPTION
Fixes #8079
Fixes #8080

The crash was caused by `QueryFieldSpec.from_stringid()` treating a formatted nested relationship like `definitionItem -> formatted` as a tree rank lookup. That produced the bogus tree name `TaxonTreeDefItem`, which led to attribute error.

Added a fix so formatted relationships that are already represented as the final tablelist relationship are appended once as relationships, not reinterpreted as tree ranks.

For the other related crash is "AssertionError: Didn't find the tree rank across any tree from stringId 1,9-determinations,4.taxon.taxon". The back-end was parsing `any rank -> formatted` as a fake tree rank named taxon.

Made a quick fix to this issue by extending the previous parser fix, so formatted relationships to actual tree tables are handled as formatting the tree node relationship, not as a rank lookup.

### Checklist

- [ ] Self-review the PR after opening it to make sure the changes look good and
      self-explanatory (or properly documented)
- [ ] Add relevant issue to release milestone
- [ ] Add pr to documentation list
- [ ] Add automated tests

### Testing instructions

#8079
- Go to Queries.
- Create a new query with `CollectionObject` as the base table.
- Add a field path like `determinations -> taxon -> any rank -> taxonomic rank -> formatted`.
- Run the query.
- [ ] Confirm the query returns results instead of showing a server error.
- [ ] Repeat with another tree definition or tree definition item formatted field if available.

#8080
- Go to Queries.
- Create a new query with `CollectionObject` as the base table.
- Add a field path like `determinations -> taxon -> any rank -> formatted`.
- Run the query.
- [ ] Confirm the query returns results instead of showing a server error.
- Repeat with another tree path if available, such as `collecting event -> locality -> geography -> any rank -> formatted`.
- [ ] Confirm each formatted tree query runs without an error.

Etc.
- [ ] Bop it
- [ ] Twist it
- [ ] Pull it
- [ ] Spin it

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of tree-structured tables so tree-related identifiers are recognized consistently during query field processing.
  * Fixed traversal logic to correctly parse field/date parts and stop consuming join path elements early when appropriate, preventing incorrect field lookups and rank handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/specify/specify7/pull/8082)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->