### PR TITLE
Merge pull request #7812 from specify/issue-7649

### DIFF
--- a/specifyweb/backend/delete_blockers/views.py
+++ b/specifyweb/backend/delete_blockers/views.py
@@ -1,9 +1,13 @@
 from django import http
-from django.db import router
+from django.db import router, transaction
 from django.db.models.deletion import Collector
 
 from specifyweb.middleware.general import require_http_methods
-from specifyweb.specify.api.crud import get_object_or_404
+from specifyweb.specify.api.crud import (
+    get_discipline_delete_guard_blockers,
+    get_object_or_404,
+    prepare_discipline_for_delete,
+)
 from specifyweb.specify.api.serializers import toJson
 from specifyweb.specify.views import login_maybe_required
 
@@ -16,10 +20,30 @@ def delete_blockers(request, model, id):
     """
     obj = get_object_or_404(model, id=int(id))
     using = router.db_for_write(obj.__class__, instance=obj)
+
+    if obj._meta.model_name == 'discipline': # Special case for discipline
+        if not request.specify_user.is_admin():
+            return http.HttpResponseForbidden('Specifyuser must be an institution admin')
+        guard_blockers = get_discipline_delete_guard_blockers(obj)
+        if guard_blockers:
+            result = guard_blockers
+        else:
+            # Try pre-delete discipline tree detaching
+            with transaction.atomic(using=using):
+                prepare_discipline_for_delete(obj)
+                result = _collect_delete_blockers(obj, using)
+                transaction.set_rollback(True, using=using)
+    else:
+        # Standard delete blockers behavior
+        result = _collect_delete_blockers(obj, using)
+
+    return http.HttpResponse(toJson(result), content_type='application/json')
+
+def _collect_delete_blockers(obj, using) -> list[dict]:
     collector = Collector(using=using)
     collector.delete_blockers = []
     collector.collect([obj])
-    result = flatten([
+    return flatten([
         [
             {
                 'table': sub_objs[0].__class__.__name__,
@@ -28,7 +52,6 @@ def delete_blockers(request, model, id):
             }
         ] for field, sub_objs in collector.delete_blockers
     ])
-    return http.HttpResponse(toJson(result), content_type='application/json')
 
 def flatten(l):
     return [item for sublist in l for item in sublist]

--- a/specifyweb/backend/trees/utils.py
+++ b/specifyweb/backend/trees/utils.py
@@ -28,6 +28,14 @@ TREE_NAMES = {
     'tectonicunit': 'Tectonic Unit'
 }
 
+DISCIPLINE_TREE_MODELS = (
+    spmodels.Geographytreedef,
+    spmodels.Geologictimeperiodtreedef,
+    spmodels.Lithostrattreedef,
+    spmodels.Taxontreedef,
+    spmodels.Tectonicunittreedef,
+)
+
 def get_search_filters(collection: spmodels.Collection, tree: str):
     tree_name = tree.lower()
     if tree_name == 'storage':

--- a/specifyweb/specify/api/crud.py
+++ b/specifyweb/specify/api/crud.py
@@ -6,11 +6,13 @@ from typing import Any, Dict
 from collections.abc import Callable
 from django.db import transaction
 from django.core.exceptions import FieldError, FieldDoesNotExist
-from django.db.models import Model, F
+from django.db.models import Model, F, Q, Subquery
 from django.http import (HttpResponseServerError, Http404)
 from django.apps import apps
 
 from specifyweb.backend.permissions.permissions import check_field_permissions, check_table_permissions
+from specifyweb.backend.businessrules.exceptions import BusinessRuleException
+from specifyweb.backend.trees.utils import DISCIPLINE_TREE_MODELS
 from specifyweb.backend.workbench.upload.auditlog import auditlog
 from specifyweb.specify import models
 from specifyweb.specify.api.api_utils import objs_to_data_, CollectionPayload
@@ -188,6 +190,147 @@ def make_default_deleter(collection=None, agent=None):
             auditlog.remove(obj, agent, parent_obj)
     return _deleter
 
+def is_discipline(obj) -> bool:
+    return getattr(getattr(obj, "_meta", None), "model_name", "") == "discipline"
+
+def get_discipline_delete_guard_blockers(discipline) -> list[dict[str, Any]]:
+    """
+    Returns discipline blockers for deleting disciplines in the configuration tool.
+    A discipline can be deleted only when it has no associated collections and no associated users.
+    """
+    if not is_discipline(discipline):
+        return []
+
+    collection_ids = sorted(discipline.collections.values_list("id", flat=True))
+
+    blockers: list[dict[str, Any]] = []
+    if collection_ids:
+        blockers.append(
+            {
+                "table": "Collection",
+                "field": "discipline",
+                "ids": collection_ids,
+            }
+        )
+        return blockers
+
+    discipline_scoped_user_blockers = (
+        (
+            "Spappresourcedir",
+            "specifyuser",
+            sorted(
+                models.Spappresourcedir.objects.filter(
+                    discipline=discipline,
+                    specifyuser__isnull=False,
+                ).values_list("id", flat=True)
+            ),
+        ),
+        (
+            "Sptasksemaphore",
+            "owner",
+            sorted(
+                models.Sptasksemaphore.objects.filter(
+                    discipline=discipline,
+                    owner__isnull=False,
+                ).values_list("id", flat=True)
+            ),
+        ),
+    )
+    for table_name, field_name, blocker_ids in discipline_scoped_user_blockers:
+        if blocker_ids:
+            blockers.append(
+                {
+                    "table": table_name,
+                    "field": field_name,
+                    "ids": blocker_ids,
+                }
+            )
+    return blockers
+
+def _raw_delete_queryset(queryset) -> None:
+    queryset._raw_delete(queryset.db)
+
+def delete_discipline_owned_setup_data(obj) -> None:
+    """
+    Remove discipline-scoped setup/config rows in bulk before the final
+    discipline delete so Django doesn't need to build one large collector graph.
+    """
+    if not is_discipline(obj):
+        return
+
+    from specifyweb.backend.businessrules.models import (
+        UniquenessRule,
+        UniquenessRuleField,
+    )
+
+    schema_ids = models.Spexportschema.objects.filter(
+        discipline_id=obj.id
+    ).values("id")
+    export_item_ids = models.Spexportschemaitem.objects.filter(
+        spexportschema_id__in=Subquery(schema_ids)
+    ).values("id")
+    _raw_delete_queryset(
+        models.Spexportschemaitemmapping.objects.filter(
+            exportschemaitem_id__in=Subquery(export_item_ids)
+        )
+    )
+    _raw_delete_queryset(
+        models.Spexportschema_exportmapping.objects.filter(
+            spexportschema_id__in=Subquery(schema_ids)
+        )
+    )
+    _raw_delete_queryset(
+        models.Spexportschemaitem.objects.filter(
+            spexportschema_id__in=Subquery(schema_ids)
+        )
+    )
+    _raw_delete_queryset(models.Spexportschema.objects.filter(discipline_id=obj.id))
+
+    container_ids = models.Splocalecontainer.objects.filter(
+        discipline_id=obj.id
+    ).values("id")
+    item_ids = models.Splocalecontaineritem.objects.filter(
+        container_id__in=Subquery(container_ids)
+    ).values("id")
+    _raw_delete_queryset(
+        models.Splocaleitemstr.objects.filter(
+            Q(containerdesc_id__in=Subquery(container_ids))
+            | Q(containername_id__in=Subquery(container_ids))
+            | Q(itemdesc_id__in=Subquery(item_ids))
+            | Q(itemname_id__in=Subquery(item_ids))
+        )
+    )
+    _raw_delete_queryset(
+        models.Splocalecontaineritem.objects.filter(
+            container_id__in=Subquery(container_ids)
+        )
+    )
+    _raw_delete_queryset(models.Splocalecontainer.objects.filter(discipline_id=obj.id))
+
+    rule_ids = UniquenessRule.objects.filter(discipline_id=obj.id).values("id")
+    _raw_delete_queryset(
+        UniquenessRuleField.objects.filter(
+            uniquenessrule_id__in=Subquery(rule_ids)
+        )
+    )
+    _raw_delete_queryset(UniquenessRule.objects.filter(discipline_id=obj.id))
+
+    _raw_delete_queryset(models.Spappresourcedir.objects.filter(discipline_id=obj.id))
+    _raw_delete_queryset(models.Sptasksemaphore.objects.filter(discipline_id=obj.id))
+    _raw_delete_queryset(models.Autonumschdsp.objects.filter(discipline_id=obj.id))
+
+def prepare_discipline_for_delete(obj) -> None:
+    """
+    Detach discipline owned tree defs and bulk delete discipline-scoped setup
+    data before deletion so empty disciplines delete quickly.
+    """
+    if not is_discipline(obj):
+        return
+
+    for tree_def_model in DISCIPLINE_TREE_MODELS:
+        tree_def_model.objects.filter(discipline_id=obj.id).update(discipline_id=None)
+
+    delete_discipline_owned_setup_data(obj)
 
 @transaction.atomic
 def put_resource(collection, agent, name: str, id, version, data: dict[str, Any]):
@@ -308,8 +451,22 @@ def delete_resource(collection, agent, name, id, version) -> None:
     locking 'version'.
     """
     obj = get_object_or_404(name, id=int(id))
