### PR TITLE
[tests]: isPrimary set to first collector

### DIFF
--- a/specifyweb/frontend/js_src/lib/components/DataModel/__tests__/businessRules.test.ts
+++ b/specifyweb/frontend/js_src/lib/components/DataModel/__tests__/businessRules.test.ts
@@ -497,6 +497,19 @@ describe.skip('Dependent Collections isPrimary', () => {
   });
 });
 
+describe('Collector business rule', () => {
+  test('isPrimary being automatically set', () => {
+    const collectingEvent = new tables.CollectingEvent.Resource();
+    const collector = new tables.Collector.Resource();
+
+    //This initializes the dependent collection
+    collectingEvent.set('collectors', []);
+    collectingEvent.getDependentResource('collectors')?.add(collector);
+
+    expect(collector.get('isPrimary')).toBe(true);
+  });
+});
+
 describe('Collecting Event', () => {
   test('Removing Collector sets first Collector as primary', () => {
     const collectingEvent = new tables.CollectingEvent.Resource({


### PR DESCRIPTION
Fixes #8233 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage for collector-related business rules, confirming that a newly added collector is automatically marked as primary when included in a collecting event.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->