### PR TITLE
Revert: Grant migrator privileges even when the user already exists

### DIFF
--- a/seed-database/README.md
+++ b/seed-database/README.md
@@ -2,6 +2,11 @@
 
 Used by development docker composition only.
 
+Files in this folder are mounted into MariaDB's `/docker-entrypoint-initdb.d`.
+They are only processed when `/var/lib/mysql` is empty, so reusing the
+`database` volume will skip these imports. If you want to re-run the seed,
+remove the volume first (for example with `docker compose down -v`).
+
 Put an `.sql` dump of your database in this directory. You can call the
 file anything you want as long as it ends with `.sql`.
 

--- a/sp7_db_setup_check.sh
+++ b/sp7_db_setup_check.sh
@@ -216,14 +216,16 @@ fi
 
 if [[ "$NEW_MIGRATOR_USER_CREATED" -eq 1 ]]; then
   echo "Granting privileges to new user..."
-  echo "Executing: mysql -h \"$DB_HOST\" -P \"$DB_PORT\" -u \"$MASTER_USER_NAME\" --password=\"<hidden>\" -e \"GRANT ALL PRIVILEGES ON \`${SQL_DB_IDENTIFIER_ESCAPED_FOR_LIKE}\`.* TO '${SQL_MIGRATOR_NAME}'@'${CLIENT_HOST}'; FLUSH PRIVILEGES;\""
-
-  if ! mysql -h "$DB_HOST" -P "$DB_PORT" -u "$MASTER_USER_NAME" --password="$MASTER_USER_PASSWORD" -e "GRANT ALL PRIVILEGES ON \`${SQL_DB_IDENTIFIER_ESCAPED_FOR_LIKE}\`.* TO '${SQL_MIGRATOR_NAME}'@'${CLIENT_HOST}'; FLUSH PRIVILEGES;"; then
-    echo "Error: Failed to grant privileges to new user."
-    exit 1
-  fi
 else
-  echo "Skipping privilege grant for migrator user: user already exists. Verifying privileges on '${DB_NAME}'..."
+  echo "Migrator user already exists. Refreshing privileges on '${DB_NAME}'..."
+fi
+
+echo "Executing: mysql -h \"$DB_HOST\" -P \"$DB_PORT\" -u \"$MASTER_USER_NAME\" --password=\"<hidden>\" -e \"GRANT ALL PRIVILEGES ON \`${SQL_DB_IDENTIFIER_ESCAPED_FOR_LIKE}\`.* TO '${SQL_MIGRATOR_NAME}'@'${CLIENT_HOST}'; FLUSH PRIVILEGES;\""
+
+if ! mysql -h "$DB_HOST" -P "$DB_PORT" -u "$MASTER_USER_NAME" --password="$MASTER_USER_PASSWORD" \
+  -e "GRANT ALL PRIVILEGES ON \`${SQL_DB_IDENTIFIER_ESCAPED_FOR_LIKE}\`.* TO '${SQL_MIGRATOR_NAME}'@'${CLIENT_HOST}'; FLUSH PRIVILEGES;"; then
+  echo "Error: Failed to grant privileges to migrator user."
+  exit 1
 fi
 
 GRANTS_OUTPUT="$(mysql -N -B --raw -h "$DB_HOST" -P "$DB_PORT" \

--- a/sp7_db_setup_check.sh
+++ b/sp7_db_setup_check.sh
@@ -197,6 +197,11 @@ else
 fi
 
 # Create migrator user if it doesn't exist
+if [[ "$SAME_MASTER_AND_MIGRATOR" == true ]]; then
+  echo "Migrator user '$MIGRATOR_NAME' uses the same credentials as master."
+  echo "Skipping creation/grant steps for a separate migrator account."
+  echo "Relying on master privileges for runtime connections."
+else
 USER_EXISTS=$(mysql -h "$DB_HOST" -P "$DB_PORT" -u "$MASTER_USER_NAME" --password="$MASTER_USER_PASSWORD" -sse \
 "SELECT COUNT(*) FROM mysql.user WHERE user = '$SQL_MIGRATOR_NAME' AND host = '$CLIENT_HOST';")
 
@@ -256,6 +261,7 @@ else
   echo "$GRANTS_OUTPUT"
   exit 1
 fi
