### PR TITLE
Accession CO subview searches with multiple catalogNumbers only returns last number

### DIFF
--- a/specifyweb/backend/express_search/search_terms.py
+++ b/specifyweb/backend/express_search/search_terms.py
@@ -117,6 +117,6 @@ def parse_search_str(collection, search_str):
     if match_quoted:
         terms = [ match_quoted.groups()[1] ]
     else:
-        terms = search_str.split()
+        terms = search_str.split(',')
 
     return list(map(TermForCollection.make_term, terms))

--- a/specifyweb/backend/express_search/search_terms.py
+++ b/specifyweb/backend/express_search/search_terms.py
@@ -117,6 +117,6 @@ def parse_search_str(collection, search_str):
     if match_quoted:
         terms = [ match_quoted.groups()[1] ]
     else:
-        terms = search_str.split(',')
+        terms = [ t.strip() for t in search_str.split(',') if t.strip() ]
 
     return list(map(TermForCollection.make_term, terms))


### PR DESCRIPTION
Express search now splits on commas instead of spaces

Fixes #8221 

### Checklist

- [x] Self-review the PR after opening it to make sure the changes look good and
      self-explanatory (or properly documented)
- [x] Add relevant issue to release milestone


### Testing instructions

- Go to any table that has a one-to-many relationship with collection objects and has a subform to add them and open the express search.
- [x] enter a comma-separated list of catalog numbers and make sure that those numbers are all returned in the results box
- [x] try adding spaces between the commas, both before and after to make sure those do not break the search box
- [x] try adding non-conventional whitespace, like a tab to ensure that the search box does not break (you'll have to paste the tab in, here it is between the quotes "	")


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced search term parsing to split unquoted input by commas (instead of whitespace), improving multi-term search behavior while keeping quoted single-term searches unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->