### PR TITLE
Fix: Review Allow new discipline deletion when it has no users and no…

### DIFF
--- a/specifyweb/backend/delete_blockers/views.py
+++ b/specifyweb/backend/delete_blockers/views.py
@@ -21,7 +21,8 @@ def delete_blockers(request, model, id):
     obj = get_object_or_404(model, id=int(id))
     using = router.db_for_write(obj.__class__, instance=obj)
 
-    if obj._meta.model_name == 'discipline': # Special case for discipline
+    # Special case for discipline
+    if obj._meta.model_name == 'discipline': 
         guard_blockers = get_discipline_delete_guard_blockers(obj)
         if guard_blockers:
             result = guard_blockers
@@ -32,11 +33,11 @@ def delete_blockers(request, model, id):
                 result = _collect_delete_blockers(obj, using)
                 transaction.set_rollback(True, using=using)
     else:
-        # Standard delete blockers behavior
-        result = _collect_delete_blockers(obj, using)
+        result = _collect_delete_blockers(obj, using) # Standard delete blockers behavior
 
     return http.HttpResponse(toJson(result), content_type='application/json')
 
+# New definition
 def _collect_delete_blockers(obj, using) -> list[dict]:
     collector = Collector(using=using)
     collector.delete_blockers = []

--- a/specifyweb/backend/trees/utils.py
+++ b/specifyweb/backend/trees/utils.py
@@ -28,6 +28,7 @@ TREE_NAMES = {
     'tectonicunit': 'Tectonic Unit'
 }
 
+# Tree model names
 DISCIPLINE_TREE_MODELS = (
     spmodels.Geographytreedef,
     spmodels.Geologictimeperiodtreedef,

--- a/specifyweb/specify/api/crud.py
+++ b/specifyweb/specify/api/crud.py
@@ -197,6 +197,7 @@ def make_default_deleter(collection=None, agent=None):
             auditlog.remove(obj, agent, parent_obj)
     return _deleter
 
+# New discipline logic
 def is_discipline(obj) -> bool:
     return getattr(getattr(obj, "_meta", None), "model_name", "") == "discipline"
 
@@ -338,6 +339,7 @@ def prepare_discipline_for_delete(obj) -> None:
         tree_def_model.objects.filter(discipline_id=obj.id).update(discipline_id=None)
 
     delete_discipline_owned_setup_data(obj)
+# End of discipline logic 
 
 @transaction.atomic
 def put_resource(collection, agent, name: str, id, version, data: dict[str, Any]):
@@ -458,6 +460,8 @@ def delete_resource(collection, agent, name, id, version) -> None:
     locking 'version'.
     """
     obj = get_object_or_404(name, id=int(id))
+
+    # check for discipline logic delition
     if is_discipline(obj):
         guard_blockers = get_discipline_delete_guard_blockers(obj)
         if guard_blockers:

--- a/specifyweb/specify/api/dispatch.py
+++ b/specifyweb/specify/api/dispatch.py
@@ -60,6 +60,7 @@ def resource_dispatch(request, model, id) -> HttpResponse:
                             content_type='application/json')
 
     elif request.method == 'DELETE':
+        #check for discipline logic deletion
         if model.lower() == 'discipline' and not request.specify_user.is_admin():
             return HttpResponseForbidden('Specifyuser must be an institution admin')
 

--- a/specifyweb/specify/tests/test_delete_blockers.py
+++ b/specifyweb/specify/tests/test_delete_blockers.py
@@ -68,6 +68,7 @@ class TestDeleteBlockers(GeographyTree):
         for node in self._node_list:
             self._assertSame(self._get_blockers(node), [])
 
+    # test discipline new deletion logic 
     def _create_discipline_with_owned_trees(self, name='Disposable Discipline'):
         placeholder_geo = models.Geographytreedef.objects.create(name=f'{name} placeholder geo')
         placeholder_geo_time = models.Geologictimeperiodtreedef.objects.create(


### PR DESCRIPTION
… collections

Fixes #7649 

<!--
> [!WARNING]  
> This PR affects database migrations. See [migration testing instructions](https://specify.github.io/testing/pull_requests.html#prs-tagged-with-label-migration).
-->

### Checklist

- [ ] Self-review the PR after opening it to make sure the changes look good and
      self-explanatory (or properly documented)
- [ ] Add relevant issue to release milestone
- [ ] Add pr to documentation list
- [ ] Add automated tests
- [ ] Add a reverse migration if a migration is present in the PR
- [ ] Add migration function to https://github.com/specify/specify7/blob/ea04665987e1b8a1b76955c7b7f702b7bf701b47/specifyweb/specify/management/commands/run_key_migration_functions.py#L50


### Testing instructions

<!-- What are the steps to verify the fixes/changes in this PR? -->
<!-- Can part of that be replaced by automated tests? -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced discipline deletion logic to include validation checks that prevent deletion when business constraints are violated, and improved cleanup procedures to properly remove associated setup data and configurations before the discipline record is deleted.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/specify/specify7/pull/8089?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->