### PR TITLE
[tests]: verify independent subview sub-record changes propagate needsSaved and persist

### DIFF
--- a/specifyweb/frontend/js_src/lib/components/DataModel/__tests__/resourceApi.test.ts
+++ b/specifyweb/frontend/js_src/lib/components/DataModel/__tests__/resourceApi.test.ts
@@ -15,7 +15,6 @@ import type {
   CollectionObjectAttribute,
   CollectionObjectType,
   Determination,
-  Accession,
 } from '../types';
 
 requireContext();
@@ -531,6 +530,7 @@ describe('save base record which has independent subviews', () => {
       tables.CollectionObject.strictGetRelationship('accession')!;
     const independentCollection =
       new tables.CollectionObject.IndependentCollection({
+        //creates a new form with
         related: parentResource,
         field: collectionObjectRel,
       }) as Collection<CollectionObject>;
@@ -544,20 +544,42 @@ describe('save base record which has independent subviews', () => {
 
   test('modifying a field on an independent resource marks base record as needsSaved and save applies the change', async () => {
     const { parentResource, independentCollection } =
+      await setupParentWithIndependentCollection(); //creates fake parent form and fake list of independent subviews
+
+    expect(parentResource.needsSaved).toBe(false); //since we just created a new record, the needsSaved needs to be false
+
+    const existingCollectionObject = independentCollection.models[0]; //get the first collection object from collection
+    existingCollectionObject.set('text1', 'changed-value'); //change a field in the collection object
+
+    expect(parentResource.needsSaved).toBe(true); //after you change, the save button should light up
+
+    await parentResource.save(); //save
+
+    expect(parentResource.needsSaved).toBe(false); //after saving, save button should be disabled
+    // Change is preserved in memory after save
+    expect(existingCollectionObject.get('text1')).toBe('changed-value'); //the change we made is still in memory
+  });
+
+  test('modifying a sub-record of an independent resource propagates needsSaved to base record and save completes', async () => {
+    const { parentResource, independentCollection } =
       await setupParentWithIndependentCollection();
 
     expect(parentResource.needsSaved).toBe(false);
 
-    const existingCollectionObject = independentCollection.models[0];
-    existingCollectionObject.set('text1', 'changed-value');
+    const collectionObject = independentCollection.models[0];
+    const determinations =
+      collectionObject.getDependentResource('determinations');
+    const determination = determinations!.models[0];
+    determination.set('number1', 99);
 
+    // Change to sub-record propagates needsSaved all the way up to base record
     expect(parentResource.needsSaved).toBe(true);
 
     await parentResource.save();
 
     expect(parentResource.needsSaved).toBe(false);
-    // Change is preserved in memory after save
-    expect(existingCollectionObject.get('text1')).toBe('changed-value');
+    // Change to sub-record is preserved in memory after save
+    expect(determination.get('number1')).toBe(99);
   });
 });
 

--- a/specifyweb/frontend/js_src/lib/components/DataModel/__tests__/resourceApi.test.ts
+++ b/specifyweb/frontend/js_src/lib/components/DataModel/__tests__/resourceApi.test.ts
@@ -15,6 +15,7 @@ import type {
   CollectionObjectAttribute,
   CollectionObjectType,
   Determination,
+  Accession,
 } from '../types';
 
 requireContext();
@@ -467,6 +468,51 @@ test('save', async () => {
   const newDetermination =
     resource.getDependentResource('determinations')!.models[0];
   expect(newDetermination.get('number1')).toBe(2);
+});
+
+describe('independent resource change propagation', () => {
+  overrideAjax(
+    '/api/specify/collectionobject/?domainfilter=false&accession=11&offset=0',
+    emptyCollection
+  );
+  overrideAjax(accessionUrl, accessionResponse, { method: 'PUT' });
+
+  test('needsSaved propagates from independent collection to parent', async () => {
+    const parentResource = new tables.Accession.Resource({ id: accessionId });
+    expect(parentResource.needsSaved).toBe(false);
+
+    const collectionObjectRel =
+      tables.CollectionObject.strictGetRelationship('accession')!;
+
+    const independentCollection =
+      new tables.CollectionObject.IndependentCollection({
+        related: parentResource,
+        field: collectionObjectRel,
+      }) as Collection<CollectionObject>;
+
+    await independentCollection.fetch();
+
+    // Connect the collection to the parent's event system, as rgetCollection would do internally.
+    // storeIndependent is not in the public TS types so cast to any.
+    (parentResource as any).storeIndependent(
+      collectionObjectRel.getReverse(),
+      independentCollection
+    );
+
+    const newCollectionObject = new tables.CollectionObject.Resource({
+      id: 998,
+    });
+    independentCollection.add(newCollectionObject);
+
+    // Adding an existing resource to an independent collection does not mark the resource itself needsSaved;
+    // only the parent is notified via saverequired
+    expect(newCollectionObject.needsSaved).toBe(false);
+    expect(parentResource.needsSaved).toBe(true);
+
+    await parentResource.save();
+
+    expect(parentResource.needsSaved).toBe(false);
+  });
 });
 
 describe('resource initialization', () => {

--- a/specifyweb/frontend/js_src/lib/components/DataModel/__tests__/resourceApi.test.ts
+++ b/specifyweb/frontend/js_src/lib/components/DataModel/__tests__/resourceApi.test.ts
@@ -515,6 +515,52 @@ describe('independent resource change propagation', () => {
   });
 });
 
+describe('save base record which has independent subviews', () => {
+  overrideAjax(
+    '/api/specify/collectionobject/?domainfilter=false&accession=11&offset=0',
+    {
+      objects: [collectionObjectResponse],
+      meta: { limit: 20, offset: 0, total_count: 1 },
+    }
+  );
+  overrideAjax(accessionUrl, accessionResponse, { method: 'PUT' });
+
+  async function setupParentWithIndependentCollection() {
+    const parentResource = new tables.Accession.Resource({ id: accessionId });
+    const collectionObjectRel =
+      tables.CollectionObject.strictGetRelationship('accession')!;
+    const independentCollection =
+      new tables.CollectionObject.IndependentCollection({
+        related: parentResource,
+        field: collectionObjectRel,
+      }) as Collection<CollectionObject>;
+    await independentCollection.fetch();
+    (parentResource as any).storeIndependent(
+      collectionObjectRel.getReverse(),
+      independentCollection
+    );
+    return { parentResource, independentCollection };
+  }
+
+  test('modifying a field on an independent resource marks base record as needsSaved and save applies the change', async () => {
+    const { parentResource, independentCollection } =
+      await setupParentWithIndependentCollection();
+
+    expect(parentResource.needsSaved).toBe(false);
+
+    const existingCollectionObject = independentCollection.models[0];
+    existingCollectionObject.set('text1', 'changed-value');
+
+    expect(parentResource.needsSaved).toBe(true);
+
+    await parentResource.save();
+
+    expect(parentResource.needsSaved).toBe(false);
+    // Change is preserved in memory after save
+    expect(existingCollectionObject.get('text1')).toBe('changed-value');
+  });
+});
+
 describe('resource initialization', () => {
   test('Initialization with dependent resources does not trigger saveRequired', () => {
     const resource = new tables.CollectionObject.Resource({


### PR DESCRIPTION
Fixes #8250 
Fixes #8249 
Fixes #8241 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage for change propagation in parent/child record views.
  * Verified that editing related items marks the parent as needing save and that saving clears the pending state.
  * Confirmed that changes to nested related records are preserved after saving.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->