+fi
 
 # Create app user if it doesn't exist
 USER_EXISTS=$(mysql -h "$DB_HOST" -P "$DB_PORT" -u "$MASTER_USER_NAME" --password="$MASTER_USER_PASSWORD" -sse \
@@ -294,13 +300,14 @@ else
 
 if [[ "$NEW_APP_USER_CREATED" -eq 1 ]]; then
   echo "Granting privileges to new user..."
-  echo "Executing: mysql -h \"$DB_HOST\" -P \"$DB_PORT\" -u \"$MASTER_USER_NAME\" --password=\"<hidden>\" -e \"GRANT SELECT, INSERT, UPDATE, DELETE, CREATE TEMPORARY TABLES, LOCK TABLES, EXECUTE ON \`${SQL_DB_IDENTIFIER_ESCAPED_FOR_LIKE}\`.* TO ${SQL_APP_USER_NAME}@'${CLIENT_HOST}'; FLUSH PRIVILEGES;\""
-  if ! mysql -h "$DB_HOST" -P "$DB_PORT" -u "$MASTER_USER_NAME" --password="$MASTER_USER_PASSWORD" -e "GRANT SELECT, INSERT, UPDATE, DELETE, CREATE TEMPORARY TABLES, LOCK TABLES, EXECUTE ON \`${SQL_DB_IDENTIFIER_ESCAPED_FOR_LIKE}\`.* TO '${SQL_APP_USER_NAME}'@'${CLIENT_HOST}'; FLUSH PRIVILEGES;"; then
-    echo "Error: Failed to grant privileges to new user."
-    exit 1
-  fi
 else
-  echo "Skipping privilege grant for app user: user already exists. Verifying privileges on '${DB_NAME}'..."
+  echo "App user already exists. Refreshing privileges on '${DB_NAME}'..."
+fi
+
+echo "Executing: mysql -h \"$DB_HOST\" -P \"$DB_PORT\" -u \"$MASTER_USER_NAME\" --password=\"<hidden>\" -e \"GRANT SELECT, INSERT, UPDATE, DELETE, CREATE TEMPORARY TABLES, LOCK TABLES, EXECUTE ON \`${SQL_DB_IDENTIFIER_ESCAPED_FOR_LIKE}\`.* TO ${SQL_APP_USER_NAME}@'${CLIENT_HOST}'; FLUSH PRIVILEGES;\""
+if ! mysql -h "$DB_HOST" -P "$DB_PORT" -u "$MASTER_USER_NAME" --password="$MASTER_USER_PASSWORD" -e "GRANT SELECT, INSERT, UPDATE, DELETE, CREATE TEMPORARY TABLES, LOCK TABLES, EXECUTE ON \`${SQL_DB_IDENTIFIER_ESCAPED_FOR_LIKE}\`.* TO '${SQL_APP_USER_NAME}'@'${CLIENT_HOST}'; FLUSH PRIVILEGES;"; then
+  echo "Error: Failed to grant privileges to app user."
+  exit 1
 fi
 
 APP_GRANTS_RAW="$(mysql -N -B -h "$DB_HOST" -P "$DB_PORT" -u "$MASTER_USER_NAME" --password="$MASTER_USER_PASSWORD" \
@@ -329,6 +336,7 @@ else
   echo "Required (any one GRANT must include all of): ${APP_REQUIRED_PRIVS[*]}"
   echo "Grants found:"
   echo "$APP_GRANTS_RAW"
+  exit 1
 fi
 fi
 

--- a/sp7_db_setup_check.sh
+++ b/sp7_db_setup_check.sh
@@ -225,10 +225,10 @@ else
   echo "Migrator user already exists. Refreshing privileges on '${DB_NAME}'..."
 fi
 
-echo "Executing: mysql -h \"$DB_HOST\" -P \"$DB_PORT\" -u \"$MASTER_USER_NAME\" --password=\"<hidden>\" -e \"GRANT ALL PRIVILEGES ON \`${SQL_DB_IDENTIFIER_ESCAPED_FOR_LIKE}\`.* TO '${SQL_MIGRATOR_NAME}'@'${CLIENT_HOST}'; FLUSH PRIVILEGES;\""
+echo "Executing: mysql -h \"$DB_HOST\" -P \"$DB_PORT\" -u \"$MASTER_USER_NAME\" --password=\"<hidden>\" -e \"GRANT ALL PRIVILEGES ON \`${SQL_DB_IDENTIFIER}\`.* TO '${SQL_MIGRATOR_NAME}'@'${CLIENT_HOST}'; FLUSH PRIVILEGES;\""
 
 if ! mysql -h "$DB_HOST" -P "$DB_PORT" -u "$MASTER_USER_NAME" --password="$MASTER_USER_PASSWORD" \
-  -e "GRANT ALL PRIVILEGES ON \`${SQL_DB_IDENTIFIER_ESCAPED_FOR_LIKE}\`.* TO '${SQL_MIGRATOR_NAME}'@'${CLIENT_HOST}'; FLUSH PRIVILEGES;"; then
+  -e "GRANT ALL PRIVILEGES ON \`${SQL_DB_IDENTIFIER}\`.* TO '${SQL_MIGRATOR_NAME}'@'${CLIENT_HOST}'; FLUSH PRIVILEGES;"; then
   echo "Error: Failed to grant privileges to migrator user."
   exit 1
 fi
@@ -304,8 +304,8 @@ else
   echo "App user already exists. Refreshing privileges on '${DB_NAME}'..."
 fi
 
-echo "Executing: mysql -h \"$DB_HOST\" -P \"$DB_PORT\" -u \"$MASTER_USER_NAME\" --password=\"<hidden>\" -e \"GRANT SELECT, INSERT, UPDATE, DELETE, CREATE TEMPORARY TABLES, LOCK TABLES, EXECUTE ON \`${SQL_DB_IDENTIFIER_ESCAPED_FOR_LIKE}\`.* TO ${SQL_APP_USER_NAME}@'${CLIENT_HOST}'; FLUSH PRIVILEGES;\""
-if ! mysql -h "$DB_HOST" -P "$DB_PORT" -u "$MASTER_USER_NAME" --password="$MASTER_USER_PASSWORD" -e "GRANT SELECT, INSERT, UPDATE, DELETE, CREATE TEMPORARY TABLES, LOCK TABLES, EXECUTE ON \`${SQL_DB_IDENTIFIER_ESCAPED_FOR_LIKE}\`.* TO '${SQL_APP_USER_NAME}'@'${CLIENT_HOST}'; FLUSH PRIVILEGES;"; then
+echo "Executing: mysql -h \"$DB_HOST\" -P \"$DB_PORT\" -u \"$MASTER_USER_NAME\" --password=\"<hidden>\" -e \"GRANT SELECT, INSERT, UPDATE, DELETE, CREATE TEMPORARY TABLES, LOCK TABLES, EXECUTE ON \`${SQL_DB_IDENTIFIER}\`.* TO ${SQL_APP_USER_NAME}@'${CLIENT_HOST}'; FLUSH PRIVILEGES;\""
+if ! mysql -h "$DB_HOST" -P "$DB_PORT" -u "$MASTER_USER_NAME" --password="$MASTER_USER_PASSWORD" -e "GRANT SELECT, INSERT, UPDATE, DELETE, CREATE TEMPORARY TABLES, LOCK TABLES, EXECUTE ON \`${SQL_DB_IDENTIFIER}\`.* TO '${SQL_APP_USER_NAME}'@'${CLIENT_HOST}'; FLUSH PRIVILEGES;"; then
   echo "Error: Failed to grant privileges to app user."
   exit 1
 fi


### PR DESCRIPTION
Fixes #8305 

<!--
> [!WARNING]  
> This PR affects database migrations. See [migration testing instructions](https://specify.github.io/testing/pull_requests.html#prs-tagged-with-label-migration).
-->

### Checklist

- [x] Self-review the PR after opening it to make sure the changes look good and
      self-explanatory (or properly documented)
- [x] Add relevant issue to release milestone
- [ ] Add pr to documentation list
- [ ] Add automated tests
- [ ] Add a reverse migration if a migration is present in the PR
- [ ] Add migration function to https://github.com/specify/specify7/blob/ea04665987e1b8a1b76955c7b7f702b7bf701b47/specifyweb/specify/management/commands/run_key_migration_functions.py#L50


### Testing instructions

<!-- What are the steps to verify the fixes/changes in this PR? -->
<!-- Can part of that be replaced by automated tests? -->

1. Check that you have a `specify_migrator`* and `specify_user`* already created in MySQL.
  - _*The users may not be of those names. They need to match the `MIGRATOR_NAME` and `APP_USER_NAME` in the _.env_ file._
 2. Edit the `.env` file so that the DATABASE_NAME is one that does not exist yet.
 3. Build/rebuild your Docker containers.
   - [ ] Check the `specify7` container logs and make sure there are no migration errors.
4. Open the application in your browser.
  - [ ] Make sure that it's opening the Specify 7 initial database setup screen.
5. Stop the containers.
6. Edit the `.env` file so that the DATABASE_NAME is one that does exist and was not previously opened in v7.12.
  - You may run into migration errors while testing an old database.
7. Build/rebuild your Docker containers.
  - [ ] Check the `specify7` container logs and make sure there are no migration errors.
8. Open the application in your browser.
  - [ ] Make sure that it's opening the Specify 7 login page.

Additional checks:
- [ ] See that changing the migrator name to master in `.env` prints the proper log message.
- [ ] See that changing the app user name to master in `.env` prints the proper log message.
- [ ] See that changing the app user name to the migrator in `.env` prints the proper log message.
- [ ] See that having an underscore or other characters that commonly need to be escaped does not affect database setup.