### PR TITLE
[test]: add basic permit creation

### DIFF
--- a/specifyweb/backend/businessrules/tests/test_permit.py
+++ b/specifyweb/backend/businessrules/tests/test_permit.py
@@ -31,3 +31,16 @@ class PermitTests(ApiTests):
 
         aa.delete()
         permit.delete()
+
+    # Create a Permit with required fields only
+    def test_create_basic_permit(self):
+        permit = models.Permit.objects.create( # creates new Permit record in the database
+            institution=self.institution,
+            permitnumber='P-BASIC-001',
+        )
+
+        # Verify save worked
+        self.assertIsNotNone(permit.id) # making sure this is not none
+        self.assertEqual(permit.version, 0) # making sure the version starts at 0
+        fetched = models.Permit.objects.get(id=permit.id) # refetching the record
+        self.assertEqual(fetched.permitnumber, 'P-BASIC-001') # comparing the fetched permitnumber to the actual permit number


### PR DESCRIPTION
Fixes #8265 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage for creating a basic permit with only required details.
  * Verified the record is saved successfully, starts at version 0, and retains the expected permit number when reloaded.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->