### PR TITLE
[Tests]: Add test suites for Add and Clone feature

### DIFF
--- a/specifyweb/backend/businessrules/tests/test_add_new_resource.py
+++ b/specifyweb/backend/businessrules/tests/test_add_new_resource.py
@@ -1,4 +1,6 @@
 from specifyweb.specify import models
+from specifyweb.specify.api.crud import post_resource
+from specifyweb.specify.api.serializers import uri_for_model
 from specifyweb.specify.tests.test_api import ApiTests
 
 
@@ -10,11 +12,17 @@ class TestAddNewObjects(ApiTests):
     """
 
     def test_add_collectionobject(self):
-        collectionobject = models.Collectionobject.objects.create(
-            collection=self.collection,
-            collectionobjecttype=self.collectionobjecttype,
-            collectionmemberid=1,
-            catalognumber='num-add',
+        collectionobject = post_resource(
+            self.collection,
+            self.agent,
+            'collectionobject',
+            {
+                'collection': uri_for_model('collection', self.collection.id),
+                'collectionobjecttype': uri_for_model(
+                    'collectionobjecttype', self.collectionobjecttype.id
+                ),
+                'catalognumber': 'num-add',
+            },
         )
 
         self.assertIsNotNone(collectionobject.id)

--- a/specifyweb/backend/businessrules/tests/test_add_new_resource.py
+++ b/specifyweb/backend/businessrules/tests/test_add_new_resource.py
@@ -36,9 +36,11 @@ class TestAddNewObjects(ApiTests):
         collectionobject.delete()
 
     def test_add_attachment(self):
-        attachment = models.Attachment.objects.create(
-            origfilename='new.txt',
-            tableid=1,
+        attachment = post_resource(
+            self.collection,
+            self.agent,
+            'attachment',
+            {'origfilename': 'new.txt', 'tableid': 1},
         )
 
         self.assertIsNotNone(attachment.id)
@@ -57,11 +59,16 @@ class TestAddNewObjects(ApiTests):
             rankid=0,
             treedef=self.taxontreedef,
         )
-        item = models.Taxontreedefitem.objects.create(
-            name='New taxon',
-            rankid=1,
-            parent=root,
-            treedef=self.taxontreedef,
+        item = post_resource(
+            self.collection,
+            self.agent,
+            'taxontreedefitem',
+            {
+                'name': 'New taxon',
+                'rankid': 1,
+                'parent': uri_for_model('taxontreedefitem', root.id),
+                'treedef': uri_for_model('taxontreedef', self.taxontreedef.id),
+            },
         )
 
         self.assertIsNotNone(item.id)
@@ -77,11 +84,18 @@ class TestAddNewObjects(ApiTests):
             rankid=0,
             treedef=self.geologictimeperiodtreedef,
         )
-        item = models.Geologictimeperiodtreedefitem.objects.create(
-            name='New geologic time period',
-            rankid=1,
-            parent=root,
-            treedef=self.geologictimeperiodtreedef,
+        item = post_resource(
+            self.collection,
+            self.agent,
+            'geologictimeperiodtreedefitem',
+            {
+                'name': 'New geologic time period',
+                'rankid': 1,
+                'parent': uri_for_model('geologictimeperiodtreedefitem', root.id),
+                'treedef': uri_for_model(
+                    'geologictimeperiodtreedef', self.geologictimeperiodtreedef.id
+                ),
+            },
         )
 
         self.assertIsNotNone(item.id)
@@ -100,11 +114,16 @@ class TestAddNewObjects(ApiTests):
             rankid=0,
             treedef=treedef,
         )
-        item = models.Lithostrattreedefitem.objects.create(
-            name='New lithostrat item',
-            rankid=1,
-            parent=root,
-            treedef=treedef,
+        item = post_resource(
+            self.collection,
+            self.agent,
+            'lithostrattreedefitem',
+            {
+                'name': 'New lithostrat item',
+                'rankid': 1,
+                'parent': uri_for_model('lithostrattreedefitem', root.id),
+                'treedef': uri_for_model('lithostrattreedef', treedef.id),
+            },
         )
 
         self.assertIsNotNone(item.id)
@@ -123,11 +142,16 @@ class TestAddNewObjects(ApiTests):
             rankid=0,
             treedef=treedef,
         )
-        item = models.Tectonicunittreedefitem.objects.create(
-            name='New tectonic unit item',
-            rankid=1,
-            parent=root,
-            treedef=treedef,
+        item = post_resource(
+            self.collection,
+            self.agent,
+            'tectonicunittreedefitem',
+            {
+                'name': 'New tectonic unit item',
+                'rankid': 1,
+                'parent': uri_for_model('tectonicunittreedefitem', root.id),
+                'treedef': uri_for_model('tectonicunittreedef', treedef.id),
+            },
         )
 
         self.assertIsNotNone(item.id)
@@ -140,11 +164,16 @@ class TestAddNewObjects(ApiTests):
         item.delete()
 
     def test_add_agent(self):
-        agent = models.Agent.objects.create(
-            agenttype=0,
-            firstname='New',
-            lastname='Agent',
-            division=self.division,
+        agent = post_resource(
+            self.collection,
+            self.agent,
+            'agent',
+            {
+                'agenttype': 0,
+                'firstname': 'New',
+                'lastname': 'Agent',
+                'division': uri_for_model('division', self.division.id),
+            },
         )
 
         self.assertIsNotNone(agent.id)
@@ -155,8 +184,11 @@ class TestAddNewObjects(ApiTests):
         agent.delete()
 
     def test_add_collectingevent(self):
-        collectingevent = models.Collectingevent.objects.create(
-            discipline=self.discipline,
+        collectingevent = post_resource(
+            self.collection,
+            self.agent,
+            'collectingevent',
+            {'discipline': uri_for_model('discipline', self.discipline.id)},
         )
 
         self.assertIsNotNone(collectingevent.id)
@@ -186,12 +218,21 @@ class TestAddNewObjects(ApiTests):
             parent=geography_root_definitionitem,
             treedef=self.geographytreedef,
         )
-        geography = models.Geography.objects.create(
-            name='New geography',
-            rankid=1,
-            definition=self.geographytreedef,
-            definitionitem=definitionitem,
-            parent=geography_root,
+        geography = post_resource(
+            self.collection,
+            self.agent,
+            'geography',
+            {
+                'name': 'New geography',
+                'rankid': 1,
+                'definition': uri_for_model(
+                    'geographytreedef', self.geographytreedef.id
+                ),
+                'definitionitem': uri_for_model(
+                    'geographytreedefitem', definitionitem.id
+                ),
+                'parent': uri_for_model('geography', geography_root.id),
+            },
         )
 
         self.assertIsNotNone(geography.id)
@@ -202,10 +243,15 @@ class TestAddNewObjects(ApiTests):
         geography.delete()
 
     def test_add_locality(self):
-        locality = models.Locality.objects.create(
-            localityname='New locality',
-            srclatlongunit=0,
-            discipline=self.discipline,
+        locality = post_resource(
+            self.collection,
+            self.agent,
+            'locality',
+            {
+                'localityname': 'New locality',
+                'srclatlongunit': 0,
+                'discipline': uri_for_model('discipline', self.discipline.id),
+            },
         )
 
         self.assertIsNotNone(locality.id)
@@ -235,10 +281,15 @@ class TestAddNewObjects(ApiTests):
             type='Discrete',
             collection=self.collection,
         )
-        group = models.Collectionobjectgroup.objects.create(
-            collection=self.collection,
-            cogtype=cogtype,
-            description='New description',
+        group = post_resource(
+            self.collection,
+            self.agent,
+            'collectionobjectgroup',
+            {
+                'collection': uri_for_model('collection', self.collection.id),
+                'cogtype': uri_for_model('collectionobjectgrouptype', cogtype.id),
+                'description': 'New description',
+            },
         )
 
         self.assertIsNotNone(group.id)
@@ -251,9 +302,14 @@ class TestAddNewObjects(ApiTests):
         group.delete()
 
     def test_add_accession(self):
-        accession = models.Accession.objects.create(
-            accessionnumber='New accession',
-            division=self.division,
+        accession = post_resource(
+            self.collection,
+            self.agent,
+            'accession',
+            {
+                'accessionnumber': 'New accession',
+                'division': uri_for_model('division', self.division.id),
+            },
         )
 
         self.assertIsNotNone(accession.id)
@@ -266,9 +322,14 @@ class TestAddNewObjects(ApiTests):
         accession.delete()
 
     def test_add_loan(self):
-        loan = models.Loan.objects.create(
-            loannumber='New loan',
-            discipline=self.discipline,
+        loan = post_resource(
+            self.collection,
+            self.agent,
+            'loan',
+            {
+                'loannumber': 'New loan',
+                'discipline': uri_for_model('discipline', self.discipline.id),
+            },
         )
 
         self.assertIsNotNone(loan.id)
@@ -279,9 +340,14 @@ class TestAddNewObjects(ApiTests):
         loan.delete()
 
     def test_add_gift(self):
-        gift = models.Gift.objects.create(
-            giftnumber='New gift',
-            discipline=self.discipline,
+        gift = post_resource(
+            self.collection,
+            self.agent,
+            'gift',
+            {
+                'giftnumber': 'New gift',
+                'discipline': uri_for_model('discipline', self.discipline.id),
+            },
         )
 
         self.assertIsNotNone(gift.id)
@@ -292,9 +358,11 @@ class TestAddNewObjects(ApiTests):
         gift.delete()
 
     def test_add_borrow(self):
-        borrow = models.Borrow.objects.create(
-            collectionmemberid=1,
-            invoicenumber='New invoice',
+        borrow = post_resource(
+            self.collection,
+            self.agent,
+            'borrow',
+            {'invoicenumber': 'New invoice'},
         )
 
         self.assertIsNotNone(borrow.id)
@@ -305,8 +373,11 @@ class TestAddNewObjects(ApiTests):
         borrow.delete()
 
     def test_add_disposal(self):
-        disposal = models.Disposal.objects.create(
-            disposalnumber='New disposal',
+        disposal = post_resource(
+            self.collection,
+            self.agent,
+            'disposal',
+            {'disposalnumber': 'New disposal'},
         )
 
         self.assertIsNotNone(disposal.id)
@@ -319,8 +390,11 @@ class TestAddNewObjects(ApiTests):
         disposal.delete()
 
     def test_add_deaccession(self):
-        deaccession = models.Deaccession.objects.create(
-            deaccessionnumber='New deaccession',
+        deaccession = post_resource(
+            self.collection,
+            self.agent,
+            'deaccession',
+            {'deaccessionnumber': 'New deaccession'},
         )
 
         self.assertIsNotNone(deaccession.id)

--- a/specifyweb/backend/businessrules/tests/test_add_new_resource.py
+++ b/specifyweb/backend/businessrules/tests/test_add_new_resource.py
@@ -1,0 +1,325 @@
+from specifyweb.specify import models
+from specifyweb.specify.tests.test_api import ApiTests
+
+
+class TestAddNewObjects(ApiTests):
+    """
+    Mirrors the "Add" button in Save.tsx: using Add creates a brand new,
+    empty resource that gets its own database id once saved, and the data
+    entered on it is persisted independently of any other record.
+    """
+
+    def test_add_collectionobject(self):
+        collectionobject = models.Collectionobject.objects.create(
+            collection=self.collection,
+            collectionobjecttype=self.collectionobjecttype,
+            collectionmemberid=1,
+            catalognumber='num-add',
+        )
+
+        self.assertIsNotNone(collectionobject.id)
+        self.assertExists(
+            models.Collectionobject.objects.filter(
+                id=collectionobject.id,
+                catalognumber='num-add',
+            )
+        )
+
+        collectionobject.delete()
+
+    def test_add_attachment(self):
+        attachment = models.Attachment.objects.create(
+            origfilename='new.txt',
+            tableid=1,
+        )
+
+        self.assertIsNotNone(attachment.id)
+        self.assertExists(
+            models.Attachment.objects.filter(
+                id=attachment.id,
+                origfilename='new.txt',
+            )
+        )
+
+        attachment.delete()
+
+    def test_add_taxontreedefitem(self):
+        root = models.Taxontreedefitem.objects.create(
+            name='Root taxon',
+            rankid=0,
+            treedef=self.taxontreedef,
+        )
+        item = models.Taxontreedefitem.objects.create(
+            name='New taxon',
+            rankid=1,
+            parent=root,
+            treedef=self.taxontreedef,
+        )
+
+        self.assertIsNotNone(item.id)
+        self.assertExists(
+            models.Taxontreedefitem.objects.filter(id=item.id, name='New taxon')
+        )
+
+        item.delete()
+
+    def test_add_geologictimeperiodtreedefitem(self):
+        root = models.Geologictimeperiodtreedefitem.objects.create(
+            name='Root geologic time period',
+            rankid=0,
+            treedef=self.geologictimeperiodtreedef,
+        )
+        item = models.Geologictimeperiodtreedefitem.objects.create(
+            name='New geologic time period',
+            rankid=1,
+            parent=root,
+            treedef=self.geologictimeperiodtreedef,
+        )
+
+        self.assertIsNotNone(item.id)
+        self.assertExists(
+            models.Geologictimeperiodtreedefitem.objects.filter(
+                id=item.id, name='New geologic time period'
+            )
+        )
+
+        item.delete()
+
+    def test_add_lithostrattreedefitem(self):
+        treedef = models.Lithostrattreedef.objects.create(name='Test lithostrat')
+        root = models.Lithostrattreedefitem.objects.create(
+            name='Root lithostrat item',
+            rankid=0,
+            treedef=treedef,
+        )
+        item = models.Lithostrattreedefitem.objects.create(
+            name='New lithostrat item',
+            rankid=1,
+            parent=root,
+            treedef=treedef,
+        )
+
+        self.assertIsNotNone(item.id)
+        self.assertExists(
+            models.Lithostrattreedefitem.objects.filter(
+                id=item.id, name='New lithostrat item'
+            )
+        )
+
+        item.delete()
+
+    def test_add_tectonicunittreedefitem(self):
+        treedef = models.Tectonicunittreedef.objects.create(name='Test tectonic unit')
+        root = models.Tectonicunittreedefitem.objects.create(
+            name='Root tectonic unit item',
+            rankid=0,
+            treedef=treedef,
+        )
+        item = models.Tectonicunittreedefitem.objects.create(
+            name='New tectonic unit item',
+            rankid=1,
+            parent=root,
+            treedef=treedef,
+        )
+
+        self.assertIsNotNone(item.id)
+        self.assertExists(
+            models.Tectonicunittreedefitem.objects.filter(
+                id=item.id, name='New tectonic unit item'
+            )
+        )
+
+        item.delete()
+
+    def test_add_agent(self):
+        agent = models.Agent.objects.create(
+            agenttype=0,
+            firstname='New',
+            lastname='Agent',
+            division=self.division,
+        )
+
+        self.assertIsNotNone(agent.id)
+        self.assertExists(
+            models.Agent.objects.filter(id=agent.id, lastname='Agent')
+        )
+
+        agent.delete()
+
+    def test_add_collectingevent(self):
+        collectingevent = models.Collectingevent.objects.create(
+            discipline=self.discipline,
+        )
+
+        self.assertIsNotNone(collectingevent.id)
+        self.assertExists(
+            models.Collectingevent.objects.filter(
+                id=collectingevent.id, discipline=self.discipline
+            )
+        )
+
+        collectingevent.delete()
+
+    def test_add_geography(self):
+        geography_root_definitionitem = models.Geographytreedefitem.objects.create(
+            name='Root geography',
+            rankid=0,
+            treedef=self.geographytreedef,
+        )
+        geography_root = models.Geography.objects.create(
+            name='Root geography',
+            rankid=0,
+            definition=self.geographytreedef,
+            definitionitem=geography_root_definitionitem,
+        )
+        definitionitem = models.Geographytreedefitem.objects.create(
+            name='Test geography level',
+            rankid=1,
+            parent=geography_root_definitionitem,
+            treedef=self.geographytreedef,
+        )
+        geography = models.Geography.objects.create(
+            name='New geography',
+            rankid=1,
+            definition=self.geographytreedef,
+            definitionitem=definitionitem,
+            parent=geography_root,
+        )
+
+        self.assertIsNotNone(geography.id)
+        self.assertExists(
+            models.Geography.objects.filter(id=geography.id, name='New geography')
+        )
+
+        geography.delete()
+
+    def test_add_locality(self):
+        locality = models.Locality.objects.create(
+            localityname='New locality',
+            srclatlongunit=0,
+            discipline=self.discipline,
+        )
+
+        self.assertIsNotNone(locality.id)
+        self.assertExists(
+            models.Locality.objects.filter(
+                id=locality.id, localityname='New locality'
+            )
+        )
+
+        locality.delete()
+
+    def test_add_collectionobjectgroup(self):
+        cog_type_picklist = models.Picklist.objects.create(
+            name='SystemCOGTypes',
+            issystem=True,
+            type=0,
+            readonly=True,
+            collection=self.collection,
+        )
+        models.Picklistitem.objects.create(
+            title='Discrete',
+            value='Discrete',
+            picklist=cog_type_picklist,
+        )
+        cogtype = models.Collectionobjectgrouptype.objects.create(
+            name='Test group type',
+            type='Discrete',
+            collection=self.collection,
+        )
+        group = models.Collectionobjectgroup.objects.create(
+            collection=self.collection,
+            cogtype=cogtype,
+            description='New description',
+        )
+
+        self.assertIsNotNone(group.id)
+        self.assertExists(
+            models.Collectionobjectgroup.objects.filter(
+                id=group.id, description='New description'
+            )
+        )
+
+        group.delete()
+
+    def test_add_accession(self):
+        accession = models.Accession.objects.create(
+            accessionnumber='New accession',
+            division=self.division,
+        )
+
+        self.assertIsNotNone(accession.id)
+        self.assertExists(
+            models.Accession.objects.filter(
+                id=accession.id, accessionnumber='New accession'
+            )
+        )
+
+        accession.delete()
+
+    def test_add_loan(self):
+        loan = models.Loan.objects.create(
+            loannumber='New loan',
+            discipline=self.discipline,
+        )
+
+        self.assertIsNotNone(loan.id)
+        self.assertExists(
+            models.Loan.objects.filter(id=loan.id, loannumber='New loan')
+        )
+
+        loan.delete()
+
+    def test_add_gift(self):
+        gift = models.Gift.objects.create(
+            giftnumber='New gift',
+            discipline=self.discipline,
+        )
+
+        self.assertIsNotNone(gift.id)
+        self.assertExists(
+            models.Gift.objects.filter(id=gift.id, giftnumber='New gift')
+        )
+
+        gift.delete()
+
+    def test_add_borrow(self):
+        borrow = models.Borrow.objects.create(
+            collectionmemberid=1,
+            invoicenumber='New invoice',
+        )
+
+        self.assertIsNotNone(borrow.id)
+        self.assertExists(
+            models.Borrow.objects.filter(id=borrow.id, invoicenumber='New invoice')
+        )
+
+        borrow.delete()
+
+    def test_add_disposal(self):
+        disposal = models.Disposal.objects.create(
+            disposalnumber='New disposal',
+        )
+
+        self.assertIsNotNone(disposal.id)
+        self.assertExists(
+            models.Disposal.objects.filter(
+                id=disposal.id, disposalnumber='New disposal'
+            )
+        )
+
+        disposal.delete()
+
+    def test_add_deaccession(self):
+        deaccession = models.Deaccession.objects.create(
+            deaccessionnumber='New deaccession',
+        )
+
+        self.assertIsNotNone(deaccession.id)
+        self.assertExists(
+            models.Deaccession.objects.filter(
+                id=deaccession.id, deaccessionnumber='New deaccession'
+            )
+        )
+
+        deaccession.delete()

--- a/specifyweb/backend/businessrules/tests/test_clone_previously_created.py
+++ b/specifyweb/backend/businessrules/tests/test_clone_previously_created.py
@@ -16,6 +16,9 @@ class TestClonePreviousVersionObjects(ApiTests):
     ResourceView.tsx hides the Clone button for that table.
     """
 
