### PR TITLE
Enforce loan preparation availability on insert (fixes #8188)

### DIFF
--- a/specifyweb/backend/businessrules/rules/interaction_rules.py
+++ b/specifyweb/backend/businessrules/rules/interaction_rules.py
@@ -29,9 +29,6 @@ def get_availability(prep, iprepid, iprepid_fld):
 
 @orm_signal_handler('pre_save', 'Loanpreparation')
 def loanprep_quantity_must_be_lte_availability(ipreparation):
-    if ipreparation.id is None:
-        return
-
     if ipreparation.preparation is not None:
         available = get_availability(
             ipreparation.preparation, ipreparation.id, "loanpreparationid") or 0

--- a/specifyweb/backend/businessrules/rules/interaction_rules.py
+++ b/specifyweb/backend/businessrules/rules/interaction_rules.py
@@ -6,7 +6,7 @@ from django.db import connection
 def get_availability(prep, iprepid, iprepid_fld):
     args = [prep.id]
     sql = """
-    select p.countAmt - coalesce(sum(lp.quantity-lp.quantityresolved),0) - coalesce(sum(gp.quantity),0) - coalesce(sum(ep.quantity),0) 
+    select p.countAmt - coalesce(sum(coalesce(lp.quantity,0)-coalesce(lp.quantityresolved,0)),0) - coalesce(sum(gp.quantity),0) - coalesce(sum(ep.quantity),0)
     from preparation p
     left join loanpreparation lp on lp.preparationid = p.preparationid
     left join giftpreparation gp on gp.preparationid = p.preparationid

--- a/specifyweb/backend/businessrules/tests/test_loanpreparation.py
+++ b/specifyweb/backend/businessrules/tests/test_loanpreparation.py
@@ -1,0 +1,104 @@
+from specifyweb.specify import models
+from specifyweb.specify.tests.test_api import ApiTests
+from ..exceptions import BusinessRuleException
+
+
+class LoanPreparationTests(ApiTests):
+    def setUp(self):
+        super().setUp()
+        self.preptype = models.Preptype.objects.create(
+            name='testPrepType',
+            isloanable=True,
+            collection=self.collection,
+        )
+        self.preparation = models.Preparation.objects.create(
+            collectionobject=self.collectionobjects[0],
+            preptype=self.preptype,
+            countamt=1,
+        )
+        self.loan_a = models.Loan.objects.create(
+            loannumber='1',
+            discipline=self.discipline)
+        self.loan_b = models.Loan.objects.create(
+            loannumber='2',
+            discipline=self.discipline)
+
+    def test_insert_cannot_exceed_availability(self):
+        models.Loanpreparation.objects.create(
+            loan=self.loan_a,
+            discipline=self.discipline,
+            preparation=self.preparation,
+            quantity=1,
+            quantityresolved=0)
+
+        with self.assertRaises(BusinessRuleException):
+            models.Loanpreparation.objects.create(
+                loan=self.loan_b,
+                discipline=self.discipline,
+                preparation=self.preparation,
+                quantity=1,
+                quantityresolved=0)
+
+    def test_insert_within_availability(self):
+        self.preparation.countamt = 2
+        self.preparation.save()
+
+        models.Loanpreparation.objects.create(
+            loan=self.loan_a,
+            discipline=self.discipline,
+            preparation=self.preparation,
+            quantity=1,
+            quantityresolved=0)
+
+        models.Loanpreparation.objects.create(
+            loan=self.loan_b,
+            discipline=self.discipline,
+            preparation=self.preparation,
+            quantity=1,
+            quantityresolved=0)
+
+    def test_resolved_loan_frees_availability(self):
+        models.Loanpreparation.objects.create(
+            loan=self.loan_a,
+            discipline=self.discipline,
+            preparation=self.preparation,
+            quantity=1,
+            quantityresolved=1,
+            isresolved=True)
+
+        models.Loanpreparation.objects.create(
+            loan=self.loan_b,
+            discipline=self.discipline,
+            preparation=self.preparation,
+            quantity=1,
+            quantityresolved=0)
+
+    def test_null_quantityresolved_treated_as_zero(self):
+        # A null Quantity Resolved must not crash the rule (#7665)...
+        models.Loanpreparation.objects.create(
+            loan=self.loan_a,
+            discipline=self.discipline,
+            preparation=self.preparation,
+            quantity=1,
+            quantityresolved=None)
+
+        # ...and the loan still counts as fully unresolved.
+        with self.assertRaises(BusinessRuleException):
+            models.Loanpreparation.objects.create(
+                loan=self.loan_b,
+                discipline=self.discipline,
+                preparation=self.preparation,
+                quantity=1,
+                quantityresolved=None)
+
+    def test_update_cannot_exceed_availability(self):
+        lp = models.Loanpreparation.objects.create(
+            loan=self.loan_a,
+            discipline=self.discipline,
+            preparation=self.preparation,
+            quantity=1,
+            quantityresolved=0)
+
+        lp.quantity = 2
+        with self.assertRaises(BusinessRuleException):
+            lp.save()


### PR DESCRIPTION
Fixes #8188

The fix for #7665 (79c3a4f9) added an early return to `loanprep_quantity_must_be_lte_availability` that skips the rule whenever `ipreparation.id is None` — i.e. on every INSERT. Since then the server has not enforced preparation availability when a loan preparation is created, so a specimen can be placed on two open loans at once through any path that bypasses the frontend InteractionDialog pre-query ("Add Unassociated Item", direct REST API POSTs, WorkBench loan uploads). The gift and exchange-out rules in the same file validate on insert; loans were the only interaction that did not.

This PR removes the early return so the availability check runs on insert again, matching the sibling rules. The null-safe quantity handling from the #7665 fix (`int(x or 0)`) is kept — that alone fixes #7665, which was a `TypeError` from calling `int(None)` when Quantity Resolved was unmapped in a WorkBench upload. On insert, `get_availability` is called with `iprepid=None` and correctly skips the self-exclusion clause, so no other change is needed.

A second commit fixes the matching null-safety gap in `get_availability`'s SQL: `sum(lp.quantity - lp.quantityresolved)` goes NULL for a row whose `quantityresolved` is NULL (e.g. created by a WorkBench upload with Quantity Resolved unmapped), so that row contributed nothing to the on-loan amount and availability was overstated. Both fields are now coalesced to 0, matching the Python side.

Added `specifyweb/backend/businessrules/tests/test_loanpreparation.py` covering:

- inserting a loan preparation that exceeds availability raises `BusinessRuleException` (the regression)
- inserting within availability succeeds
- a resolved loan frees availability for a new loan
- a null `quantityresolved` does not crash the rule (#7665 regression guard) and still counts as fully unresolved
- the existing update-path enforcement still works

All existing loan-preparation-creating tests in `businessrules`, `interactions`, `specify`, and `workbench` stay within availability, so no other test changes were needed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced availability calculation to properly handle missing or zero values in quantity fields.
  * Strengthened loan-preparation validation to apply consistently across all data conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->