-    return delete_obj(obj, (make_default_deleter(collection, agent)), version)
+    if is_discipline(obj):
+        guard_blockers = get_discipline_delete_guard_blockers(obj)
+        if guard_blockers:
+            raise BusinessRuleException(
+                "Discipline cannot be deleted while it has associated users or collections."
+            )
+        clean_predelete = prepare_discipline_for_delete
+    else:
+        clean_predelete = None
 
+    return delete_obj(
+        obj,
+        make_default_deleter(collection, agent),
+        version,
+        clean_predelete=clean_predelete,
+    )
 
 def get_collection(logged_in_collection, model, checker: ReadPermChecker, control_params=GetCollectionForm.defaults, params={}) -> CollectionPayload:
     from specifyweb.specify.api.serializers import _obj_to_data

--- a/specifyweb/specify/api/dispatch.py
+++ b/specifyweb/specify/api/dispatch.py
@@ -1,5 +1,11 @@
 import json
-from django.http import (HttpResponse, HttpResponseBadRequest, HttpResponseNotAllowed, QueryDict)
+from django.http import (
+    HttpResponse,
+    HttpResponseBadRequest,
+    HttpResponseForbidden,
+    HttpResponseNotAllowed,
+    QueryDict,
+)
 
 from django.core.exceptions import FieldError
 