+    def _clone_resource(self, name, data):
+        return post_resource(self.collection, self.agent, name, data)
+
     def setUp(self):
         super().setUp()
 
@@ -206,10 +209,13 @@ class TestClonePreviousVersionObjects(ApiTests):
     def test_clone_attachment(self):
         original = self.attachments[0]
 
-        clone = models.Attachment.objects.create(
-            origfilename=original.origfilename,
-            tableid=original.tableid,
-            remarks=original.remarks,
+        clone = self._clone_resource(
+            'attachment',
+            {
+                'origfilename': original.origfilename,
+                'tableid': original.tableid,
+                'remarks': original.remarks,
+            },
         )
 
         self.assertNotEqual(clone.id, original.id)
@@ -225,13 +231,16 @@ class TestClonePreviousVersionObjects(ApiTests):
     def test_clone_taxontreedefitem(self):
         original = self.taxontreedefitems[0]
 
-        clone = models.Taxontreedefitem.objects.create(
-            # Name is unique per tree definition, so it is not copied
-            name='Test taxon (clone)',
-            rankid=original.rankid,
-            parent=original.parent,
-            treedef=original.treedef,
-            remarks=original.remarks,
+        clone = self._clone_resource(
+            'taxontreedefitem',
+            {
+                # Name is unique per tree definition, so it is not copied.
+                'name': 'Test taxon (clone)',
+                'rankid': original.rankid,
+                'parent': uri_for_model('taxontreedefitem', original.parent_id),
+                'treedef': uri_for_model('taxontreedef', original.treedef_id),
+                'remarks': original.remarks,
+            },
         )
 
         self.assertNotEqual(clone.id, original.id)
@@ -249,12 +258,19 @@ class TestClonePreviousVersionObjects(ApiTests):
     def test_clone_geologictimeperiodtreedefitem(self):
         original = self.geologictimeperiodtreedefitems[0]
 
-        clone = models.Geologictimeperiodtreedefitem.objects.create(
-            name=original.name,
-            rankid=original.rankid,
-            parent=original.parent,
-            treedef=original.treedef,
-            remarks=original.remarks,
+        clone = self._clone_resource(
+            'geologictimeperiodtreedefitem',
+            {
+                'name': original.name,
+                'rankid': original.rankid,
+                'parent': uri_for_model(
+                    'geologictimeperiodtreedefitem', original.parent_id
+                ),
+                'treedef': uri_for_model(
+                    'geologictimeperiodtreedef', original.treedef_id
+                ),
+                'remarks': original.remarks,
+            },
         )
 
         self.assertNotEqual(clone.id, original.id)
@@ -272,12 +288,15 @@ class TestClonePreviousVersionObjects(ApiTests):
     def test_clone_lithostrattreedefitem(self):
         original = self.lithostrattreedefitems[0]
 
-        clone = models.Lithostrattreedefitem.objects.create(
-            name=original.name,
-            rankid=original.rankid,
-            parent=original.parent,
-            treedef=original.treedef,
-            remarks=original.remarks,
+        clone = self._clone_resource(
+            'lithostrattreedefitem',
+            {
+                'name': original.name,
+                'rankid': original.rankid,
+                'parent': uri_for_model('lithostrattreedefitem', original.parent_id),
+                'treedef': uri_for_model('lithostrattreedef', original.treedef_id),
+                'remarks': original.remarks,
+            },
         )
 
         self.assertNotEqual(clone.id, original.id)
@@ -295,12 +314,15 @@ class TestClonePreviousVersionObjects(ApiTests):
     def test_clone_tectonicunittreedefitem(self):
         original = self.tectonicunittreedefitems[0]
 
-        clone = models.Tectonicunittreedefitem.objects.create(
-            name=original.name,
-            rankid=original.rankid,
-            parent=original.parent,
-            treedef=original.treedef,
-            remarks=original.remarks,
+        clone = self._clone_resource(
+            'tectonicunittreedefitem',
+            {
+                'name': original.name,
+                'rankid': original.rankid,
+                'parent': uri_for_model('tectonicunittreedefitem', original.parent_id),
+                'treedef': uri_for_model('tectonicunittreedef', original.treedef_id),
+                'remarks': original.remarks,
+            },
         )
 
         self.assertNotEqual(clone.id, original.id)
@@ -318,12 +340,15 @@ class TestClonePreviousVersionObjects(ApiTests):
     def test_clone_agent(self):
         original = self.agents[0]
 
-        clone = models.Agent.objects.create(
-            agenttype=original.agenttype,
-            firstname=original.firstname,
-            lastname=original.lastname,
-            division=original.division,
-            remarks=original.remarks,
+        clone = self._clone_resource(
+            'agent',
+            {
+                'agenttype': original.agenttype,
+                'firstname': original.firstname,
+                'lastname': original.lastname,
+                'division': uri_for_model('division', original.division_id),
+                'remarks': original.remarks,
+            },
         )
 
         self.assertNotEqual(clone.id, original.id)
@@ -341,9 +366,12 @@ class TestClonePreviousVersionObjects(ApiTests):
     def test_clone_collectingevent(self):
         original = self.collectingevents[0]
 
-        clone = models.Collectingevent.objects.create(
-            discipline=original.discipline,
-            remarks=original.remarks,
+        clone = self._clone_resource(
+            'collectingevent',
+            {
+                'discipline': uri_for_model('discipline', original.discipline_id),
+                'remarks': original.remarks,
+            },
         )
 
         self.assertNotEqual(clone.id, original.id)
@@ -358,13 +386,18 @@ class TestClonePreviousVersionObjects(ApiTests):
     def test_clone_geography(self):
         original = self.geographies[0]
 
-        clone = models.Geography.objects.create(
-            name=original.name,
-            rankid=original.rankid,
-            definition=original.definition,
-            definitionitem=original.definitionitem,
-            parent=original.parent,
-            remarks=original.remarks,
+        clone = self._clone_resource(
+            'geography',
+            {
+                'name': original.name,
+                'rankid': original.rankid,
+                'definition': uri_for_model('geographytreedef', original.definition_id),
+                'definitionitem': uri_for_model(
+                    'geographytreedefitem', original.definitionitem_id
+                ),
+                'parent': uri_for_model('geography', original.parent_id),
+                'remarks': original.remarks,
+            },
         )
 
         self.assertNotEqual(clone.id, original.id)
@@ -382,11 +415,14 @@ class TestClonePreviousVersionObjects(ApiTests):
     def test_clone_locality(self):
         original = self.localities[0]
 
-        clone = models.Locality.objects.create(
-            localityname=original.localityname,
-            srclatlongunit=original.srclatlongunit,
-            discipline=original.discipline,
-            remarks=original.remarks,
+        clone = self._clone_resource(
+            'locality',
+            {
+                'localityname': original.localityname,
+                'srclatlongunit': original.srclatlongunit,
+                'discipline': uri_for_model('discipline', original.discipline_id),
+                'remarks': original.remarks,
+            },
         )
 
         self.assertNotEqual(clone.id, original.id)
@@ -402,11 +438,14 @@ class TestClonePreviousVersionObjects(ApiTests):
     def test_clone_accession(self):
         original = self.accessions[0]
 
-        clone = models.Accession.objects.create(
-            # Accession number is unique per division, so it is not copied
-            accessionnumber='Test accession (clone)',
-            division=original.division,
-            remarks=original.remarks,
+        clone = self._clone_resource(
+            'accession',
+            {
+                # Accession number is unique per division, so it is not copied.
+                'accessionnumber': 'Test accession (clone)',
+                'division': uri_for_model('division', original.division_id),
+                'remarks': original.remarks,
+            },
         )
 
         self.assertNotEqual(clone.id, original.id)
@@ -422,11 +461,14 @@ class TestClonePreviousVersionObjects(ApiTests):
     def test_clone_loan(self):
         original = self.loans[0]
 
-        clone = models.Loan.objects.create(
-            # Loan number is unique per discipline, so it is not copied
-            loannumber='Test loan (clone)',
-            discipline=original.discipline,
-            remarks=original.remarks,
+        clone = self._clone_resource(
+            'loan',
+            {
+                # Loan number is unique per discipline, so it is not copied.
+                'loannumber': 'Test loan (clone)',
+                'discipline': uri_for_model('discipline', original.discipline_id),
+                'remarks': original.remarks,
+            },
         )
 
         self.assertNotEqual(clone.id, original.id)
@@ -442,11 +484,14 @@ class TestClonePreviousVersionObjects(ApiTests):
     def test_clone_gift(self):
         original = self.gifts[0]
 
-        clone = models.Gift.objects.create(
-            # Gift number is unique per discipline, so it is not copied
-            giftnumber='Test gift (clone)',
-            discipline=original.discipline,
-            remarks=original.remarks,
+        clone = self._clone_resource(
+            'gift',
+            {
+                # Gift number is unique per discipline, so it is not copied.
+                'giftnumber': 'Test gift (clone)',
+                'discipline': uri_for_model('discipline', original.discipline_id),
+                'remarks': original.remarks,
+            },
         )
 
         self.assertNotEqual(clone.id, original.id)
@@ -462,14 +507,16 @@ class TestClonePreviousVersionObjects(ApiTests):
     def test_clone_borrow(self):
         original = self.borrows[0]
 
-        clone = models.Borrow.objects.create(
-            collectionmemberid=original.collectionmemberid,
-            invoicenumber=original.invoicenumber,
-            remarks=original.remarks,
+        clone = self._clone_resource(
+            'borrow',
+            {
+                'invoicenumber': original.invoicenumber,
+                'remarks': original.remarks,
+            },
         )
 
         self.assertNotEqual(clone.id, original.id)
-        self.assertEqual(clone.collectionmemberid, original.collectionmemberid)
+        self.assertEqual(clone.collectionmemberid, self.collection.id)
         self.assertEqual(clone.invoicenumber, original.invoicenumber)
         self.assertEqual(clone.remarks, original.remarks)
 
@@ -481,10 +528,13 @@ class TestClonePreviousVersionObjects(ApiTests):
     def test_clone_disposal(self):
         original = self.disposals[0]
 
-        clone = models.Disposal.objects.create(
-            # Disposal number is unique, so it is not copied
-            disposalnumber='Test disposal (clone)',
-            remarks=original.remarks,
+        clone = self._clone_resource(
+            'disposal',
+            {
+                # Disposal number is unique, so it is not copied.
+                'disposalnumber': 'Test disposal (clone)',
+                'remarks': original.remarks,
+            },
         )
 
         self.assertNotEqual(clone.id, original.id)
@@ -499,10 +549,13 @@ class TestClonePreviousVersionObjects(ApiTests):
     def test_clone_deaccession(self):
         original = self.deaccessions[0]
 
-        clone = models.Deaccession.objects.create(
-            # Deaccession number is unique, so it is not copied
-            deaccessionnumber='Test deaccession (clone)',
-            remarks=original.remarks,
+        clone = self._clone_resource(
+            'deaccession',
+            {
+                # Deaccession number is unique, so it is not copied.
+                'deaccessionnumber': 'Test deaccession (clone)',
+                'remarks': original.remarks,
+            },
         )
 
         self.assertNotEqual(clone.id, original.id)

--- a/specifyweb/backend/businessrules/tests/test_clone_previously_created.py
+++ b/specifyweb/backend/businessrules/tests/test_clone_previously_created.py
@@ -1,0 +1,505 @@
+from specifyweb.specify import models
+from specifyweb.specify.tests.test_api import ApiTests
+
+
+class TestClonePreviousVersionObjects(ApiTests):
+    """
+    Mirrors the "Clone" button in Save.tsx: cloning a record creates a
+    brand new, independent database object with the applicable data copied
+    over from the original, while fields that must stay unique (e.g. catalog
+    or accession numbers) are not blindly duplicated. The original record
+    must remain unaffected by the clone.
+
+    CollectionObjectGroup is intentionally not covered here: NO_CLONE in
+    ResourceView.tsx hides the Clone button for that table.
+    """
+
+    def setUp(self):
+        super().setUp()
+
+        self.attachments = [
+            models.Attachment.objects.create(
+                origfilename='test.txt',
+                tableid=1,
+                remarks='Test remarks',
+            )
+        ]
+        taxon_root = models.Taxontreedefitem.objects.create(
+            name='Root taxon',
+            rankid=0,
+            treedef=self.taxontreedef,
+        )
+        self.taxontreedefitems = [
+            models.Taxontreedefitem.objects.create(
+                name='Test taxon',
+                rankid=1,
+                parent=taxon_root,
+                treedef=self.taxontreedef,
+                remarks='Test remarks',
+            )
+        ]
+
+        geologic_root = models.Geologictimeperiodtreedefitem.objects.create(
+            name='Root geologic time period',
+            rankid=0,
+            treedef=self.geologictimeperiodtreedef,
+        )
+        self.geologictimeperiodtreedefitems = [
+            models.Geologictimeperiodtreedefitem.objects.create(
+                name='Test geologic time period',
+                rankid=1,
+                parent=geologic_root,
+                treedef=self.geologictimeperiodtreedef,
+                remarks='Test remarks',
+            )
+        ]
+
+        lithostrat_treedef = models.Lithostrattreedef.objects.create(
+            name='Test lithostrat',
+        )
+        lithostrat_root = models.Lithostrattreedefitem.objects.create(
+            name='Root lithostrat item',
+            rankid=0,
+            treedef=lithostrat_treedef,
+        )
+        self.lithostrattreedefitems = [
+            models.Lithostrattreedefitem.objects.create(
+                name='Test lithostrat item',
+                rankid=1,
+                parent=lithostrat_root,
+                treedef=lithostrat_treedef,
+                remarks='Test remarks',
+            )
+        ]
+
+        tectonic_treedef = models.Tectonicunittreedef.objects.create(
+            name='Test tectonic unit',
+        )
+        tectonic_root = models.Tectonicunittreedefitem.objects.create(
+            name='Root tectonic unit item',
+            rankid=0,
+            treedef=tectonic_treedef,
+        )
+        self.tectonicunittreedefitems = [
+            models.Tectonicunittreedefitem.objects.create(
+                name='Test tectonic unit item',
+                rankid=1,
+                parent=tectonic_root,
+                treedef=tectonic_treedef,
+                remarks='Test remarks',
+            )
+        ]
+
+        self.agents = [self.agent]
+        self.collectingevents = [self.collectingevent]
+
+        geography_root_definitionitem = models.Geographytreedefitem.objects.create(
+            name='Root geography',
+            rankid=0,
+            treedef=self.geographytreedef,
+        )
+        geography_root = models.Geography.objects.create(
+            name='Root geography',
+            rankid=0,
+            definition=self.geographytreedef,
+            definitionitem=geography_root_definitionitem,
+        )
+        definitionitem = models.Geographytreedefitem.objects.create(
+            name='Test geography level',
+            rankid=1,
+            parent=geography_root_definitionitem,
+            treedef=self.geographytreedef,
+        )
+        self.geographies = [
+            models.Geography.objects.create(
+                name='Test geography',
+                rankid=1,
+                definition=self.geographytreedef,
+                definitionitem=definitionitem,
+                parent=geography_root,
+                remarks='Test remarks',
+            )
+        ]
+        self.localities = [
+            models.Locality.objects.create(
+                localityname='Test locality',
+                srclatlongunit=0,
+                discipline=self.discipline,
+                remarks='Test remarks',
+            )
+        ]
+
+        self.accessions = [
+            models.Accession.objects.create(
+                accessionnumber='Test accession',
+                division=self.division,
+                remarks='Test remarks',
+            )
+        ]
+        self.loans = [
+            models.Loan.objects.create(
+                loannumber='Test loan',
+                discipline=self.discipline,
+                remarks='Test remarks',
+            )
+        ]
+        self.gifts = [
+            models.Gift.objects.create(
+                giftnumber='Test gift',
+                discipline=self.discipline,
+                remarks='Test remarks',
+            )
+        ]
+        self.borrows = [
+            models.Borrow.objects.create(
+                collectionmemberid=1,
+                invoicenumber='Test invoice',
+                remarks='Test remarks',
+            )
+        ]
+        self.disposals = [
+            models.Disposal.objects.create(
+                disposalnumber='Test disposal',
+                remarks='Test remarks',
+            )
+        ]
+        self.deaccessions = [
+            models.Deaccession.objects.create(
+                deaccessionnumber='Test deaccession',
+                remarks='Test remarks',
+            )
+        ]
+
+    def test_clone_collectionobject(self):
+        original = self.collectionobjects[0]
+
+        clone = models.Collectionobject.objects.create(
+            collection=original.collection,
+            collectionobjecttype=original.collectionobjecttype,
+            collectionmemberid=original.collectionmemberid,
+            # Catalog number is unique per collection, so it is not copied
+            catalognumber='num-clone',
+        )
+
+        self.assertNotEqual(clone.id, original.id)
+        self.assertEqual(clone.collection_id, original.collection_id)
+        self.assertEqual(
+            clone.collectionobjecttype_id, original.collectionobjecttype_id
+        )
+        self.assertNotEqual(clone.catalognumber, original.catalognumber)
+
+        original.refresh_from_db()
+        self.assertEqual(original.catalognumber, 'num-0')
+
+        clone.delete()
+
+    def test_clone_attachment(self):
+        original = self.attachments[0]
+
+        clone = models.Attachment.objects.create(
+            origfilename=original.origfilename,
+            tableid=original.tableid,
+            remarks=original.remarks,
+        )
+
+        self.assertNotEqual(clone.id, original.id)
+        self.assertEqual(clone.origfilename, original.origfilename)
+        self.assertEqual(clone.tableid, original.tableid)
+        self.assertEqual(clone.remarks, original.remarks)
+
+        original.refresh_from_db()
+        self.assertEqual(original.origfilename, 'test.txt')
+
+        clone.delete()
+
+    def test_clone_taxontreedefitem(self):
+        original = self.taxontreedefitems[0]
+
+        clone = models.Taxontreedefitem.objects.create(
+            # Name is unique per tree definition, so it is not copied
+            name='Test taxon (clone)',
+            rankid=original.rankid,
+            parent=original.parent,
+            treedef=original.treedef,
+            remarks=original.remarks,
+        )
+
+        self.assertNotEqual(clone.id, original.id)
+        self.assertEqual(clone.rankid, original.rankid)
+        self.assertEqual(clone.parent_id, original.parent_id)
+        self.assertEqual(clone.treedef_id, original.treedef_id)
+        self.assertEqual(clone.remarks, original.remarks)
+        self.assertNotEqual(clone.name, original.name)
+
+        original.refresh_from_db()
+        self.assertEqual(original.name, 'Test taxon')
+
+        clone.delete()
+
+    def test_clone_geologictimeperiodtreedefitem(self):
+        original = self.geologictimeperiodtreedefitems[0]
+
+        clone = models.Geologictimeperiodtreedefitem.objects.create(
+            name=original.name,
+            rankid=original.rankid,
+            parent=original.parent,
+            treedef=original.treedef,
+            remarks=original.remarks,
+        )
+
+        self.assertNotEqual(clone.id, original.id)
+        self.assertEqual(clone.name, original.name)
+        self.assertEqual(clone.rankid, original.rankid)
+        self.assertEqual(clone.parent_id, original.parent_id)
+        self.assertEqual(clone.treedef_id, original.treedef_id)
+        self.assertEqual(clone.remarks, original.remarks)
+
+        original.refresh_from_db()
+        self.assertEqual(original.name, 'Test geologic time period')
+
+        clone.delete()
+
+    def test_clone_lithostrattreedefitem(self):
+        original = self.lithostrattreedefitems[0]
+
+        clone = models.Lithostrattreedefitem.objects.create(
+            name=original.name,
+            rankid=original.rankid,
+            parent=original.parent,
+            treedef=original.treedef,
+            remarks=original.remarks,
+        )
+
+        self.assertNotEqual(clone.id, original.id)
+        self.assertEqual(clone.name, original.name)
+        self.assertEqual(clone.rankid, original.rankid)
+        self.assertEqual(clone.parent_id, original.parent_id)
+        self.assertEqual(clone.treedef_id, original.treedef_id)
+        self.assertEqual(clone.remarks, original.remarks)
+
+        original.refresh_from_db()
+        self.assertEqual(original.name, 'Test lithostrat item')
+
+        clone.delete()
+
+    def test_clone_tectonicunittreedefitem(self):
+        original = self.tectonicunittreedefitems[0]
+
+        clone = models.Tectonicunittreedefitem.objects.create(
+            name=original.name,
+            rankid=original.rankid,
+            parent=original.parent,
+            treedef=original.treedef,
+            remarks=original.remarks,
+        )
+
+        self.assertNotEqual(clone.id, original.id)
+        self.assertEqual(clone.name, original.name)
+        self.assertEqual(clone.rankid, original.rankid)
+        self.assertEqual(clone.parent_id, original.parent_id)
+        self.assertEqual(clone.treedef_id, original.treedef_id)
+        self.assertEqual(clone.remarks, original.remarks)
+
+        original.refresh_from_db()
+        self.assertEqual(original.name, 'Test tectonic unit item')
+
+        clone.delete()
+
+    def test_clone_agent(self):
+        original = self.agents[0]
+
+        clone = models.Agent.objects.create(
+            agenttype=original.agenttype,
+            firstname=original.firstname,
+            lastname=original.lastname,
+            division=original.division,
+            remarks=original.remarks,
+        )
+
+        self.assertNotEqual(clone.id, original.id)
+        self.assertEqual(clone.agenttype, original.agenttype)
+        self.assertEqual(clone.firstname, original.firstname)
+        self.assertEqual(clone.lastname, original.lastname)
+        self.assertEqual(clone.division_id, original.division_id)
+
+        original.refresh_from_db()
+        self.assertEqual(original.firstname, 'Test')
+        self.assertEqual(original.lastname, 'User')
+
+        clone.delete()
+
+    def test_clone_collectingevent(self):
+        original = self.collectingevents[0]
+
+        clone = models.Collectingevent.objects.create(
+            discipline=original.discipline,
+            remarks=original.remarks,
+        )
+
+        self.assertNotEqual(clone.id, original.id)
+        self.assertEqual(clone.discipline_id, original.discipline_id)
+        self.assertEqual(clone.remarks, original.remarks)
+
+        original.refresh_from_db()
+        self.assertEqual(original.discipline_id, self.discipline.id)
+
+        clone.delete()
+
+    def test_clone_geography(self):
+        original = self.geographies[0]
+
+        clone = models.Geography.objects.create(
+            name=original.name,
+            rankid=original.rankid,
+            definition=original.definition,
+            definitionitem=original.definitionitem,
+            parent=original.parent,
+            remarks=original.remarks,
+        )
+
+        self.assertNotEqual(clone.id, original.id)
+        self.assertEqual(clone.name, original.name)
+        self.assertEqual(clone.definition_id, original.definition_id)
+        self.assertEqual(clone.definitionitem_id, original.definitionitem_id)
+        self.assertEqual(clone.parent_id, original.parent_id)
+        self.assertEqual(clone.remarks, original.remarks)
+
+        original.refresh_from_db()
+        self.assertEqual(original.name, 'Test geography')
+
+        clone.delete()
+
+    def test_clone_locality(self):
+        original = self.localities[0]
+
+        clone = models.Locality.objects.create(
+            localityname=original.localityname,
+            srclatlongunit=original.srclatlongunit,
+            discipline=original.discipline,
+            remarks=original.remarks,
+        )
+
+        self.assertNotEqual(clone.id, original.id)
+        self.assertEqual(clone.localityname, original.localityname)
+        self.assertEqual(clone.discipline_id, original.discipline_id)
+        self.assertEqual(clone.remarks, original.remarks)
+
+        original.refresh_from_db()
+        self.assertEqual(original.localityname, 'Test locality')
+
+        clone.delete()
+
+    def test_clone_accession(self):
+        original = self.accessions[0]
+
+        clone = models.Accession.objects.create(
+            # Accession number is unique per division, so it is not copied
+            accessionnumber='Test accession (clone)',
+            division=original.division,
+            remarks=original.remarks,
+        )
+
+        self.assertNotEqual(clone.id, original.id)
+        self.assertEqual(clone.division_id, original.division_id)
+        self.assertEqual(clone.remarks, original.remarks)
+        self.assertNotEqual(clone.accessionnumber, original.accessionnumber)
+
+        original.refresh_from_db()
+        self.assertEqual(original.accessionnumber, 'Test accession')
+
+        clone.delete()
+
+    def test_clone_loan(self):
+        original = self.loans[0]
+
+        clone = models.Loan.objects.create(
+            # Loan number is unique per discipline, so it is not copied
+            loannumber='Test loan (clone)',
+            discipline=original.discipline,
+            remarks=original.remarks,
+        )
+
+        self.assertNotEqual(clone.id, original.id)
+        self.assertEqual(clone.discipline_id, original.discipline_id)
+        self.assertEqual(clone.remarks, original.remarks)
+        self.assertNotEqual(clone.loannumber, original.loannumber)
+
+        original.refresh_from_db()
+        self.assertEqual(original.loannumber, 'Test loan')
+
+        clone.delete()
+
+    def test_clone_gift(self):
+        original = self.gifts[0]
+
+        clone = models.Gift.objects.create(
+            # Gift number is unique per discipline, so it is not copied
+            giftnumber='Test gift (clone)',
+            discipline=original.discipline,
+            remarks=original.remarks,
+        )
+
+        self.assertNotEqual(clone.id, original.id)
+        self.assertEqual(clone.discipline_id, original.discipline_id)
+        self.assertEqual(clone.remarks, original.remarks)
+        self.assertNotEqual(clone.giftnumber, original.giftnumber)
+
+        original.refresh_from_db()
+        self.assertEqual(original.giftnumber, 'Test gift')
+
+        clone.delete()
+
+    def test_clone_borrow(self):
+        original = self.borrows[0]
+
+        clone = models.Borrow.objects.create(
+            collectionmemberid=original.collectionmemberid,
+            invoicenumber=original.invoicenumber,
+            remarks=original.remarks,
+        )
+
+        self.assertNotEqual(clone.id, original.id)
+        self.assertEqual(clone.collectionmemberid, original.collectionmemberid)
+        self.assertEqual(clone.invoicenumber, original.invoicenumber)
+        self.assertEqual(clone.remarks, original.remarks)
+
+        original.refresh_from_db()
+        self.assertEqual(original.invoicenumber, 'Test invoice')
+
+        clone.delete()
+
+    def test_clone_disposal(self):
+        original = self.disposals[0]
+
+        clone = models.Disposal.objects.create(
+            # Disposal number is unique, so it is not copied
+            disposalnumber='Test disposal (clone)',
+            remarks=original.remarks,
+        )
+
+        self.assertNotEqual(clone.id, original.id)
+        self.assertEqual(clone.remarks, original.remarks)
+        self.assertNotEqual(clone.disposalnumber, original.disposalnumber)
+
+        original.refresh_from_db()
+        self.assertEqual(original.disposalnumber, 'Test disposal')
+
+        clone.delete()
+
+    def test_clone_deaccession(self):
+        original = self.deaccessions[0]
+
+        clone = models.Deaccession.objects.create(
+            # Deaccession number is unique, so it is not copied
+            deaccessionnumber='Test deaccession (clone)',
+            remarks=original.remarks,
+        )
+
+        self.assertNotEqual(clone.id, original.id)
+        self.assertEqual(clone.remarks, original.remarks)
+        self.assertNotEqual(clone.deaccessionnumber, original.deaccessionnumber)
+
+        original.refresh_from_db()
+        self.assertEqual(original.deaccessionnumber, 'Test deaccession')
+
+        clone.delete()

--- a/specifyweb/backend/businessrules/tests/test_clone_previously_created.py
+++ b/specifyweb/backend/businessrules/tests/test_clone_previously_created.py
@@ -1,4 +1,6 @@
 from specifyweb.specify import models
+from specifyweb.specify.api.crud import post_resource
+from specifyweb.specify.api.serializers import uri_for_model
 from specifyweb.specify.tests.test_api import ApiTests
 
 
@@ -173,12 +175,18 @@ class TestClonePreviousVersionObjects(ApiTests):
     def test_clone_collectionobject(self):
         original = self.collectionobjects[0]
 
-        clone = models.Collectionobject.objects.create(
-            collection=original.collection,
-            collectionobjecttype=original.collectionobjecttype,
-            collectionmemberid=original.collectionmemberid,
-            # Catalog number is unique per collection, so it is not copied
-            catalognumber='num-clone',
+        clone = post_resource(
+            self.collection,
+            self.agent,
+            'collectionobject',
+            {
+                'collection': uri_for_model('collection', original.collection_id),
+                'collectionobjecttype': uri_for_model(
+                    'collectionobjecttype', original.collectionobjecttype_id
+                ),
+                # Catalog number is unique per collection, so it is regenerated.
+                'catalognumber': 'num-clone',
+            },
         )
 
         self.assertNotEqual(clone.id, original.id)
@@ -186,6 +194,8 @@ class TestClonePreviousVersionObjects(ApiTests):
         self.assertEqual(
             clone.collectionobjecttype_id, original.collectionobjecttype_id
         )
+        self.assertEqual(clone.collectionmemberid, self.collection.id)
+        self.assertEqual(clone.createdbyagent_id, self.agent.id)
         self.assertNotEqual(clone.catalognumber, original.catalognumber)
 
         original.refresh_from_db()

--- a/specifyweb/frontend/js_src/lib/components/DataModel/__tests__/domain.test.ts
+++ b/specifyweb/frontend/js_src/lib/components/DataModel/__tests__/domain.test.ts
@@ -2,6 +2,7 @@ import { overrideAjax } from '../../../tests/ajax';
 import { requireContext } from '../../../tests/helpers';
 import { monthsPickListName } from '../../PickLists/definitions';
 import { formatUrl } from '../../Router/queryString';
+import { Http } from '../../../utils/ajax/definitions';
 import { addMissingFields } from '../addMissingFields';
 import { formatRelationshipPath } from '../helpers';
 import { getResourceApiUrl } from '../resource';
@@ -125,6 +126,19 @@ describe('Resource initialization preferences', () => {
     jest.clearAllMocks();
   });
 
+  overrideAjax(
+    '/api/specify/collectionobject/',
+    {
+      resource_uri: getResourceApiUrl('CollectionObject', 2),
+      id: 2,
+      collection: getResourceApiUrl('Collection', 4),
+      collectionObjectType: getResourceApiUrl('CollectionObjectType', 2),
+      catalogNumber: 'num-regenerated',
+      text1: 'copied field',
+    },
+    { method: 'POST', responseCode: Http.CREATED }
+  );
+
   test('CO_CREATE_COA', () => {
     const collectionObject = new tables.CollectionObject.Resource();
     expect(collectionObject.get('collectionObjectAttribute')).toBe(
@@ -200,6 +214,12 @@ describe('Resource initialization preferences', () => {
     );
     expect(cloned.get('text1')).toBe('copied field');
     expect(cloned.get('catalogNumber')).toBeUndefined();
+
+    await cloned.save();
+
+    expect(cloned.id).toBe(2);
+    expect(cloned.get('catalogNumber')).toBe('num-regenerated');
+    expect(cloned.get('text1')).toBe('copied field');
 
     expect(original.id).toBe(1);
     expect(original.get('catalogNumber')).toBe('num-original');

--- a/specifyweb/frontend/js_src/lib/components/DataModel/__tests__/domain.test.ts
+++ b/specifyweb/frontend/js_src/lib/components/DataModel/__tests__/domain.test.ts
@@ -11,6 +11,7 @@ import {
   getCollectionForResource,
 } from '../scoping';
 import { tables } from '../tables';
+import type { Tables } from '../types';
 
 requireContext();
 
@@ -174,6 +175,75 @@ describe('Resource initialization preferences', () => {
         .then((collection) => collection.models.length)
     ).resolves.toBe(0);
   });
+
+  test('Cloning a CollectionObject copies fields and omits unique fields', async () => {
+    const original = new tables.CollectionObject.Resource(
+      addMissingFields('CollectionObject', {
+        resource_uri: getResourceApiUrl('CollectionObject', 1),
+        id: 1,
+        collection: getResourceApiUrl(
+          'Collection',
+          schema.domainLevelIds.collection
+        ),
+        collectionObjectType: getResourceApiUrl('CollectionObjectType', 2),
+        catalogNumber: 'num-original',
+        text1: 'copied field',
+      })
+    );
+
+    const cloned = await original.clone(true);
+
+    expect(cloned.id).toBeUndefined();
+    expect(cloned.get('collection')).toBe(original.get('collection'));
+    expect(cloned.get('collectionObjectType')).toBe(
+      original.get('collectionObjectType')
+    );
+    expect(cloned.get('text1')).toBe('copied field');
+    expect(cloned.get('catalogNumber')).toBeUndefined();
+
+    expect(original.id).toBe(1);
+    expect(original.get('catalogNumber')).toBe('num-original');
+    expect(original.get('text1')).toBe('copied field');
+  });
+
+  test.each([
+    'Attachment',
+    'TaxonTreeDefItem',
+    'GeologicTimePeriodTreeDefItem',
+    'LithoStratTreeDefItem',
+    'TectonicUnitTreeDefItem',
+    'Agent',
+    'CollectingEvent',
+    'Geography',
+    'Locality',
+    'Accession',
+    'Loan',
+    'Gift',
+    'Borrow',
+    'Disposal',
+    'Deaccession',
+  ])(
+    'Cloning %s copies fields and preserves the original',
+    async (tableName) => {
+      const typedTableName = tableName as keyof Tables;
+      const table = tables[typedTableName];
+      const record = {
+        resource_uri: getResourceApiUrl(typedTableName, 1),
+        id: 1,
+        remarks: 'Test remarks',
+      };
+      const original = new table.Resource(
+        addMissingFields(typedTableName, record)
+      );
+
+      const cloned = await original.clone(true);
+
+      expect(cloned.id).toBeUndefined();
+      expect(cloned.get('remarks')).toBe('Test remarks');
+      expect(original.id).toBe(1);
+      expect(original.get('remarks')).toBe('Test remarks');
+    }
+  );
 
   test('Cloning resource does not create duplicates', async () => {
     // See Issue #3278

--- a/specifyweb/frontend/js_src/lib/components/Forms/__tests__/Save.test.tsx
+++ b/specifyweb/frontend/js_src/lib/components/Forms/__tests__/Save.test.tsx
@@ -1,0 +1,27 @@
+import { act } from '@testing-library/react';
+import React from 'react';
+
+import { commonText } from '../../../localization/common';
+import { formsText } from '../../../localization/forms';
+import { requireContext } from '../../../tests/helpers';
+import { mount } from '../../../tests/reactUtils';
+import { tables } from '../../DataModel/tables';
+import { SaveButton } from '../Save';
+
+requireContext();
+
+test('Clone button is hidden for CollectionObjectGroup, but Add button is not', async () => {
+  const resource = new tables.CollectionObjectGroup.Resource();
+  const form = document.createElement('form');
+
+  const { queryByRole } = mount(
+    <SaveButton form={form} resource={resource} onAdd={jest.fn()} />
+  );
+  // Let pending business rule checks resolve before asserting
+  await act(async () => undefined);
+
+  expect(
+    queryByRole('button', { name: formsText.clone() })
+  ).not.toBeInTheDocument();
+  expect(queryByRole('button', { name: commonText.add() })).toBeInTheDocument();
+});


### PR DESCRIPTION
Fixes #8501 

<!--
> [!WARNING]  
> This PR affects database migrations. See [migration testing instructions](https://specify.github.io/testing/pull_requests.html#prs-tagged-with-label-migration).
-->

### Checklist

- [ ] Self-review the PR after opening it to make sure the changes look good and
      self-explanatory (or properly documented)
- [ ] Add relevant issue to release milestone
- [ ] Add pr to documentation list
- [ ] Add automated tests
- [ ] Add a reverse migration if a migration is present in the PR
- [ ] Add migration function to https://github.com/specify/specify7/blob/ea04665987e1b8a1b76955c7b7f702b7bf701b47/specifyweb/specify/management/commands/run_key_migration_functions.py#L50


### Testing instructions

<!-- What are the steps to verify the fixes/changes in this PR? -->
<!-- Can part of that be replaced by automated tests? -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Added coverage for creating new records across collections, agents, events, geography, loans, gifts, and other record types.
  - Added checks confirming cloned records copy eligible information without duplicating unique values.
  - Verified original records remain unchanged after cloning.
  - Confirmed collection object groups display the Add action without a Clone action.
  - Expanded validation for hierarchical records and related data configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->