### PR TITLE
fix(queries): skip missing tree ranks

### DIFF
--- a/specifyweb/backend/stored_queries/execution.py
+++ b/specifyweb/backend/stored_queries/execution.py
@@ -1086,6 +1086,10 @@ def build_query(
         )
 
         if field is None:
+            # Keep the result column in place when a displayed tree rank is
+            # missing, while omitting its filter and sort behavior.
+            if fs.display:
+                query = query.add_columns(sql.null())
             continue
 
         formatted_field = None

--- a/specifyweb/backend/stored_queries/query_construct.py
+++ b/specifyweb/backend/stored_queries/query_construct.py
@@ -29,6 +29,7 @@ class QueryConstruct(namedtuple('QueryConstruct', 'collection objectformatter qu
 
     def handle_tree_field(self, node, table, tree_rank: TreeRankQuery, next_join_path, current_field_spec: QueryFieldSpec):
         query = self
+        query_before_tree_joins = query
         if query.collection is None:  # Not sure it makes sense to query across collections
             raise AssertionError(
                 f"No Collection found in Query for {table}",
@@ -70,7 +71,13 @@ class QueryConstruct(namedtuple('QueryConstruct', 'collection objectformatter qu
             if (tree_rank.treedef_id is None or tree_rank.treedef_id == treedef_id)
             ] if tup[1] is not None]
 
-        assert len(treedefs_with_ranks) >= 1, "Didn't find the tree rank across any tree"
+        if not treedefs_with_ranks:
+            logger.warning(
+                "Didn't find tree rank %r across any %s tree; skipping field",
+                tree_rank.name,
+                table.name,
+            )
+            return query_before_tree_joins, None, None, table
 
         treedefitem_params = [treedefitem_id for (_, treedefitem_id) in treedefs_with_ranks]
 

--- a/specifyweb/backend/stored_queries/queryfieldspec.py
+++ b/specifyweb/backend/stored_queries/queryfieldspec.py
@@ -534,6 +534,8 @@ class QueryFieldSpec(
         # print "is auditlog obj format field = " + str(self.is_auditlog_obj_format_field(formatauditobjs))
         # print "############################################################################"
         query, orm_field, field, table = self.add_spec_to_query(query, formatter)
+        if orm_field is None:
+            return query, None, None
         return self.apply_filter(
             query,
             orm_field,


### PR DESCRIPTION
Fixes #3351

If a query, data export, (or soon, data view query) is executed in a collection that doesn't have matching ranks, this prevents it from crashing. This is a common problem for databases that share queries between collections, especially when those collections exist in other disciplines where some tree ranks might not exist. It also allows us to ship default queries or export mappings that function even if the ranks included in the defaults are not present in the collection(s).

<img width="1292" height="151" alt="file-aadc6b629ebf5b71ba3717018319b345" src="https://github.com/user-attachments/assets/9ac7cdbd-dbac-4312-aad0-5aed018afabf" />

<img width="1592" height="328" alt="file-908159827dfe4acddce4929f932febe9" src="https://github.com/user-attachments/assets/62d6adaa-c036-4092-be39-e3a62128d811" />


### Checklist

- [X] Self-review the PR after opening it to make sure the changes look good and
      self-explanatory (or properly documented)
- [ ] Add relevant issue to release milestone
- [ ] Add pr to documentation list
- [X] Add automated tests

### Testing instructions

1. Open or create a stored query containing a tree-rank field that is not present in the active collection. (If you are having a hard time finding one, I guess you can use this: [FakeRankQuery.json](https://github.com/user-attachments/files/32052427/FakeRankQuery.json))
2. Execute the query in the table view and confirm that it does not crash and that the remaining result columns stay aligned with their headers.
3. Apply a filter or sort using the unavailable rank and confirm that the query still executes while ignoring that field.
4. Export the same query and confirm that the export completes and the unavailable field is omitted or empty without shifting other columns.

There is automated coverage should verify both a missing displayed rank (preserving the result-column position) and a missing filtered/sorted rank (ignoring the field without changing the result set).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed query results so unresolved fields retain the correct column positions.
  * Prevented invalid filtering and sorting when a query field cannot be resolved.
  * Improved handling of queries involving unavailable or unmatched tree fields.
  * Added warnings instead of failing when tree-based fields cannot be matched.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->