### PR TITLE
fix(queries): preserve sort in exported CSVs, again

### DIFF
--- a/specifyweb/backend/stored_queries/execution.py
+++ b/specifyweb/backend/stored_queries/execution.py
@@ -401,7 +401,7 @@ def query_to_csv(
     See build_query for details of the other accepted arguments.
     """
     set_group_concat_max_len(session.connection())
-    query, __ = build_query(
+    query, order_by_exprs = build_query(
         session,
         collection,
         user,
@@ -409,6 +409,7 @@ def query_to_csv(
         field_specs,
         BuildQueryProps(recordsetid=recordsetid, replace_nulls=True, distinct=distinct),
     )
+    query = query.order_by(*order_by_exprs)
     query_rows = apply_special_post_query_processing(
         query=query,
         processors=DefaultQueryProcessors(


### PR DESCRIPTION
Fixes #5038 

This PR adds back the CSV export tool preserving the sort order of a query. This was lost when #7994 was merged into `main` a few days ago.

> ### Checklist
> 
> - [x] Self-review the PR after opening it to make sure the changes look good and
>       self-explanatory (or properly documented)
> - [x] Add relevant issue to release milestone
> - [ ] Add automated tests
> 
> 
> ### Testing instructions
> 
> - Create a new query
> - Sort by any field
> - Click "Create CSV" and download it when it is finished
> - [ ] Verify that the exported CSV is sorted by the same column as in the query.
>     - Note that any other column may not be sorted if the column you sorted by has duplicates (i.e. two agents with the first name "A")
> - [ ] Sort by multiple columns and ensure the left-most column is sorted first
>     - after that, it should sort by the next column to the right, and so on
> 
> ### Screenshots
> (sorting by taxon in descending order)
> <img width="1509" height="580" alt="2026-06-08-1042" src="https://github.com/user-attachments/assets/4c93955c-d008-4003-885f-2c2c876c96f6" />
> 
> 
> 
> <img width="934" height="651" alt="2026-06-08-1040" src="https://github.com/user-attachments/assets/5ba27beb-5f4f-48e1-94f8-010f73994861" />
> 
> 
> 
> <!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * CSV exports now preserve the requested query result ordering.
  * Exported data consistently matches the ordering shown by the query.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->