### PR TITLE
Fix: Disable attachment relationships in batch edit

### DIFF
--- a/specifyweb/backend/stored_queries/batch_edit.py
+++ b/specifyweb/backend/stored_queries/batch_edit.py
@@ -65,6 +65,7 @@ def get_readonly_fields(table: Table):
         rel.name
         for rel in table.relationships
         if rel.relatedModelName.lower() in BATCH_EDIT_READONLY_TABLES
+        or "attachment" in rel.relatedModelName.lower()
     ]
     if table.name.lower() == "determination":
         relationships = ["preferredtaxon"]


### PR DESCRIPTION
Fixes #8314

### Checklist

- [ ] Self-review the PR after opening it to make sure the changes look good and
      self-explanatory (or properly documented)
- [ ] Add relevant issue to release milestone
- [ ] Add pr to documentation list
- [ ] Add automated tests
- [ ] Add a reverse migration if a migration is present in the PR
- [ ] Add migration function to https://github.com/specify/specify7/blob/ea04665987e1b8a1b76955c7b7f702b7bf701b47/specifyweb/specify/management/commands/run_key_migration_functions.py#L50


### Testing instructions

- Create a query with an attachment relationship. (I.e: collection object base table >> collection object attachment >> attachment >> title) 
- Save your query 
- Click batch edit 
- Verify attachment "title" column is disabled