@@ -54,6 +60,9 @@ def resource_dispatch(request, model, id) -> HttpResponse:
                             content_type='application/json')
 
     elif request.method == 'DELETE':
+        if model.lower() == 'discipline' and not request.specify_user.is_admin():
+            return HttpResponseForbidden('Specifyuser must be an institution admin')
+
         # Block deleting currently logged collection
         if model.lower() == 'collection' and int(id) == request.specify_collection.id:
             raise BusinessRuleException(

--- a/specifyweb/specify/tests/test_delete_blockers.py
+++ b/specifyweb/specify/tests/test_delete_blockers.py
@@ -1,7 +1,11 @@
 from django.test import Client
 import json
 
+from specifyweb.backend.permissions.models import UserPolicy
 from specifyweb.backend.trees.tests.test_trees import GeographyTree
+from specifyweb.backend.businessrules.exceptions import BusinessRuleException
+from specifyweb.specify import models
+from specifyweb.specify.api.crud import delete_resource
 
 def _url(obj):
     return f"/delete_blockers/delete_blockers/{obj._meta.model_name}/{obj.id}/"
@@ -63,3 +67,108 @@ class TestDeleteBlockers(GeographyTree):
         
         for node in self._node_list:
             self._assertSame(self._get_blockers(node), [])
+
+    def _create_discipline_with_owned_trees(self, name='Disposable Discipline'):
+        placeholder_geo = models.Geographytreedef.objects.create(name=f'{name} placeholder geo')
+        placeholder_geo_time = models.Geologictimeperiodtreedef.objects.create(
+            name=f'{name} placeholder geotime'
+        )
+
+        discipline = models.Discipline.objects.create(
+            name=name,
+            type='paleobotany',
+            division=self.division,
+            datatype=self.datatype,
+            geographytreedef=placeholder_geo,
+            geologictimeperiodtreedef=placeholder_geo_time,
+        )
+
+        geography_tree = models.Geographytreedef.objects.create(
+            name=f'{name} geography',
+            discipline=discipline,
+        )
+        geography_rank = models.Geographytreedefitem.objects.create(
+            name='Planet',
+            rankid=0,
+            treedef=geography_tree,
+        )
+        models.Geography.objects.create(
+            name='Earth',
+            rankid=0,
+            definition=geography_tree,
+            definitionitem=geography_rank,
+        )
+
+        geotime_tree = models.Geologictimeperiodtreedef.objects.create(
+            name=f'{name} geotime',
+            discipline=discipline,
+        )
+        geotime_rank = models.Geologictimeperiodtreedefitem.objects.create(
+            name='Root',
+            rankid=0,
+            treedef=geotime_tree,
+        )
+        models.Geologictimeperiod.objects.create(
+            name='Root',
+            rankid=0,
+            definition=geotime_tree,
+            definitionitem=geotime_rank,
+        )
+
+        taxon_tree = models.Taxontreedef.objects.create(
+            name=f'{name} taxon',
+            discipline=discipline,
+        )
+        taxon_rank = models.Taxontreedefitem.objects.create(
+            name='Life',
+            rankid=0,
+            treedef=taxon_tree,
+        )
+        models.Taxon.objects.create(
+            name='Life',
+            rankid=0,
+            definition=taxon_tree,
+            definitionitem=taxon_rank,
+        )
+
+        discipline.geographytreedef = geography_tree
+        discipline.geologictimeperiodtreedef = geotime_tree
+        discipline.taxontreedef = taxon_tree
+        discipline.save()
+        return discipline
+
+    def test_discipline_blocked_when_has_collections(self):
+        blockers = self._get_blockers(self.discipline)
+        self._assertSame(
+            blockers,
+            [dict(table='Collection', field='discipline', ids=[self.collection.id])],
+        )
+
+    def test_discipline_blocked_when_has_users(self):
+        discipline = self._create_discipline_with_owned_trees('User Blocked Discipline')
+        resource_dir = models.Spappresourcedir.objects.create(
+            discipline=discipline,
+            specifyuser=self.specifyuser,
+            ispersonal=False,
+        )
+
+        blockers = self._get_blockers(discipline)
+        self._assertSame(
+            blockers,
+            [dict(table='Spappresourcedir', field='specifyuser', ids=[resource_dir.id])],
+        )
+
+        with self.assertRaises(BusinessRuleException):
+            delete_resource(
+                self.collection, self.agent, 'discipline', discipline.id, discipline.version
+            )
+
+    def test_discipline_without_users_or_collections_can_be_deleted(self):
+        discipline = self._create_discipline_with_owned_trees('Deletable Discipline')
+        blockers = self._get_blockers(discipline)
+        self._assertSame(blockers, [])
+
+        delete_resource(
+            self.collection, self.agent, 'discipline', discipline.id, discipline.version
+        )
+        self.assertFalse(models.Discipline.objects.filter(id=discipline.id).exists())


### PR DESCRIPTION
Allow new discipline deletion when it has no users and no collections

Fixes #

<!--
> [!WARNING]  
> This PR affects database migrations. See [migration testing instructions](https://specify.github.io/testing/pull_requests.html#prs-tagged-with-label-migration).
-->

### Checklist

- [ ] Self-review the PR after opening it to make sure the changes look good and
      self-explanatory (or properly documented)
- [ ] Add relevant issue to release milestone
- [ ] Add pr to documentation list
- [ ] Add automated tests
- [ ] Add a reverse migration if a migration is present in the PR
- [ ] Add migration function to https://github.com/specify/specify7/blob/ea04665987e1b8a1b76955c7b7f702b7bf701b47/specifyweb/specify/management/commands/run_key_migration_functions.py#L50


### Testing instructions

<!-- What are the steps to verify the fixes/changes in this PR? -->
<!-- Can part of that be replaced by automated tests? -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ability to delete disciplines with built-in safeguards
  * Restricted to administrator users only
  * Prevents deletion if discipline has associated collections or users
  * Automatically manages cleanup of related tree definitions

* **Tests**
  * New test coverage for discipline deletion protection scenarios

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/specify/specify7/pull/8090?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->