### PR TITLE
fix: preserve Splocaleitemstr custom text on migrate

### DIFF
--- a/specifyweb/specify/migration_utils/update_schema_config.py
+++ b/specifyweb/specify/migration_utils/update_schema_config.py
@@ -187,6 +187,28 @@ def uncapitilize(string: str) -> str:
     return string.lower() if len(string) <= 1 else string[0].lower() + string[1:]
 
 def bulk_create_splocaleitemstr_idempotent(Splocaleitemstr, rows: list[dict]) -> int:
+    """
+    Idempotently ensure Splocaleitemstr rows exist without clobbering custom text.
+
+    Creates any missing `Splocaleitemstr` rows described by `rows`, removes
+    duplicate rows, and preserves existing `text` values (it does NOT
+    overwrite customized captions). Returns the number of rows created.
+
+    Args:
+        Splocaleitemstr: The Django model class for `SpLocaleItemStr`.
+        rows: A list of dictionaries describing rows to create. Each dict
+            must set exactly one FK among `itemname`, `itemdesc`,
+            `containername`, or `containerdesc` and include `language` and
+            `text` fields. FK values should be model instances.
+
+    Returns:
+        int: Number of `Splocaleitemstr` rows created.
+
+    Note:
+        This function intentionally preserves existing `text` values to
+        avoid overwriting administrator/customized captions during
+        migrations (see issue #8128).
+    """
     if not rows:
         return 0
 
@@ -233,7 +255,11 @@ def bulk_create_splocaleitemstr_idempotent(Splocaleitemstr, rows: list[dict]) ->
             key = (r["language"], r[fk_field].pk)
             desired_by_key[key] = r
 
-        rows_to_update = []
+        # We will only create missing rows and remove duplicate rows.
+        # Do NOT overwrite existing `text` values — preserve any customized
+        # localized captions that may exist in the database. Overwriting
+        # existing text with defaults during upgrade caused user custom
+        # captions to be lost (see issue #8128).
         ids_to_delete: set[int] = set()
         to_create = []
         for key, desired_row in desired_by_key.items():
@@ -244,9 +270,16 @@ def bulk_create_splocaleitemstr_idempotent(Splocaleitemstr, rows: list[dict]) ->
                 continue
 
             keeper = existing_for_key[0]
+            # If the existing text differs from the desired default, preserve
+            # the existing text rather than overwriting it. This avoids
+            # clobbering administrator/customized captions during migration.
             if keeper.text != desired_row["text"]:
-                keeper.text = desired_row["text"]
-                rows_to_update.append(keeper)
+                logger.info(
+                    "Preserving existing Splocaleitemstr text for language=%s fk_id=%s id=%s",
+                    key[0],
+                    key[1],
+                    keeper.id,
+                )
 
             for duplicate in existing_for_key[1:]:
                 ids_to_delete.add(duplicate.id)
@@ -254,9 +287,7 @@ def bulk_create_splocaleitemstr_idempotent(Splocaleitemstr, rows: list[dict]) ->
         if ids_to_delete:
             Splocaleitemstr.objects.filter(id__in=ids_to_delete).delete()
 
-        if rows_to_update:
-            Splocaleitemstr.objects.bulk_update(rows_to_update, ["text"])
-
+        # Create any missing rows, but do not update existing text values.
         if to_create:
             Splocaleitemstr.objects.bulk_create(to_create)
             total_created += len(to_create)

--- a/specifyweb/specify/migration_utils/update_schema_config.py
+++ b/specifyweb/specify/migration_utils/update_schema_config.py
@@ -269,7 +269,12 @@ def bulk_create_splocaleitemstr_idempotent(Splocaleitemstr, rows: list[dict]) ->
                 to_create.append(Splocaleitemstr(**desired_row))
                 continue
 
-            keeper = existing_for_key[0]
+            # Prefer a row whose text already differs from the default so we
+            # preserve a customized caption instead of deleting it as a dup.
+            keeper = next(
+                (row for row in existing_for_key if row.text != desired_row["text"]),
+                existing_for_key[0],
+            )
             # If the existing text differs from the desired default, preserve
             # the existing text rather than overwriting it. This avoids
             # clobbering administrator/customized captions during migration.
@@ -281,8 +286,11 @@ def bulk_create_splocaleitemstr_idempotent(Splocaleitemstr, rows: list[dict]) ->
                     keeper.id,
                 )
 
