### PR TITLE
feat(Query Builder): Respect Sorting When Exporting Query to CSV (duplicate of #8168)

### DIFF
--- a/specifyweb/backend/stored_queries/execution.py
+++ b/specifyweb/backend/stored_queries/execution.py
@@ -330,8 +330,8 @@ def query_to_csv(
         field_specs,
         BuildQueryProps(recordsetid=recordsetid, replace_nulls=True, distinct=distinct),
     )
-    query = apply_special_post_query_processing(query, tableid, field_specs, collection, user, should_list_query=False)
     query = query.order_by(*order_by_expers)
+    query = apply_special_post_query_processing(query, tableid, field_specs, collection, user, should_list_query=False)
 
     logger.debug("query_to_csv starting")
 

--- a/specifyweb/backend/stored_queries/execution.py
+++ b/specifyweb/backend/stored_queries/execution.py
@@ -322,7 +322,7 @@ def query_to_csv(
     See build_query for details of the other accepted arguments.
     """
     set_group_concat_max_len(session.connection())
-    query, __ = build_query(
+    query, order_by_expers = build_query(
         session,
         collection,
         user,
@@ -331,6 +331,7 @@ def query_to_csv(
         BuildQueryProps(recordsetid=recordsetid, replace_nulls=True, distinct=distinct),
     )
     query = apply_special_post_query_processing(query, tableid, field_specs, collection, user, should_list_query=False)
+    query = query.order_by(*order_by_expers)
 
     logger.debug("query_to_csv starting")
 


### PR DESCRIPTION
Fixes #5038 

### Checklist

- [x] Self-review the PR after opening it to make sure the changes look good and
      self-explanatory (or properly documented)
- [x] Add relevant issue to release milestone
- [ ] Add automated tests


### Testing instructions

- Create a new query
- Sort by any field
- Click "Create CSV" and download it when it is finished
- [ ] Verify that the exported CSV is sorted by the same column as in the query.
    - Note that any other column may not be sorted if the column you sorted by has duplicates (i.e. two agents with the first name "A")
- [ ] Sort by multiple columns and ensure the left-most column is sorted first
    - after that, it should sort by the next column to the right, and so on

### Screenshots
(sorting by taxon in descending order)
<img width="1509" height="580" alt="2026-06-08-1042" src="https://github.com/user-attachments/assets/4c93955c-d008-4003-885f-2c2c876c96f6" />



<img width="934" height="651" alt="2026-06-08-1040" src="https://github.com/user-attachments/assets/5ba27beb-5f4f-48e1-94f8-010f73994861" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * CSV export now honors query sort order so exported rows match displayed ordering.
  * Export processing now always receives a valid query object, preventing failures when special post-query handling does not require listing results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->