### PR TITLE
Fix latitude2 is not converted to lat2text in workbench

### DIFF
--- a/specifyweb/backend/stored_queries/batch_edit.py
+++ b/specifyweb/backend/stored_queries/batch_edit.py
@@ -921,7 +921,7 @@ def rewrite_coordinate_fields(row, _mapped_rows: dict[tuple[tuple[str, ...], ...
     field_replacement_map = {
         'latitude1': 'lat1text',
         'longitude1': 'long1text',
-        'latiude2': 'lat2text',
+        'latitude2': 'lat2text',
         'longitude2': 'long2text'
     }
 


### PR DESCRIPTION
Fixes #8099

In batch edit, latitude2 field should now take the value from lat2text

Look at this PR for more detailed info: https://github.com/specify/specify7/pull/7379

### Checklist

- [x] Self-review the PR after opening it to make sure the changes look good and
      self-explanatory (or properly documented)
- [ ] Add relevant issue to release milestone
- [ ] Add pr to documentation list
- [ ] Add automated tests


### Testing instructions

- Create a query with locality as a base table. Include one or more of the coordinate decimal fields (Latitude 1, Longitude 1, Latitude 2, and/or Longitude 2) in the Query. Make sure you have localities with values filled in latitude2 and longitude2.
- Run the query and click batch edit
- [ ] See that the lat2text column is present and readonly, and that latitude2 uses the value from lat2text

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected coordinate field handling for the second latitude decimal in batch edit operations, ensuring accurate data rewriting and proper alignment with corresponding text representations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/specify/specify7/pull/8100?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->