-            for duplicate in existing_for_key[1:]:
-                ids_to_delete.add(duplicate.id)
+            # Remove every other row for this key; the keeper is the only one
+            # we want to preserve once duplicates have been collapsed.
+            for duplicate in existing_for_key:
+                if duplicate.id != keeper.id:
+                    ids_to_delete.add(duplicate.id)
 
         if ids_to_delete:
             Splocaleitemstr.objects.filter(id__in=ids_to_delete).delete()


### PR DESCRIPTION
Fixes #8128 

This preservescustomized schema captions by preventing `Splocaleitemstr` text from being overwritten when applying schema defaults.

It updates the `bulk_create_splocaleitemstr_idempotent` function to preserve existing `text` values, removes duplicates only while creating missing rows.

The previous behavior updated existing splocale string rows with default text during migration, which removed custom captions.

### Testing instructions

1. Prepare a test database (or use an existing v7.12.0.6 DB snapshot) and confirm a customized caption exists for a known schema field.

2. Run the targeted migration function that applies schema defaults:
```
docker exec -it specify7 /bin/bash
```

then run
```
specify@4624293fe5c7:/opt/specify7$ python3 manage.py run_key_migration_functions fix_schema_config --verbose
```

```
[28/May/2026 13:14:26] [INFO] [specifyweb.specify.migration_utils.update_schema_config:277] Preserving existing Splocaleitemstr text for language=en fk_id=181 id=381
[28/May/2026 13:14:26] [INFO] [specifyweb.specify.migration_utils.update_schema_config:277] Preserving existing Splocaleitemstr text for language=en fk_id=163 id=393
[28/May/2026 13:14:26] [INFO] [specifyweb.specify.migration_utils.update_schema_config:277] Preserving existing Splocaleitemstr text for language=en fk_id=164 id=394
[28/May/2026 13:14:26] [INFO] [specifyweb.specify.migration_utils.update_schema_config:277] Preserving existing Splocaleitemstr text for language=en fk_id=168 id=398
[28/May/2026 13:14:26] [INFO] [specifyweb.specify.migration_utils.update_schema_config:277] Preserving existing Splocaleitemstr text for language=en fk_id=169 id=399
[28/May/2026 13:14:26] [INFO] [specifyweb.specify.migration_utils.update_schema_config:277] Preserving existing Splocaleitemstr text for language=en fk_id=174 id=404
[28/May/2026 13:14:26] [INFO] [specifyweb.specify.migration_utils.update_schema_config:277] Preserving existing Splocaleitemstr text for language=en fk_id=175 id=405
[28/May/2026 13:14:26] [INFO] [specifyweb.specify.migration_utils.update_schema_config:277] Preserving existing Splocaleitemstr text for language=en fk_id=180 id=410
[28/May/2026 13:14:26] [INFO] [specifyweb.specify.migration_utils.update_schema_config:277] Preserving existing Splocaleitemstr text for language=en fk_id=181 id=411
[28/May/2026 13:14:26] [INFO] [specifyweb.specify.migration_utils.update_schema_config:277] Preserving existing Splocaleitems
```

3. Verify the customized caption was preserved (SQL, example query for catalog number):
```
SELECT sps.SpLocaleItemStrID AS 'String ID', sps.`Text` AS 'Field Label',
       d.Name AS 'Discipline Name', slc.Format AS 'Field Format', slc.Name AS 'Database Field', slc.PickListName, splc.Name AS 'Database Table',
       slc.IsHidden AS 'Is Hidden?', slc.SpLocaleContainerItemID AS 'Container ID'
FROM splocaleitemstr sps
JOIN splocalecontaineritem slc ON sps.SpLocaleContainerItemNameID = slc.SpLocaleContainerItemID
JOIN splocalecontainer slca ON slc.SpLocaleContainerID = slca.SpLocaleContainerID
JOIN splocalecontainer splc ON slc.SpLocaleContainerID = splc.SpLocaleContainerID
JOIN discipline d ON slca.DisciplineID = d.usergroupscopeid 
WHERE slc.Name = 'catalogNumber';
```

4. Also verify that:
- Missing locale rows are created for intended defaults (can recreate by deleting them via SQL from the `splocaleitemstr` table).
- Duplicate `splocalecontaineritem`/`splocaleitemstr` duplicates (if any) have still been deduplicated. You can create these manually via SQL.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Migrations now preserve existing user-customized captions and text instead of overwriting them with defaults.
  * Migration process still creates any missing entries and removes duplicate records, maintaining data integrity during upgrades.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/specify/specify7/pull/8130?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->