### PR TITLE
fix(datamodel): add missing attachment relationships

### DIFF
--- a/specifyweb/specify/datamodel.py
+++ b/specifyweb/specify/datamodel.py
@@ -594,8 +594,8 @@ datamodel = Datamodel(tables=[
             Index(name='AttchmentGuidIDX', column_names=['GUID'])
         ],
         relationships=[
-            Relationship(name='absoluteageattachments', type='one-to-many',required=False, relatedModelName='AbsoluteAgeAttachment', otherSideName='attachment'),
-            Relationship(name='relativeageattachments', type='one-to-many',required=False, relatedModelName='RelativeAgeAttachment', otherSideName='attachment'),
+            Relationship(name='absoluteAgeAttachments', type='one-to-many',required=False, relatedModelName='AbsoluteAgeAttachment', otherSideName='attachment'),
+            Relationship(name='relativeAgeAttachments', type='one-to-many',required=False, relatedModelName='RelativeAgeAttachment', otherSideName='attachment'),
             Relationship(name='accessionAttachments', type='one-to-many',required=False, relatedModelName='AccessionAttachment', otherSideName='attachment'),
             Relationship(name='agentAttachments', type='one-to-many',required=False, relatedModelName='AgentAttachment', otherSideName='attachment'),
             Relationship(name='attachmentImageAttribute', type='many-to-one',required=False, relatedModelName='AttachmentImageAttribute', column='AttachmentImageAttributeID', otherSideName='attachments'),

--- a/specifyweb/specify/datamodel.py
+++ b/specifyweb/specify/datamodel.py
@@ -594,6 +594,8 @@ datamodel = Datamodel(tables=[
             Index(name='AttchmentGuidIDX', column_names=['GUID'])
         ],
         relationships=[
+            Relationship(name='absoluteageattachments', type='one-to-many',required=False, relatedModelName='AbsoluteAgeAttachment', otherSideName='attachment'),
+            Relationship(name='relativeageattachments', type='one-to-many',required=False, relatedModelName='RelativeAgeAttachment', otherSideName='attachment'),
             Relationship(name='accessionAttachments', type='one-to-many',required=False, relatedModelName='AccessionAttachment', otherSideName='attachment'),
             Relationship(name='agentAttachments', type='one-to-many',required=False, relatedModelName='AgentAttachment', otherSideName='attachment'),
             Relationship(name='attachmentImageAttribute', type='many-to-one',required=False, relatedModelName='AttachmentImageAttribute', column='AttachmentImageAttributeID', otherSideName='attachments'),


### PR DESCRIPTION
Fixes #8181 

There were missing attachment data model relationships for some of the new tables. This fixes that.

### Testing instructions

- [ ] Perform a batch edit on an attachment table and verify that you can save and commit the changes (see #8181)

<img width="1392" height="1522" alt="image" src="https://github.com/user-attachments/assets/72f153dc-df03-457f-b91d-c5b426e290f0" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated data model relationships to establish connections between attachments and age-related records, providing enhanced organization for absolute and relative age documentation within the system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->