### PR TITLE
fix(trees): replace child/synonym LEFT JOINs with scalar subqueries

### DIFF
--- a/specifyweb/backend/trees/views.py
+++ b/specifyweb/backend/trees/views.py
@@ -208,15 +208,22 @@ def get_tree_rows(treedef, tree, parentid, sortfield, include_author, session):
             else func.min(literal("NULL"))
         ).label("author"),
 
-        func.count(distinct(child._id)).label("child_count"),
-        group_concat(distinct(synonym.fullName), separator=", ").label("synonyms"),
+        select(func.count(child._id))
+            .where(child.ParentID == node._id)
+            .correlate(node)
+            .scalar_subquery()
+            .label("child_count"),
+
+        select(group_concat(distinct(synonym.fullName), separator=", "))
+            .where(synonym.AcceptedID == node._id)
+            .correlate(node)
+            .scalar_subquery()
+            .label("synonyms"),
     ]
 
     query = (
         select(*cols)
-        .outerjoin(child, child.ParentID  == node._id)
         .outerjoin(accepted, node.AcceptedID == accepted._id)
-        .outerjoin(synonym, synonym.AcceptedID == node._id)
         .where(treedef_col == int(treedef))
         .where(node.ParentID == parentid)
         .group_by(node._id)


### PR DESCRIPTION
Fixes #8242 

The tree view endpoint constructed queries with three independent `LEFT OUTER JOIN`s on the same tree table, one for counting children, one for looking up the accepted parent, and one for aggregating synonyms. When expanding a node with many children, the result set would balloon as `children * accepted_matches * synonyms`, overwhelming the database and causing a 504 gateway timeout.

This happened because each join added rows multiplicatively before `GROUP BY` collapsed them with `DISTINCT` aggregates like `count(DISTINCT ...)` and `GROUP_CONCAT(DISTINCT ...)`. For a storage tree node like "Rack 001" at SAIAB, which has hundreds of direct child storage locations, the query would run for 40+ seconds and continue executing even after the HTTP connection was severed. Page refreshes would spawn additional instances, all consuming database resources.

### Testing instructions

Compare against the same database on both `v7` and on `issue-8242`.

1. Use the SAIAB database backup provided in the linked issue
2. Log into any collection (e.g. "Biodiversity Occurrences")
3. Search for "Rack 001" in the Storage tree
4. Expand the node. It should load normally without 504

- [ ] Browse tree nodes generally (Taxon, Geography, Storage) to confirm `child_count` and `synonyms` still display correctly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tree row calculations so child counts and synonym lists display more consistently in tree views.
  * Reduced duplicated results in tree listings by changing how related items are gathered.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->