### PR TITLE
feat(trees): allow shared trees in TreeView search

### DIFF
--- a/specifyweb/frontend/js_src/lib/components/TreeView/Search.tsx
+++ b/specifyweb/frontend/js_src/lib/components/TreeView/Search.tsx
@@ -79,7 +79,8 @@ export function TreeViewSearch<SCHEMA extends AnyTree>({
               definition: treeDefinitionId,
               limit: DEFAULT_FETCH_SEARCH_LIMIT,
               orderBy: 'name',
-              domainFilter: true,
+              // Tree search already scopes by the selected definition; allow shared trees.
+              domainFilter: false,
             },
             {
               [resolvedSearchField]: searchCaseSensitive


### PR DESCRIPTION
This sets the `domainFilter` to `false` in the TreeView search query so searches include shared trees. The tree search is already scoped by the selected definition, making the domain filter redundant; added an inline comment explaining the change.

In local testing at NHMD, I can confirm that this resolves the issue of trees being scoped incorrectly. Although the nodes appear in the tree viewer and can be assigned through the forms and searched using the query builder, they do not display in the tree viewer. Fedor also confirmed this issue.

This PR **does not** cause records from other disciplines to appear in the results.

Example database:

|CollectionName|CollectionID|DisciplineID|DisciplineTaxonTreeDefID|TypeTaxonTreeDefID|CollectionObjectTypeID|TypeName|ObjectsUsingThisType|
|--------------|------------|------------|------------------------|------------------|----------------------|--------|--------------------|
|NHMD Vertebrate Paleontology|4|3|1|1|1|Vertebrate Paleontology|19819|
|NHMD Invertebrate Paleontology|327682|327681|1|1|3|Invertebrate Paleontology|1154|
|NHMD Micropaleontology|950272|327681|1|1|17|Invertebrate Paleontology|4720|


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated tree search scoping to include shared trees in search results.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/specify/specify7/pull/8104?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->