### PR TITLE
Fix: Remove extra close button for app resource overlay

### DIFF
--- a/specifyweb/frontend/js_src/lib/components/AppResources/Editor.tsx
+++ b/specifyweb/frontend/js_src/lib/components/AppResources/Editor.tsx
@@ -240,11 +240,17 @@ export function AppResourceEditor({
 
   const footer = (
     <>
-      <Button.Secondary
-        onClick={(): void => navigate('/specify/resources/', { replace: true })}
-      >
+      {      
+      // handleClone is undefined when the editor is used in a dialog, so don't show the close button in that case
+        handleClone === undefined ? 
+          undefined 
+          : 
+            <Button.Secondary
+          onClick={(): void => navigate('/specify/resources/', { replace: true })}
+        >
         {commonText.close()}
-      </Button.Secondary>
+        </Button.Secondary>
+      }
       <span className="-ml-2 flex-1" />
       {formElement !== null &&
       hasToolPermission(

--- a/specifyweb/frontend/js_src/lib/components/AppResources/Editor.tsx
+++ b/specifyweb/frontend/js_src/lib/components/AppResources/Editor.tsx
@@ -240,16 +240,17 @@ export function AppResourceEditor({
 
   const footer = (
     <>
-      {      
-      // handleClone is undefined when the editor is used in a dialog, so don't show the close button in that case
-        handleClone === undefined ? 
-          undefined 
-          : 
-            <Button.Secondary
-          onClick={(): void => navigate('/specify/resources/', { replace: true })}
-        >
-        {commonText.close()}
-        </Button.Secondary>
+      {
+        // handleClone is undefined when the editor is used in a dialog, so don't show the close button in that case
+        handleClone === undefined ? undefined : (
+          <Button.Secondary
+            onClick={(): void =>
+              navigate('/specify/resources/', { replace: true })
+            }
+          >
+            {commonText.close()}
+          </Button.Secondary>
+        )
       }
       <span className="-ml-2 flex-1" />
       {formElement !== null &&


### PR DESCRIPTION
Fixes #8401 

<!--
> [!WARNING]  
> This PR affects database migrations. See [migration testing instructions](https://specify.github.io/testing/pull_requests.html#prs-tagged-with-label-migration).
-->

### Checklist

- [ ] Self-review the PR after opening it to make sure the changes look good and
      self-explanatory (or properly documented)
- [ ] Add relevant issue to release milestone
- [ ] Add pr to documentation list
- [ ] Add automated tests
- [ ] Add a reverse migration if a migration is present in the PR
- [ ] Add migration function to https://github.com/specify/specify7/blob/ea04665987e1b8a1b76955c7b7f702b7bf701b47/specifyweb/specify/management/commands/run_key_migration_functions.py#L50


### Testing instructions

- Go to Schema config
- Click on any table
- Press Add on either table format or aggregation
- [ ] Verify only one Close button is present and brings you back to schema config 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the editor footer so the close button appears only when supported.
  * The close button remains hidden when the editor is opened in a dialog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->