### PR TITLE
Fix: Add chnostrat name to accepted chrono field to avoid bio filter

### DIFF
--- a/config/backstop/global.views.xml
+++ b/config/backstop/global.views.xml
@@ -1877,7 +1877,7 @@
 				</row>
 				<row>
 					<cell type="label" labelfor="acceptedParent"/>
-					<cell type="field" id="acceptedParent" uitype="querycbx" initialize="editbtn=false;newbtn=false" name="acceptedParent" colspan="4"/>
+					<cell type="field" id="acceptedParent" uitype="querycbx" initialize="name=ChronosStrat;editbtn=false;newbtn=false" name="acceptedParent" colspan="4"/>
 					<cell type="field" id="isAccepted" uitype="checkbox" name="isAccepted" default="true"/>
 				</row>
 				<row>
@@ -1960,7 +1960,7 @@
 				</row>
 				<row>
 					<cell type="label" labelfor="acceptedParent"/>
-					<cell type="field" id="acceptedParent" uitype="querycbx" initialize="editbtn=false;newbtn=false" name="acceptedParent" colspan="4"/>
+					<cell type="field" id="acceptedParent" uitype="querycbx" initialize="name=ChronosStrat;editbtn=false;newbtn=false" name="acceptedParent" colspan="4"/>
 					<cell type="field" id="isAccepted" uitype="checkbox" name="isAccepted" default="true"/>
 				</row>
 				<row>


### PR DESCRIPTION
Fixes #8402 

<!--
> [!WARNING]  
> This PR affects database migrations. See [migration testing instructions](https://specify.github.io/testing/pull_requests.html#prs-tagged-with-label-migration).
-->

### Checklist

- [ ] Self-review the PR after opening it to make sure the changes look good and
      self-explanatory (or properly documented)
- [ ] Add relevant issue to release milestone
- [ ] Add pr to documentation list
- [ ] Add automated tests
- [ ] Add a reverse migration if a migration is present in the PR
- [ ] Add migration function to https://github.com/specify/specify7/blob/ea04665987e1b8a1b76955c7b7f702b7bf701b47/specifyweb/specify/management/commands/run_key_migration_functions.py#L50


### Testing instructions

- Open a new chronostrat record
- Type in the Preferred Chronostrat field
- [ ] Verify chronostrat names appear


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated geologic time period forms to use the correct stratigraphic view when selecting accepted parent periods.
  * Preserved restrictions preventing editing or creating parent entries from these controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->